### PR TITLE
chore(deps): bump node 20 → 24 (Phase B)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.23.0
 
 # --- Stage 1: build the React SPA ---
-FROM node:20.20.2-alpine AS frontend-build
+FROM node:24.15.0-alpine AS frontend-build
 WORKDIR /build
 # Cache deps separately
 COPY frontend/package.json frontend/package-lock.json ./

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
-        "@types/node": "20.19.39",
+        "@types/node": "24.12.2",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
@@ -3585,13 +3585,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -6758,9 +6758,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
-    "@types/node": "20.19.39",
+    "@types/node": "24.12.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",


### PR DESCRIPTION
**Phase B of the deferred-majors plan.**

| Item | From | To |
|---|---|---|
| Dockerfile FROM | \`node:20.20.2-alpine\` | \`node:24.15.0-alpine\` |
| @types/node | 20.19.39 | 24.12.2 |

## Why bare \`-alpine\` (not \`-alpine3.23\`)

Renovate's docker manager has trouble tracking tags with two embedded versions. The bare \`-alpine\` form lets renovate track only the node version; Docker resolves the Alpine release in line with the LTS pairing. Matches the prior \`node:20.20.2-alpine\` form.

## Risk evaluation

The earlier major-bump research flagged a historical npm-on-Alpine \"Exit handler never called!\" regression at Node 22+. Verified clean via local docker build of the frontend-build stage:

\`\`\`
docker build --target frontend-build --platform linux/amd64 .
✓ built in 11s — npm ci + tsc -b + vite build all succeed
\`\`\`

If the regression resurfaces on arm64 or in CI, fallback is \`node:24.15.0-bookworm-slim\` (debian-based; +~50MB image).

## Test plan

- [x] Frontend gates: typecheck/lint clean, vitest 21/21, build succeeds
- [x] Local \`docker build --platform linux/amd64\` of frontend-build stage clean
- [ ] CI multi-arch matrix passes on both linux/amd64 and linux/arm64