### PR TITLE
ci: build Dockerfile on amd64 + arm64 native runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,28 @@ jobs:
           uv run alembic upgrade head
       - name: Tests
         run: uv run pytest -v
+
+  docker-build:
+    # Verify the Dockerfile builds on both supported runtime architectures.
+    # Native runners (no QEMU emulation) per arch via matrix.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      - name: Build (no push)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: false
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}


### PR DESCRIPTION
## Summary

New \`docker-build\` matrix job in \`ci.yml\` that builds the Dockerfile on both supported runtime architectures, using GitHub's free native arm64 runners (no QEMU emulation).

| Platform | Runner |
|---|---|
| linux/amd64 | ubuntu-24.04 |
| linux/arm64 | ubuntu-24.04-arm |

Build runs in parallel with the existing \`check\` job. No registry push — the goal is to fail fast on Dockerfile changes that break either arch.

## Why native runners

QEMU-emulated arm64 builds typically run 3–5× longer than native. With native runners (free for public repos), arm64 build time is comparable to amd64.

## Caching

Per-arch GHA cache scope (\`type=gha,mode=max,scope=<platform>\`) — first build on each branch is cold, subsequent builds reuse layers.

## Actions pinned

- \`docker/setup-buildx-action@4d04d5d\` (v4.0.0)
- \`docker/build-push-action@bcafcac\` (v7.1.0)

## Test plan

- [x] YAML syntax valid
- [x] \`renovate --platform=local --dry-run=extract\` shows 7 github-actions deps (was 4); all SHA-pinned
- [ ] CI passes on this PR — both \`check\` and \`docker-build (linux/amd64)\` and \`docker-build (linux/arm64)\` green