### PR TITLE
deps: bump typescript 5.9.3 → 6.0.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,7 +49,7 @@
         "prettier": "3.8.3",
         "tailwindcss": "3.4.19",
         "tailwindcss-animate": "1.0.7",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "8.0.10",
         "vitest": "4.1.5"
       }
@@ -6187,9 +6187,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "prettier": "3.8.3",
     "tailwindcss": "3.4.19",
     "tailwindcss-animate": "1.0.7",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "8.0.10",
     "vitest": "4.1.5"
   }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,6 @@
     "noUncheckedSideEffectImports": true,
     "skipLibCheck": true,
     "types": [],
-    "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

Last \"easy major\" deferred from the earlier easy-majors PR.

| Dep | Before | After |
|---|---|---|
| typescript | 5.9.3 | 6.0.3 |

## Migration delta

One deprecation surfaced: \`baseUrl\` in \`tsconfig.json\` is deprecated in TS 6 (will be removed in TS 7). Removed it. TS 6 resolves \`paths\` relative to the tsconfig location by default, so \`paths: { \"@/*\": [\"./src/*\"] }\` keeps working unchanged.

No \`ignoreDeprecations\` shim needed — the codebase had only this one deprecated option.

## Gate results

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean (max-warnings 0)
- [x] \`npm run test -- --run\` — 21 passed (6 files)
- [x] \`npm run build\` — succeeds, bundle unchanged (CSS 19.27 KB / JS 422.45 KB)
- [ ] CI passes