### PR TITLE
chore(security): secret scanning + ggshield pre-commit + renovate pre-commit manager

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.0
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.20.2
     hooks:
       - id: mypy
         args: [--config-file=pyproject.toml]
@@ -16,3 +16,12 @@ repos:
           - sqlalchemy>=2.0
           - fastapi
           - structlog
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.50.2
+    hooks:
+      - id: ggshield
+        # Scans staged changes for secrets before commit. Free for individuals
+        # (1000 commits/month). Repo is public, so we also rely on GitHub
+        # native secret scanning + push protection for defence-in-depth.
+        language_version: python3
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,6 @@ repos:
         # native secret scanning + push protection for defence-in-depth.
         language_version: python3
         stages: [pre-commit]
+        # ggshield decides what to scan internally (staged ranges); don't
+        # let pre-commit pass file paths as CLI args.
+        pass_filenames: false

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,9 @@
   "docker-compose": {
     "enabled": false
   },
+  "pre-commit": {
+    "enabled": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am on monday"]


### PR DESCRIPTION
Now that the repo is public, layered defence-in-depth for secrets.

## GitHub-native (configured on repo via gh API, not in this PR)

| Feature | State |
|---|---|
| \`secret_scanning\` | ✅ enabled |
| \`secret_scanning_push_protection\` | ✅ enabled (blocks pushes with detected secrets) |
| \`secret_scanning_non_provider_patterns\` | ❌ silently declined — requires GHAS |
| \`secret_scanning_validity_checks\` | ❌ silently declined — requires GHAS |

## Pre-commit changes (in this PR)

| Hook | From | To |
|---|---|---|
| \`astral-sh/ruff-pre-commit\` | v0.4.0 | v0.15.12 (matches the project's dev dep) |
| \`pre-commit/mirrors-mypy\` | v1.10.0 | v1.20.2 (matches the project's dev dep) |
| \`gitguardian/ggshield\` | (new) | v1.50.2 — secrets caught client-side before push |

## Renovate config change (in this PR)

The \`pre-commit\` manager is **not** enabled in \`config:recommended\` by default. Adding \`"pre-commit": { "enabled": true }\` so renovate now tracks the 3 hooks. Verified with \`renovate --platform=local --dry-run=extract\`:

\`\`\`
pre-commit: {fileCount: 1, depCount: 3}
\`\`\`

Hooks will land in the weekly \"all non-major dependencies\" PR via the catch-all rule.

## Local verification

- \`pre-commit validate-config\` exit 0
- \`pre-commit run ggshield --all-files\` Passed (no secrets in repo)
- \`renovate-config-validator\` clean

## Summary by Sourcery

Strengthen local security and maintenance by updating Python lint/type-check hooks, adding client-side secret scanning, and enabling Renovate management of pre-commit hooks.

Enhancements:
- Update ruff and mypy pre-commit hooks to align with the project’s configured dev dependency versions.
- Add a ggshield pre-commit hook to scan staged changes for secrets before commits.
- Enable Renovate’s pre-commit manager so pre-commit hook versions are automatically tracked and updated.