### PR TITLE
phase 5b-1a: alert close (backend)

### DIFF
--- a/alembic/versions/0004_alert_close.py
+++ b/alembic/versions/0004_alert_close.py
@@ -1,0 +1,39 @@
+"""add alert close columns.
+
+Revision ID: 0004_alert_close
+Revises: 0003_pushover_config_json
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_alert_close"
+down_revision: str | Sequence[str] | None = "0003_pushover_config_json"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "alerts",
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "alerts",
+        sa.Column("close_reason", sa.String(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_alerts_closed_at"),
+        "alerts",
+        ["closed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_alerts_closed_at"), table_name="alerts")
+    op.drop_column("alerts", "close_reason")
+    op.drop_column("alerts", "closed_at")

--- a/src/yas/db/models/_types.py
+++ b/src/yas/db/models/_types.py
@@ -116,3 +116,8 @@ class DayOfWeek(StrEnum):
     fri = "fri"
     sat = "sat"
     sun = "sun"
+
+
+class CloseReason(StrEnum):
+    acknowledged = "acknowledged"
+    dismissed = "dismissed"

--- a/src/yas/db/models/alert.py
+++ b/src/yas/db/models/alert.py
@@ -9,7 +9,7 @@ from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from yas.db.base import Base
-from yas.db.models._types import AlertType
+from yas.db.models._types import AlertType, CloseReason
 
 
 class Alert(Base):
@@ -34,5 +34,9 @@ class Alert(Base):
     skipped: Mapped[bool] = mapped_column(default=False)
     dedup_key: Mapped[str] = mapped_column(String, nullable=False, index=True)
     payload_json: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    closed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    close_reason: Mapped[CloseReason | None] = mapped_column(String, nullable=True)
 
     __table_args__ = (Index("ix_alerts_unsent_due", "scheduled_for", "sent_at"),)

--- a/src/yas/web/routes/alerts.py
+++ b/src/yas/web/routes/alerts.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from yas.db.models import Alert
 from yas.db.models._types import AlertType
 from yas.db.session import session_scope
-from yas.web.routes.alerts_schemas import AlertListResponse, AlertOut
+from yas.web.routes.alerts_schemas import AlertCloseIn, AlertListResponse, AlertOut
 
 router = APIRouter(prefix="/api/alerts", tags=["alerts"])
 
@@ -123,3 +123,17 @@ async def resend_alert(request: Request, alert_id: int) -> AlertOut:
         await s.flush()
 
         return AlertOut.model_validate(cloned)
+
+
+@router.post("/{alert_id}/close", response_model=AlertOut)
+async def close_alert(request: Request, alert_id: int, body: AlertCloseIn) -> AlertOut:
+    async with session_scope(_engine(request)) as s:
+        alert = (await s.execute(select(Alert).where(Alert.id == alert_id))).scalar_one_or_none()
+        if alert is None:
+            raise HTTPException(status_code=404, detail=f"alert {alert_id} not found")
+        if alert.closed_at is None:
+            alert.closed_at = datetime.now(UTC)
+        alert.close_reason = body.reason
+        await s.flush()
+        await s.refresh(alert)
+        return AlertOut.model_validate(alert)

--- a/src/yas/web/routes/alerts.py
+++ b/src/yas/web/routes/alerts.py
@@ -137,3 +137,15 @@ async def close_alert(request: Request, alert_id: int, body: AlertCloseIn) -> Al
         await s.flush()
         await s.refresh(alert)
         return AlertOut.model_validate(alert)
+
+
+@router.post("/{alert_id}/reopen", response_model=AlertOut)
+async def reopen_alert(request: Request, alert_id: int) -> AlertOut:
+    async with session_scope(_engine(request)) as s:
+        alert = (await s.execute(select(Alert).where(Alert.id == alert_id))).scalar_one_or_none()
+        if alert is None:
+            raise HTTPException(status_code=404, detail=f"alert {alert_id} not found")
+        alert.closed_at = None
+        alert.close_reason = None
+        await s.flush()
+        return AlertOut.model_validate(alert)

--- a/src/yas/web/routes/alerts_schemas.py
+++ b/src/yas/web/routes/alerts_schemas.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from yas.db.models._types import CloseReason
+
 
 class AlertOut(BaseModel):
     """Alert detail for GET responses."""
@@ -24,6 +26,8 @@ class AlertOut(BaseModel):
     skipped: bool
     dedup_key: str
     payload_json: dict[str, Any]
+    closed_at: datetime | None = None
+    close_reason: CloseReason | None = None
 
 
 class AlertListResponse(BaseModel):
@@ -33,3 +37,9 @@ class AlertListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class AlertCloseIn(BaseModel):
+    """Request body for POST /api/alerts/{id}/close."""
+
+    reason: CloseReason

--- a/src/yas/web/routes/inbox.py
+++ b/src/yas/web/routes/inbox.py
@@ -34,6 +34,7 @@ async def inbox_summary(
     request: Request,
     since: Annotated[datetime, Query()],
     until: Annotated[datetime, Query()],
+    include_closed: Annotated[bool, Query()] = False,
 ) -> InboxSummaryOut:
     if since >= until:
         raise HTTPException(status_code=422, detail="since must be before until")
@@ -52,6 +53,8 @@ async def inbox_summary(
             .order_by(Alert.scheduled_for.desc())
             .limit(50)
         )
+        if not include_closed:
+            alerts_q = alerts_q.where(Alert.closed_at.is_(None))
         alert_rows = (await s.execute(alerts_q)).all()
         inbox_alerts: list[InboxAlertOut] = []
         for alert, kid_name in alert_rows:
@@ -76,6 +79,8 @@ async def inbox_summary(
                     dedup_key=alert.dedup_key,
                     payload_json=alert.payload_json or {},
                     summary_text=summary,
+                    closed_at=alert.closed_at,
+                    close_reason=alert.close_reason,
                 )
             )
 

--- a/src/yas/web/routes/inbox_schemas.py
+++ b/src/yas/web/routes/inbox_schemas.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from yas.db.models._types import CloseReason
+
 
 class InboxAlertOut(BaseModel):
     """Enriched alert shape for the inbox endpoint.
@@ -30,6 +32,8 @@ class InboxAlertOut(BaseModel):
     dedup_key: str
     payload_json: dict[str, Any]
     summary_text: str
+    closed_at: datetime | None = None
+    close_reason: CloseReason | None = None
 
 
 class InboxKidMatchCountOut(BaseModel):

--- a/tests/integration/test_api_alerts_close.py
+++ b/tests/integration/test_api_alerts_close.py
@@ -1,0 +1,111 @@
+"""Integration tests for POST /api/alerts/{id}/close and /reopen."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from yas.db.base import Base
+from yas.db.models import Alert, Kid
+from yas.db.models._types import AlertType
+from yas.db.session import create_engine_for, session_scope
+from yas.web.app import create_app
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("YAS_ANTHROPIC_API_KEY", "sk-test")
+    url = f"sqlite+aiosqlite:///{tmp_path}/c.db"
+    monkeypatch.setenv("YAS_DATABASE_URL", url)
+    engine = create_engine_for(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with session_scope(engine) as s:
+        s.add(Kid(id=1, name="Sam", dob=date(2019, 5, 1)))
+        await s.flush()
+        s.add(
+            Alert(
+                id=1,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=datetime.now(UTC) - timedelta(hours=1),
+                sent_at=None,
+                skipped=False,
+                dedup_key="open-1",
+                payload_json={"msg": "open"},
+            )
+        )
+    app = create_app(engine=engine, fetcher=None, llm=None, geocoder=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c, engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_close_alert_with_acknowledged_sets_fields(client):
+    c, _ = client
+    r = await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["close_reason"] == "acknowledged"
+    assert body["closed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_close_alert_with_dismissed_sets_fields(client):
+    c, _ = client
+    r = await c.post("/api/alerts/1/close", json={"reason": "dismissed"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["close_reason"] == "dismissed"
+    assert body["closed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_closing_already_closed_with_same_reason_is_idempotent(client):
+    c, _ = client
+    first = await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    closed_at_first = first.json()["closed_at"]
+
+    second = await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    assert second.status_code == 200
+    assert second.json()["close_reason"] == "acknowledged"
+    # closed_at MUST NOT advance on a same-reason re-close.
+    assert second.json()["closed_at"] == closed_at_first
+
+
+@pytest.mark.asyncio
+async def test_closing_already_closed_with_different_reason_updates_reason(client):
+    c, _ = client
+    first = await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    closed_at_first = first.json()["closed_at"]
+
+    second = await c.post("/api/alerts/1/close", json={"reason": "dismissed"})
+    assert second.status_code == 200
+    assert second.json()["close_reason"] == "dismissed"
+    # Last-write-wins on reason; closed_at does NOT advance.
+    assert second.json()["closed_at"] == closed_at_first
+
+
+@pytest.mark.asyncio
+async def test_close_returns_404_for_unknown_id(client):
+    c, _ = client
+    r = await c.post("/api/alerts/9999/close", json={"reason": "acknowledged"})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_close_returns_422_when_reason_missing(client):
+    c, _ = client
+    r = await c.post("/api/alerts/1/close", json={})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_close_returns_422_for_invalid_reason(client):
+    c, _ = client
+    r = await c.post("/api/alerts/1/close", json={"reason": "snoozed"})
+    assert r.status_code == 422

--- a/tests/integration/test_api_alerts_close.py
+++ b/tests/integration/test_api_alerts_close.py
@@ -136,3 +136,19 @@ async def test_reopen_returns_404_for_unknown_id(client):
     c, _ = client
     r = await c.post("/api/alerts/9999/reopen")
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_close_after_reopen_sets_new_closed_at(client):
+    c, _ = client
+    first = await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    closed_at_1 = first.json()["closed_at"]
+    assert closed_at_1 is not None
+
+    await c.post("/api/alerts/1/reopen")
+
+    third = await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    assert third.status_code == 200
+    closed_at_2 = third.json()["closed_at"]
+    assert closed_at_2 is not None
+    assert closed_at_2 != closed_at_1

--- a/tests/integration/test_api_alerts_close.py
+++ b/tests/integration/test_api_alerts_close.py
@@ -109,3 +109,30 @@ async def test_close_returns_422_for_invalid_reason(client):
     c, _ = client
     r = await c.post("/api/alerts/1/close", json={"reason": "snoozed"})
     assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reopen_clears_both_fields(client):
+    c, _ = client
+    await c.post("/api/alerts/1/close", json={"reason": "acknowledged"})
+    r = await c.post("/api/alerts/1/reopen")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["closed_at"] is None
+    assert body["close_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_reopen_already_open_is_idempotent(client):
+    c, _ = client
+    r = await c.post("/api/alerts/1/reopen")
+    assert r.status_code == 200
+    assert r.json()["closed_at"] is None
+    assert r.json()["close_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_reopen_returns_404_for_unknown_id(client):
+    c, _ = client
+    r = await c.post("/api/alerts/9999/reopen")
+    assert r.status_code == 404

--- a/tests/integration/test_api_inbox.py
+++ b/tests/integration/test_api_inbox.py
@@ -5,7 +5,7 @@ from httpx import ASGITransport, AsyncClient
 
 from yas.db.base import Base
 from yas.db.models import Alert, CrawlRun, Kid, Match, Offering, Page, Site
-from yas.db.models._types import AlertType, CrawlStatus
+from yas.db.models._types import AlertType, CloseReason, CrawlStatus
 from yas.db.session import create_engine_for, session_scope
 from yas.web.app import create_app
 
@@ -234,3 +234,124 @@ async def test_inbox_falls_back_gracefully_for_unknown_stored_alert_type(client)
     assert a["type"] == "some_legacy_type_not_in_enum"
     assert isinstance(a["summary_text"], str)
     assert len(a["summary_text"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_inbox_summary_excludes_closed_alerts_by_default(client):
+    c, engine = client
+    now = datetime.now(UTC)
+    async with session_scope(engine) as s:
+        s.add(Kid(id=1, name="Sam", dob=date(2019, 5, 1)))
+        await s.flush()
+        s.add(
+            Alert(
+                id=1,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=now - timedelta(hours=1),
+                dedup_key="open-1",
+                payload_json={},
+            )
+        )
+        s.add(
+            Alert(
+                id=2,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=now - timedelta(hours=2),
+                dedup_key="closed-1",
+                payload_json={},
+                closed_at=now,
+                close_reason=CloseReason.acknowledged,
+            )
+        )
+    r = await c.get(
+        "/api/inbox/summary",
+        params={"since": _iso(now - timedelta(days=1)), "until": _iso(now + timedelta(days=1))},
+    )
+    assert r.status_code == 200
+    ids = {a["id"] for a in r.json()["alerts"]}
+    assert ids == {1}
+
+
+@pytest.mark.asyncio
+async def test_inbox_summary_with_include_closed_returns_closed_alerts(client):
+    c, engine = client
+    now = datetime.now(UTC)
+    async with session_scope(engine) as s:
+        s.add(Kid(id=1, name="Sam", dob=date(2019, 5, 1)))
+        await s.flush()
+        s.add(
+            Alert(
+                id=1,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=now - timedelta(hours=1),
+                dedup_key="open-1",
+                payload_json={},
+            )
+        )
+        s.add(
+            Alert(
+                id=2,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=now - timedelta(hours=2),
+                dedup_key="closed-1",
+                payload_json={},
+                closed_at=now,
+                close_reason=CloseReason.dismissed,
+            )
+        )
+    r = await c.get(
+        "/api/inbox/summary",
+        params={
+            "since": _iso(now - timedelta(days=1)),
+            "until": _iso(now + timedelta(days=1)),
+            "include_closed": "true",
+        },
+    )
+    assert r.status_code == 200
+    alerts = r.json()["alerts"]
+    ids_to_reasons = {a["id"]: a["close_reason"] for a in alerts}
+    assert ids_to_reasons == {1: None, 2: "dismissed"}
+
+
+@pytest.mark.asyncio
+async def test_closing_schedule_posted_alert_does_not_reduce_site_activity_count(client):
+    """Regression: site-distinct schedule_posted count is analytics, not inbox.
+
+    Closing a schedule_posted alert should NOT change posted_new_count.
+    """
+    c, engine = client
+    now = datetime.now(UTC)
+    async with session_scope(engine) as s:
+        s.add(Site(id=1, name="X", base_url="https://x"))
+        await s.flush()
+        s.add(
+            Alert(
+                id=1,
+                type=AlertType.schedule_posted,
+                site_id=1,
+                channels=["email"],
+                scheduled_for=now - timedelta(hours=1),
+                dedup_key="sp-1",
+                payload_json={},
+                closed_at=now,
+                close_reason=CloseReason.acknowledged,
+            )
+        )
+    r = await c.get(
+        "/api/inbox/summary",
+        params={"since": _iso(now - timedelta(days=1)), "until": _iso(now + timedelta(days=1))},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # The closed schedule_posted alert is NOT in the inbox alert list…
+    assert body["alerts"] == []
+    # …but the site-distinct analytics count still sees it.
+    assert body["site_activity"]["posted_new_count"] == 1


### PR DESCRIPTION
## Summary
- Adds Alert.closed_at + close_reason columns (nullable, indexed) and CloseReason StrEnum
- POST /api/alerts/{id}/close (idempotent, last-reason-wins) and POST /api/alerts/{id}/reopen
- Inbox summary excludes closed alerts by default; ?include_closed=true opts back in
- schedule_posted analytics count intentionally unfiltered (regression test locks it in)

Backend-only — frontend wiring is Phase 5b-1b.

## Test plan
- [x] uv run pytest -q (541 passed; +13 from 528 baseline)
- [x] uv run ruff check . && uv run ruff format --check . clean
- [x] uv run mypy src clean
- [x] alembic upgrade head clean on fresh DB
- [x] alembic upgrade head clean on DB at previous head (0003_pushover_config_json)
- [ ] CI passes

## Summary by Sourcery

Add backend support for closing and reopening alerts, tracking close state, and exposing it via alert and inbox APIs.

New Features:
- Introduce CloseReason enum and closed_at/close_reason fields on alerts to track alert close state.
- Expose alert close state in alert detail and inbox summary API responses.
- Add POST /api/alerts/{id}/close and POST /api/alerts/{id}/reopen endpoints to close and reopen alerts.

Enhancements:
- Update inbox summary API to optionally include closed alerts while excluding them by default and to keep schedule_posted analytics counts unaffected by closing alerts.

Tests:
- Add integration tests covering alert close/reopen endpoints, inbox closed-alert filtering, and regression for schedule_posted analytics counts.