### PR TITLE
phase 5c-1: per-kid calendar view (week + month)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-phase-5c-1-kid-calendar.md
+++ b/docs/superpowers/plans/2026-04-29-phase-5c-1-kid-calendar.md
@@ -1,0 +1,2050 @@
+# Phase 5c-1 — Per-kid Calendar View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a per-kid calendar view (`/kids/$id/calendar`) that renders enrollments + unavailability blocks on a week or month grid, with click-to-cancel/delete via popover. One new aggregated backend endpoint plus two mutation hooks reusing the canonical 5b-1b pattern.
+
+**Architecture:** Backend grows a pure-function recurring-expansion helper (`src/yas/calendar/occurrences.py`), an aggregated read endpoint (`GET /api/kids/{id}/calendar`), and one `KidCalendarOut` Pydantic model. Frontend installs `react-big-calendar`, adds a route + `CalendarView` + `CalendarEventPopover`, two new TanStack Query mutations (`useCancelEnrollment`, `useDeleteUnavailability`) following 5b-1b's optimistic + rollback pattern. KidTabs gains a Calendar entry.
+
+**Tech Stack:** SQLAlchemy 2.x async, FastAPI, Pydantic v2, pytest-asyncio, React 19, TanStack Query 5, TanStack Router, `react-big-calendar` (new), `date-fns`, MSW, Vitest + React Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md`
+
+**Project conventions to maintain:**
+- Backend deps already pinned to exact patch in `pyproject.toml`. No new backend deps in this slice.
+- Frontend deps pinned to exact patch in `frontend/package.json` (no `^`/`~`). Use `npm install --save-exact react-big-calendar@<latest-stable>` for the new dep.
+- All commits signed via 1Password SSH agent. Set `SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"` before each `git commit` in fresh shells (subagents do NOT inherit it). After each commit verify with `git cat-file commit HEAD | grep -q '^gpgsig '`.
+- Branch already created: `phase-5c-1-kid-calendar`. Do NOT commit to `main`.
+- Backend gates: `uv run pytest -q --no-cov`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src`.
+- Frontend gates from `frontend/`: `npm run typecheck`, `npm run lint`, `npm run test`. (`format:check` has pre-existing failures — don't introduce new ones; only assert the files you touch are clean.)
+- Backend baseline: 543 tests. Frontend baseline: 31 tests (8 files).
+- Hand-maintained types in `frontend/src/lib/types.ts` mirror Pydantic schemas; keep them in sync.
+
+---
+
+## File Structure
+
+**Create — backend:**
+- `src/yas/calendar/__init__.py` — empty package marker.
+- `src/yas/calendar/occurrences.py` — pure-function `expand_recurring` helper.
+- `src/yas/web/routes/kid_calendar.py` — `GET /api/kids/{kid_id}/calendar` handler (separate from `kids.py` to keep that file from growing).
+- `src/yas/web/routes/kid_calendar_schemas.py` — `KidCalendarOut`, `CalendarEventOut` Pydantic models.
+- `tests/unit/test_calendar_occurrences.py` — pure-function tests for `expand_recurring`.
+- `tests/integration/test_api_kids_calendar.py` — endpoint integration tests.
+
+**Modify — backend:**
+- `src/yas/web/app.py` — register the new router.
+
+**Create — frontend:**
+- `frontend/src/components/calendar/CalendarView.tsx` — wraps `react-big-calendar`.
+- `frontend/src/components/calendar/CalendarEventPopover.tsx` — popover with action.
+- `frontend/src/components/calendar/CalendarView.test.tsx`
+- `frontend/src/components/calendar/CalendarEventPopover.test.tsx`
+- `frontend/src/components/calendar/calendar-overrides.css` — minimal Tailwind v4-friendly overrides for `react-big-calendar`'s base styles.
+- `frontend/src/routes/kids.$id.calendar.tsx` — TanStack Router route.
+
+**Modify — frontend:**
+- `frontend/package.json` — add `react-big-calendar` (exact patch).
+- `frontend/src/lib/types.ts` — add `CalendarEvent`, `KidCalendarResponse`.
+- `frontend/src/lib/queries.ts` — add `useKidCalendar`.
+- `frontend/src/lib/mutations.ts` — add `useCancelEnrollment`, `useDeleteUnavailability`.
+- `frontend/src/lib/mutations.test.tsx` — tests for the two new mutations.
+- `frontend/src/test/handlers.ts` — MSW handlers for the new endpoint and mutation routes.
+- `frontend/src/components/layout/KidTabs.tsx` — add Calendar tab.
+
+---
+
+## Task 1 — Pure-function recurring expansion (TDD, backend, isolated)
+
+**Files:**
+- Create: `src/yas/calendar/__init__.py`
+- Create: `src/yas/calendar/occurrences.py`
+- Create: `tests/unit/test_calendar_occurrences.py`
+
+End state: `expand_recurring(...)` is implemented and exhaustively unit-tested. No HTTP, no DB. ~10 unit tests.
+
+- [ ] **Step 1: Create the package marker**
+
+```bash
+mkdir -p src/yas/calendar
+touch src/yas/calendar/__init__.py
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/unit/test_calendar_occurrences.py`:
+
+```python
+"""Pure-function tests for the calendar recurring-expansion helper."""
+
+from __future__ import annotations
+
+from datetime import date, time
+
+from yas.calendar.occurrences import Occurrence, expand_recurring
+
+
+def _occ(d: tuple[int, int, int], start: tuple[int, int] | None, end: tuple[int, int] | None) -> Occurrence:
+    return Occurrence(
+        date=date(*d),
+        time_start=time(*start) if start else None,
+        time_end=time(*end) if end else None,
+        all_day=start is None and end is None,
+    )
+
+
+def test_weekly_recurring_within_range_returns_correct_dates():
+    # Mon 2026-04-27, Wed 2026-04-29, Fri 2026-05-01.
+    out = list(
+        expand_recurring(
+            days_of_week=["mon", "wed", "fri"],
+            time_start=time(16, 0),
+            time_end=time(17, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == [
+        _occ((2026, 4, 27), (16, 0), (17, 0)),
+        _occ((2026, 4, 29), (16, 0), (17, 0)),
+        _occ((2026, 5, 1), (16, 0), (17, 0)),
+    ]
+
+
+def test_date_start_clips_lower_bound():
+    out = list(
+        expand_recurring(
+            days_of_week=["tue"],
+            time_start=time(10, 0),
+            time_end=time(11, 0),
+            date_start=date(2026, 4, 28),
+            date_end=None,
+            range_from=date(2026, 4, 21),
+            range_to=date(2026, 5, 5),
+        )
+    )
+    # Tue 2026-04-21 is excluded by date_start; Tue 2026-04-28 and 2026-05-05 (out of range) excluded.
+    assert [o.date for o in out] == [date(2026, 4, 28)]
+
+
+def test_date_end_clips_upper_bound_inclusive():
+    out = list(
+        expand_recurring(
+            days_of_week=["tue"],
+            time_start=time(10, 0),
+            time_end=time(11, 0),
+            date_start=None,
+            date_end=date(2026, 4, 28),
+            range_from=date(2026, 4, 21),
+            range_to=date(2026, 5, 12),
+        )
+    )
+    # date_end is inclusive; Tue 2026-04-21 and 2026-04-28 included; 2026-05-05 excluded.
+    assert [o.date for o in out] == [date(2026, 4, 21), date(2026, 4, 28)]
+
+
+def test_range_to_is_exclusive():
+    out = list(
+        expand_recurring(
+            days_of_week=["mon"],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 4, 27),  # empty half-open range
+        )
+    )
+    assert out == []
+
+
+def test_all_day_when_both_times_none():
+    out = list(
+        expand_recurring(
+            days_of_week=["sat"],
+            time_start=None,
+            time_end=None,
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 25),
+            range_to=date(2026, 4, 26),
+        )
+    )
+    assert len(out) == 1
+    assert out[0].all_day is True
+    assert out[0].time_start is None
+    assert out[0].time_end is None
+
+
+def test_empty_days_of_week_returns_no_occurrences():
+    out = list(
+        expand_recurring(
+            days_of_week=[],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == []
+
+
+def test_days_of_week_case_insensitive():
+    out = list(
+        expand_recurring(
+            days_of_week=["MON", "Wed"],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert [o.date for o in out] == [date(2026, 4, 27), date(2026, 4, 29)]
+
+
+def test_source_outside_request_window_returns_no_occurrences():
+    out = list(
+        expand_recurring(
+            days_of_week=["mon"],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=date(2026, 1, 1),
+            date_end=date(2026, 1, 31),
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == []
+
+
+def test_malformed_partial_time_skipped():
+    """time_start without time_end (or vice versa) is malformed; helper skips."""
+    out = list(
+        expand_recurring(
+            days_of_week=["mon"],
+            time_start=time(9, 0),
+            time_end=None,
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == []
+```
+
+- [ ] **Step 3: Run the tests; confirm they FAIL**
+
+```bash
+uv run pytest tests/unit/test_calendar_occurrences.py -q --no-cov
+```
+
+Expected: ImportError (module doesn't exist yet) → all 9 tests fail at collection.
+
+- [ ] **Step 4: Implement `expand_recurring`**
+
+Create `src/yas/calendar/occurrences.py`:
+
+```python
+"""Pure-function expansion of recurring weekly patterns into per-date occurrences.
+
+No DB, no HTTP — call sites pass the row's pattern fields and a request window
+and get back concrete occurrences within the intersection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import date, time, timedelta
+
+# Map weekday name → date.weekday() value (Mon=0..Sun=6).
+_WEEKDAY: dict[str, int] = {
+    "mon": 0,
+    "tue": 1,
+    "wed": 2,
+    "thu": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Occurrence:
+    """A concrete dated event derived from a recurring pattern."""
+
+    date: date
+    time_start: time | None
+    time_end: time | None
+    all_day: bool
+
+
+def expand_recurring(
+    *,
+    days_of_week: list[str],
+    time_start: time | None,
+    time_end: time | None,
+    date_start: date | None,
+    date_end: date | None,
+    range_from: date,
+    range_to: date,
+) -> Iterator[Occurrence]:
+    """Yield occurrences for each weekday in `days_of_week` within the
+    intersection of [range_from, range_to) (half-open) and
+    [date_start, date_end] (closed, both endpoints inclusive when set).
+
+    A row with both `time_start` and `time_end` set produces timed
+    occurrences; both None produces all-day occurrences. A partial
+    (one set, one None) is treated as malformed and yields nothing.
+    """
+
+    # Validate time pairing.
+    if (time_start is None) != (time_end is None):
+        return
+    all_day = time_start is None and time_end is None
+
+    # Normalize weekday names; silently skip unknown values.
+    target_weekdays = {
+        _WEEKDAY[name.lower()]
+        for name in days_of_week
+        if name.lower() in _WEEKDAY
+    }
+    if not target_weekdays:
+        return
+
+    # Clip the iteration range against the source's date_start/date_end.
+    lo = range_from
+    if date_start is not None and date_start > lo:
+        lo = date_start
+    hi = range_to  # exclusive
+    if date_end is not None:
+        # date_end is inclusive on the source row; convert to exclusive
+        # by adding one day so the half-open `lo..hi` loop works uniformly.
+        hi_from_source = date_end + timedelta(days=1)
+        if hi_from_source < hi:
+            hi = hi_from_source
+
+    cursor = lo
+    while cursor < hi:
+        if cursor.weekday() in target_weekdays:
+            yield Occurrence(
+                date=cursor,
+                time_start=time_start,
+                time_end=time_end,
+                all_day=all_day,
+            )
+        cursor += timedelta(days=1)
+```
+
+- [ ] **Step 5: Re-run tests; confirm all 9 PASS**
+
+```bash
+uv run pytest tests/unit/test_calendar_occurrences.py -q --no-cov
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 6: Run full backend gates**
+
+```bash
+uv run pytest -q --no-cov && uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: 552 passed (543 + 9); ruff/format/mypy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git add src/yas/calendar/__init__.py src/yas/calendar/occurrences.py tests/unit/test_calendar_occurrences.py
+git commit -m "feat(calendar): expand_recurring helper for date-range occurrences
+
+Pure-function expansion of (days_of_week + time_start/end + date bounds)
+into concrete date occurrences within a half-open request window.
+Foundation for the calendar route in the next task."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 2 — Calendar API endpoint (TDD, backend)
+
+**Files:**
+- Create: `src/yas/web/routes/kid_calendar_schemas.py`
+- Create: `src/yas/web/routes/kid_calendar.py`
+- Create: `tests/integration/test_api_kids_calendar.py`
+- Modify: `src/yas/web/app.py`
+
+End state: `GET /api/kids/{kid_id}/calendar?from=&to=` is wired and tested. ~8 integration tests covering the spec §2.1 boundary semantics.
+
+- [ ] **Step 1: Write the schemas**
+
+Create `src/yas/web/routes/kid_calendar_schemas.py`:
+
+```python
+"""Pydantic models for GET /api/kids/{kid_id}/calendar."""
+
+from __future__ import annotations
+
+from datetime import date, time
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CalendarEventOut(BaseModel):
+    id: str  # composite "kind:source-id:date" — see spec §2.1
+    kind: Literal["enrollment", "unavailability"]
+    date: date
+    time_start: time | None = None
+    time_end: time | None = None
+    all_day: bool
+    title: str
+    # enrollment-only:
+    enrollment_id: int | None = None
+    offering_id: int | None = None
+    location_id: int | None = None
+    status: str | None = None
+    # unavailability-only:
+    block_id: int | None = None
+    source: str | None = None
+    from_enrollment_id: int | None = None
+
+
+class KidCalendarOut(BaseModel):
+    """Python's `from` keyword conflict resolved via Pydantic alias.
+
+    `from_` is the Python attribute; FastAPI emits `from` on the wire
+    because the route handler uses `response_model_by_alias=True`.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    kid_id: int
+    from_: date = Field(alias="from")
+    to: date
+    events: list[CalendarEventOut]
+```
+
+- [ ] **Step 2: Write the failing integration tests**
+
+Create `tests/integration/test_api_kids_calendar.py`:
+
+```python
+"""Integration tests for GET /api/kids/{kid_id}/calendar."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from yas.db.base import Base
+from yas.db.models import (
+    Enrollment,
+    Kid,
+    Offering,
+    Page,
+    Site,
+    UnavailabilityBlock,
+)
+from yas.db.models._types import (
+    EnrollmentStatus,
+    OfferingStatus,
+    UnavailabilitySource,
+)
+from yas.db.session import create_engine_for, session_scope
+from yas.web.app import create_app
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("YAS_ANTHROPIC_API_KEY", "sk-test")
+    url = f"sqlite+aiosqlite:///{tmp_path}/c.db"
+    monkeypatch.setenv("YAS_DATABASE_URL", url)
+    engine = create_engine_for(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    app = create_app(engine=engine, fetcher=None, llm=None, geocoder=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c, engine
+    await engine.dispose()
+
+
+async def _seed_kid_with_enrollment(engine, *, kid_id=1, offering_id=1):
+    async with session_scope(engine) as s:
+        s.add(Kid(id=kid_id, name="Sam", dob=date(2019, 5, 1)))
+        s.add(Site(id=1, name="X", base_url="https://x"))
+        s.add(Page(id=1, site_id=1, url="https://x/p"))
+        await s.flush()
+        s.add(
+            Offering(
+                id=offering_id,
+                site_id=1,
+                page_id=1,
+                name="T-Ball",
+                normalized_name="t-ball",
+                days_of_week=["tue", "thu"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+        await s.flush()
+        s.add(
+            Enrollment(
+                id=10,
+                kid_id=kid_id,
+                offering_id=offering_id,
+                status=EnrollmentStatus.enrolled.value,
+                enrolled_at=datetime.now(UTC),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_returns_404_for_unknown_kid(client):
+    c, _ = client
+    r = await c.get("/api/kids/9999/calendar?from=2026-04-27&to=2026-05-04")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_returns_422_when_from_not_before_to(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    r = await c.get("/api/kids/1/calendar?from=2026-05-04&to=2026-04-27")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_returns_422_when_range_exceeds_90_days(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    r = await c.get("/api/kids/1/calendar?from=2026-01-01&to=2026-04-15")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_returns_enrolled_offering_occurrences(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kid_id"] == 1
+    assert body["from"] == "2026-04-27"
+    assert body["to"] == "2026-05-04"
+    enrollment_events = [e for e in body["events"] if e["kind"] == "enrollment"]
+    # Tue 2026-04-28 + Thu 2026-04-30; offering's date range is broader.
+    assert len(enrollment_events) == 2
+    dates = sorted(e["date"] for e in enrollment_events)
+    assert dates == ["2026-04-28", "2026-04-30"]
+    e = enrollment_events[0]
+    assert e["enrollment_id"] == 10
+    assert e["offering_id"] == 1
+    assert e["status"] == "enrolled"
+    assert e["title"] == "T-Ball"
+    assert e["time_start"] == "16:00:00"
+    assert e["all_day"] is False
+
+
+@pytest.mark.asyncio
+async def test_excludes_cancelled_enrollments(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        from sqlalchemy import select
+        e = (await s.execute(select(Enrollment).where(Enrollment.id == 10))).scalar_one()
+        e.status = EnrollmentStatus.cancelled.value
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    assert [e for e in body["events"] if e["kind"] == "enrollment"] == []
+
+
+@pytest.mark.asyncio
+async def test_returns_unavailability_blocks_with_from_enrollment_id(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        s.add(
+            UnavailabilityBlock(
+                id=20,
+                kid_id=1,
+                source=UnavailabilitySource.school.value,
+                label="School",
+                days_of_week=["mon", "tue", "wed", "thu", "fri"],
+                time_start=time(8, 30),
+                time_end=time(15, 0),
+                date_start=date(2026, 1, 1),
+                date_end=date(2026, 6, 30),
+                active=True,
+            )
+        )
+        s.add(
+            UnavailabilityBlock(
+                id=21,
+                kid_id=1,
+                source=UnavailabilitySource.enrollment.value,
+                label="T-Ball",
+                days_of_week=["tue", "thu"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                date_start=date(2026, 4, 1),
+                date_end=date(2026, 6, 30),
+                active=True,
+                source_enrollment_id=10,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    school = [e for e in body["events"] if e["kind"] == "unavailability" and e["block_id"] == 20]
+    assert len(school) == 5  # Mon..Fri
+    assert school[0]["from_enrollment_id"] is None
+    enrollment_block = [
+        e for e in body["events"] if e["kind"] == "unavailability" and e["block_id"] == 21
+    ]
+    assert len(enrollment_block) == 2  # Tue, Thu
+    assert enrollment_block[0]["from_enrollment_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_excludes_inactive_blocks(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        s.add(
+            UnavailabilityBlock(
+                id=22,
+                kid_id=1,
+                source=UnavailabilitySource.manual.value,
+                days_of_week=["wed"],
+                time_start=time(13, 0),
+                time_end=time(14, 0),
+                date_start=date(2026, 4, 1),
+                date_end=date(2026, 6, 30),
+                active=False,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    assert all(e.get("block_id") != 22 for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_excludes_other_kids_events(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    async with session_scope(engine) as s:
+        s.add(Kid(id=2, name="Riley", dob=date(2017, 3, 1)))
+        await s.flush()
+        s.add(
+            Enrollment(
+                id=11,
+                kid_id=2,
+                offering_id=1,
+                status=EnrollmentStatus.enrolled.value,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    assert all(e.get("enrollment_id") != 11 for e in body["events"])
+```
+
+- [ ] **Step 3: Run tests; confirm FAIL**
+
+```bash
+uv run pytest tests/integration/test_api_kids_calendar.py -q --no-cov
+```
+
+Expected: tests fail at route resolution (404 from FastAPI's not-found-route, not our 404) or at import.
+
+- [ ] **Step 4: Implement the route**
+
+Create `src/yas/web/routes/kid_calendar.py`:
+
+```python
+"""GET /api/kids/{kid_id}/calendar — aggregated per-kid event view."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from yas.calendar.occurrences import expand_recurring
+from yas.db.models import Enrollment, Kid, Offering, UnavailabilityBlock
+from yas.db.models._types import EnrollmentStatus
+from yas.db.session import session_scope
+from yas.web.routes.kid_calendar_schemas import CalendarEventOut, KidCalendarOut
+
+router = APIRouter(prefix="/api/kids", tags=["kids"])
+
+_MAX_RANGE_DAYS = 90
+
+
+def _engine(req: Request) -> AsyncEngine:
+    engine: AsyncEngine = req.app.state.yas.engine
+    return engine
+
+
+@router.get("/{kid_id}/calendar", response_model=KidCalendarOut, response_model_by_alias=True)
+async def get_kid_calendar(
+    request: Request,
+    kid_id: int,
+    from_: Annotated[date, Query(alias="from")],
+    to: Annotated[date, Query()],
+) -> KidCalendarOut:
+    if from_ >= to:
+        raise HTTPException(status_code=422, detail="from must be before to")
+    if (to - from_).days > _MAX_RANGE_DAYS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"range exceeds {_MAX_RANGE_DAYS}-day cap",
+        )
+
+    async with session_scope(_engine(request)) as s:
+        kid = (await s.execute(select(Kid).where(Kid.id == kid_id))).scalar_one_or_none()
+        if kid is None:
+            raise HTTPException(status_code=404, detail=f"kid {kid_id} not found")
+
+        events: list[CalendarEventOut] = []
+
+        # 1. Active enrollments + offering join.
+        enrollment_rows = (
+            await s.execute(
+                select(Enrollment, Offering)
+                .join(Offering, Offering.id == Enrollment.offering_id)
+                .where(Enrollment.kid_id == kid_id)
+                .where(Enrollment.status == EnrollmentStatus.enrolled.value)
+            )
+        ).all()
+        for enrollment, offering in enrollment_rows:
+            for occ in expand_recurring(
+                days_of_week=list(offering.days_of_week or []),
+                time_start=offering.time_start,
+                time_end=offering.time_end,
+                date_start=offering.start_date,
+                date_end=offering.end_date,
+                range_from=from_,
+                range_to=to,
+            ):
+                events.append(
+                    CalendarEventOut(
+                        id=f"enrollment:{enrollment.id}:{occ.date.isoformat()}",
+                        kind="enrollment",
+                        date=occ.date,
+                        time_start=occ.time_start,
+                        time_end=occ.time_end,
+                        all_day=occ.all_day,
+                        title=offering.name,
+                        enrollment_id=enrollment.id,
+                        offering_id=offering.id,
+                        location_id=offering.location_id,
+                        status=enrollment.status,
+                    )
+                )
+
+        # 2. Active unavailability blocks.
+        block_rows = (
+            (
+                await s.execute(
+                    select(UnavailabilityBlock)
+                    .where(UnavailabilityBlock.kid_id == kid_id)
+                    .where(UnavailabilityBlock.active.is_(True))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for block in block_rows:
+            for occ in expand_recurring(
+                days_of_week=list(block.days_of_week or []),
+                time_start=block.time_start,
+                time_end=block.time_end,
+                date_start=block.date_start,
+                date_end=block.date_end,
+                range_from=from_,
+                range_to=to,
+            ):
+                events.append(
+                    CalendarEventOut(
+                        id=f"unavailability:{block.id}:{occ.date.isoformat()}",
+                        kind="unavailability",
+                        date=occ.date,
+                        time_start=occ.time_start,
+                        time_end=occ.time_end,
+                        all_day=occ.all_day,
+                        title=block.label or block.source,
+                        block_id=block.id,
+                        source=block.source,
+                        from_enrollment_id=block.source_enrollment_id,
+                    )
+                )
+
+        events.sort(key=lambda e: (e.date, e.time_start or ""))
+        return KidCalendarOut(kid_id=kid_id, from_=from_, to=to, events=events)
+```
+
+- [ ] **Step 5: Register the router**
+
+In `src/yas/web/app.py`, find where other routers are included (look for `app.include_router(...)` calls). Add:
+
+```python
+from yas.web.routes import kid_calendar  # add to imports
+
+app.include_router(kid_calendar.router)
+```
+
+- [ ] **Step 6: Re-run integration tests; confirm all PASS**
+
+```bash
+uv run pytest tests/integration/test_api_kids_calendar.py -q --no-cov
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 7: Run full backend gates**
+
+```bash
+uv run pytest -q --no-cov && uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: 560 passed (552 + 8); ruff/format/mypy clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git add src/yas/web/routes/kid_calendar.py src/yas/web/routes/kid_calendar_schemas.py tests/integration/test_api_kids_calendar.py src/yas/web/app.py
+git commit -m "feat(api): GET /api/kids/{kid_id}/calendar
+
+Aggregated per-kid view of enrollment occurrences (active enrollments
++ joined offering) and unavailability blocks within a half-open
+[from, to) date range. Caps range at 90 days defensively.
+
+Reuses the expand_recurring helper from the previous commit."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 3 — Frontend types + query hook + MSW handlers (no UI yet)
+
+**Files:**
+- Modify: `frontend/src/lib/types.ts`
+- Modify: `frontend/src/lib/queries.ts`
+- Modify: `frontend/src/test/handlers.ts`
+
+End state: TypeScript types match the backend response, `useKidCalendar` exists and is tested via MSW. No visible UI yet.
+
+- [ ] **Step 1: Add frontend types**
+
+In `frontend/src/lib/types.ts`, append:
+
+```ts
+export type CalendarEventKind = 'enrollment' | 'unavailability';
+
+export interface CalendarEvent {
+  id: string;            // composite "kind:source-id:date"
+  kind: CalendarEventKind;
+  date: string;          // YYYY-MM-DD
+  time_start: string | null;   // "HH:MM:SS" or null for all-day
+  time_end: string | null;
+  all_day: boolean;
+  title: string;
+  // enrollment-only:
+  enrollment_id?: number | null;
+  offering_id?: number | null;
+  location_id?: number | null;
+  status?: string | null;
+  // unavailability-only:
+  block_id?: number | null;
+  source?: string | null;
+  from_enrollment_id?: number | null;
+}
+
+export interface KidCalendarResponse {
+  kid_id: number;
+  from: string;  // YYYY-MM-DD
+  to: string;
+  events: CalendarEvent[];
+}
+```
+
+- [ ] **Step 2: Add `useKidCalendar` to `lib/queries.ts`**
+
+Append:
+
+```ts
+export function useKidCalendar({
+  kidId,
+  from,
+  to,
+}: {
+  kidId: number;
+  from: string;
+  to: string;
+}) {
+  return useQuery({
+    queryKey: ['kids', kidId, 'calendar', from, to],
+    queryFn: () =>
+      api.get<KidCalendarResponse>(
+        `/api/kids/${kidId}/calendar?from=${from}&to=${to}`,
+      ),
+    enabled: Number.isFinite(kidId) && !!from && !!to,
+  });
+}
+```
+
+(Add `KidCalendarResponse` to the import block at the top of the file.)
+
+- [ ] **Step 3: Add MSW handlers**
+
+In `frontend/src/test/handlers.ts`, append to the `handlers` array:
+
+```ts
+http.get('/api/kids/:id/calendar', ({ params, request }) => {
+  const url = new URL(request.url);
+  return HttpResponse.json({
+    kid_id: Number(params.id),
+    from: url.searchParams.get('from'),
+    to: url.searchParams.get('to'),
+    events: [],
+  });
+}),
+http.patch('/api/enrollments/:id', async ({ params, request }) => {
+  const body = (await request.json()) as { status?: string };
+  return HttpResponse.json({
+    id: Number(params.id),
+    kid_id: 1,
+    offering_id: 1,
+    status: body.status ?? 'cancelled',
+    enrolled_at: null,
+    notes: null,
+    created_at: '2026-04-29T12:00:00Z',
+  });
+}),
+http.delete('/api/unavailability/:id', () => new HttpResponse(null, { status: 204 })),
+```
+
+- [ ] **Step 4: Run frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: all clean (no new tests yet, but types compile and existing tests pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/lib/types.ts frontend/src/lib/queries.ts frontend/src/test/handlers.ts
+git commit -m "feat(frontend): types + useKidCalendar hook + MSW handlers
+
+Mirrors the backend KidCalendarOut shape. Adds MSW handlers for the
+new GET endpoint and the two existing routes the calendar will
+mutate (PATCH /api/enrollments/{id}, DELETE /api/unavailability/{id})
+so subsequent tasks can test against them."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 4 — Mutation hooks: `useCancelEnrollment` + `useDeleteUnavailability` (TDD)
+
+**Files:**
+- Modify: `frontend/src/lib/mutations.ts`
+- Modify: `frontend/src/lib/mutations.test.tsx`
+
+End state: Two new mutation hooks following the canonical 5b-1b shape. ~5 new tests covering optimistic remove + rollback for both.
+
+- [ ] **Step 1: Append failing tests to `mutations.test.tsx`**
+
+Append at the bottom of `frontend/src/lib/mutations.test.tsx`:
+
+```tsx
+import { useCancelEnrollment, useDeleteUnavailability } from './mutations';
+import type { KidCalendarResponse } from './types';
+
+const seedCal = (events: KidCalendarResponse['events']): KidCalendarResponse => ({
+  kid_id: 1,
+  from: '2026-04-27',
+  to: '2026-05-04',
+  events,
+});
+
+describe('useCancelEnrollment', () => {
+  it('removes all enrollment occurrences and linked-block occurrences for that enrollment', async () => {
+    const qc = new QueryClient();
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04'],
+      seedCal([
+        {
+          id: 'enrollment:42:2026-04-28',
+          kind: 'enrollment',
+          date: '2026-04-28',
+          time_start: '16:00:00',
+          time_end: '17:00:00',
+          all_day: false,
+          title: 'T-Ball',
+          enrollment_id: 42,
+          offering_id: 7,
+          status: 'enrolled',
+        },
+        {
+          id: 'unavailability:21:2026-04-28',
+          kind: 'unavailability',
+          date: '2026-04-28',
+          time_start: '16:00:00',
+          time_end: '17:00:00',
+          all_day: false,
+          title: 'T-Ball',
+          block_id: 21,
+          source: 'enrollment',
+          from_enrollment_id: 42,
+        },
+        {
+          id: 'unavailability:20:2026-04-28',
+          kind: 'unavailability',
+          date: '2026-04-28',
+          time_start: '08:30:00',
+          time_end: '15:00:00',
+          all_day: false,
+          title: 'School',
+          block_id: 20,
+          source: 'school',
+          from_enrollment_id: null,
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useCancelEnrollment(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({ kidId: 1, enrollmentId: 42 });
+    });
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    // Only the school block remains.
+    expect(after?.events).toHaveLength(1);
+    expect(after?.events[0].block_id).toBe(20);
+  });
+
+  it('rolls back on server error', async () => {
+    server.use(
+      http.patch('/api/enrollments/:id', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+    );
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const original = seedCal([
+      {
+        id: 'enrollment:42:2026-04-28',
+        kind: 'enrollment',
+        date: '2026-04-28',
+        time_start: '16:00:00',
+        time_end: '17:00:00',
+        all_day: false,
+        title: 'T-Ball',
+        enrollment_id: 42,
+        offering_id: 7,
+        status: 'enrolled',
+      },
+    ]);
+    qc.setQueryData(['kids', 1, 'calendar', '2026-04-27', '2026-05-04'], original);
+
+    const { result } = renderHook(() => useCancelEnrollment(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current
+        .mutateAsync({ kidId: 1, enrollmentId: 42 })
+        .catch(() => {});
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toHaveLength(1);
+    expect(after?.events[0].enrollment_id).toBe(42);
+  });
+});
+
+describe('useDeleteUnavailability', () => {
+  it('removes the matching unavailability event from cache', async () => {
+    const qc = new QueryClient();
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04'],
+      seedCal([
+        {
+          id: 'unavailability:20:2026-04-28',
+          kind: 'unavailability',
+          date: '2026-04-28',
+          time_start: '08:30:00',
+          time_end: '15:00:00',
+          all_day: false,
+          title: 'School',
+          block_id: 20,
+          source: 'school',
+          from_enrollment_id: null,
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useDeleteUnavailability(), {
+      wrapper: makeWrapper(qc),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ kidId: 1, blockId: 20 });
+    });
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toEqual([]);
+  });
+
+  it('rolls back on server error', async () => {
+    server.use(
+      http.delete('/api/unavailability/:id', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+    );
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const original = seedCal([
+      {
+        id: 'unavailability:20:2026-04-28',
+        kind: 'unavailability',
+        date: '2026-04-28',
+        time_start: '08:30:00',
+        time_end: '15:00:00',
+        all_day: false,
+        title: 'School',
+        block_id: 20,
+        source: 'school',
+        from_enrollment_id: null,
+      },
+    ]);
+    qc.setQueryData(['kids', 1, 'calendar', '2026-04-27', '2026-05-04'], original);
+
+    const { result } = renderHook(() => useDeleteUnavailability(), {
+      wrapper: makeWrapper(qc),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ kidId: 1, blockId: 20 }).catch(() => {});
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; confirm FAIL**
+
+```bash
+cd frontend && npm run test -- mutations
+```
+
+Expected: hooks not exported yet → fail.
+
+- [ ] **Step 3: Implement the two hooks**
+
+Append to `frontend/src/lib/mutations.ts`:
+
+```ts
+import type { KidCalendarResponse } from './types';
+
+interface CancelEnrollmentInput {
+  kidId: number;
+  enrollmentId: number;
+}
+
+export function useCancelEnrollment() {
+  const qc = useQueryClient();
+  type Ctx = {
+    snapshots: ReadonlyArray<readonly [QueryKey, KidCalendarResponse | undefined]>;
+  };
+  return useMutation<unknown, Error, CancelEnrollmentInput, Ctx>({
+    mutationFn: ({ enrollmentId }) =>
+      api.patch(`/api/enrollments/${enrollmentId}`, { status: 'cancelled' }),
+
+    onMutate: async ({ kidId, enrollmentId }) => {
+      await qc.cancelQueries({ queryKey: ['kids', kidId, 'calendar'] });
+      const snapshots = qc.getQueriesData<KidCalendarResponse>({
+        queryKey: ['kids', kidId, 'calendar'],
+      });
+
+      for (const [key, data] of snapshots) {
+        if (!data) continue;
+        const filtered = data.events.filter(
+          (e) =>
+            e.enrollment_id !== enrollmentId &&
+            e.from_enrollment_id !== enrollmentId,
+        );
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async (_data, _err, { kidId }) => {
+      await qc.invalidateQueries({ queryKey: ['kids', kidId, 'calendar'] });
+    },
+  });
+}
+
+interface DeleteUnavailabilityInput {
+  kidId: number;
+  blockId: number;
+}
+
+export function useDeleteUnavailability() {
+  const qc = useQueryClient();
+  type Ctx = {
+    snapshots: ReadonlyArray<readonly [QueryKey, KidCalendarResponse | undefined]>;
+  };
+  return useMutation<unknown, Error, DeleteUnavailabilityInput, Ctx>({
+    mutationFn: ({ blockId }) => api.delete(`/api/unavailability/${blockId}`),
+
+    onMutate: async ({ kidId, blockId }) => {
+      await qc.cancelQueries({ queryKey: ['kids', kidId, 'calendar'] });
+      const snapshots = qc.getQueriesData<KidCalendarResponse>({
+        queryKey: ['kids', kidId, 'calendar'],
+      });
+
+      for (const [key, data] of snapshots) {
+        if (!data) continue;
+        const filtered = data.events.filter((e) => e.block_id !== blockId);
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async (_data, _err, { kidId }) => {
+      await qc.invalidateQueries({ queryKey: ['kids', kidId, 'calendar'] });
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Add `patch` and `delete` to `api`**
+
+In `frontend/src/lib/api.ts`, extend the `api` object:
+
+```ts
+export const api = {
+  get<T>(path: string) {
+    return request<T>(path);
+  },
+  post<T>(path: string, body?: unknown) {
+    return request<T>(path, {
+      method: 'POST',
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  },
+  patch<T>(path: string, body?: unknown) {
+    return request<T>(path, {
+      method: 'PATCH',
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  },
+  delete<T = void>(path: string) {
+    return request<T>(path, { method: 'DELETE' });
+  },
+};
+```
+
+**Required: handle 204 in `request()`.** The existing `request<T>()` calls `r.json()` unconditionally and will throw on `DELETE /api/unavailability/{id}`'s empty 204 response. Add this guard inside `request()` before the JSON parse:
+
+```ts
+if (r.status === 204) {
+  return undefined as T;
+}
+return r.json() as Promise<T>;
+```
+
+Verify by reading `frontend/src/lib/api.ts` first; the existing fn body ends with `return r.json() as Promise<T>;` and the guard goes immediately above that line.
+
+- [ ] **Step 5: Re-run all mutation tests; confirm they pass**
+
+```bash
+cd frontend && npm run test -- mutations
+```
+
+Expected: 9 passed (5 from 5b-1b + 4 new).
+
+- [ ] **Step 6: Run all frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 35 passed total (31 + 4).
+
+- [ ] **Step 7: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/lib/mutations.ts frontend/src/lib/mutations.test.tsx frontend/src/lib/api.ts
+git commit -m "feat(frontend): useCancelEnrollment + useDeleteUnavailability
+
+Both follow the canonical 5b-1b mutation pattern (cancelQueries +
+snapshot + optimistic setQueryData + onError rollback + awaited
+invalidate). useCancelEnrollment also strips linked-block events
+from the cache so the UI doesn't briefly show an orphaned block.
+
+Adds api.patch / api.delete helpers (delete handles 204 responses)."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 5 — `react-big-calendar` install + `CalendarView` component (TDD)
+
+**Files:**
+- Modify: `frontend/package.json` (and lockfile)
+- Create: `frontend/src/components/calendar/CalendarView.tsx`
+- Create: `frontend/src/components/calendar/CalendarView.test.tsx`
+- Create: `frontend/src/components/calendar/calendar-overrides.css`
+
+End state: `<CalendarView>` renders events on week or month grid, calls `onSelectEvent` on click. ~3 tests.
+
+- [ ] **Step 1: Install the dependency**
+
+```bash
+cd frontend && npm install --save-exact react-big-calendar @types/react-big-calendar
+```
+
+Verify the version in `package.json` is pinned (no `^`/`~`).
+
+- [ ] **Step 2: Write failing tests**
+
+Create `frontend/src/components/calendar/CalendarView.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CalendarView } from './CalendarView';
+import type { CalendarEvent } from '@/lib/types';
+
+const events: CalendarEvent[] = [
+  {
+    id: 'enrollment:1:2026-04-29',
+    kind: 'enrollment',
+    date: '2026-04-29',
+    time_start: '16:00:00',
+    time_end: '17:00:00',
+    all_day: false,
+    title: 'T-Ball',
+    enrollment_id: 1,
+    offering_id: 7,
+    status: 'enrolled',
+  },
+];
+
+describe('CalendarView', () => {
+  it('renders an event title in the grid', () => {
+    render(
+      <CalendarView
+        events={events}
+        view="week"
+        onView={vi.fn()}
+        date={new Date('2026-04-29T12:00:00Z')}
+        onNavigate={vi.fn()}
+        onSelectEvent={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/T-Ball/i)).toBeInTheDocument();
+  });
+
+  it('calls onSelectEvent when an event is clicked', async () => {
+    const onSelectEvent = vi.fn();
+    render(
+      <CalendarView
+        events={events}
+        view="week"
+        onView={vi.fn()}
+        date={new Date('2026-04-29T12:00:00Z')}
+        onNavigate={vi.fn()}
+        onSelectEvent={onSelectEvent}
+      />,
+    );
+    await userEvent.click(screen.getByText(/T-Ball/i));
+    expect(onSelectEvent).toHaveBeenCalledTimes(1);
+    expect(onSelectEvent.mock.calls[0][0].id).toBe('enrollment:1:2026-04-29');
+  });
+
+  it('renders the same events in month view', () => {
+    render(
+      <CalendarView
+        events={events}
+        view="month"
+        onView={vi.fn()}
+        date={new Date('2026-04-29T12:00:00Z')}
+        onNavigate={vi.fn()}
+        onSelectEvent={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/T-Ball/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run; confirm FAIL**
+
+```bash
+npm run test -- CalendarView
+```
+
+Expected: component doesn't exist.
+
+- [ ] **Step 4: Implement `CalendarView.tsx`**
+
+Create `frontend/src/components/calendar/CalendarView.tsx`:
+
+```tsx
+import { Calendar, dateFnsLocalizer, Views, type View } from 'react-big-calendar';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import { enUS } from 'date-fns/locale';
+import type { CalendarEvent } from '@/lib/types';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import './calendar-overrides.css';
+
+const locales = { 'en-US': enUS };
+const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+
+interface RbcEvent {
+  title: string;
+  start: Date;
+  end: Date;
+  allDay: boolean;
+  resource: CalendarEvent;
+}
+
+function toRbc(e: CalendarEvent): RbcEvent {
+  // Build a Date from "YYYY-MM-DD" + "HH:MM:SS". For all-day, span the whole day.
+  const [y, m, d] = e.date.split('-').map(Number);
+  if (e.all_day) {
+    const start = new Date(y, m - 1, d, 0, 0, 0);
+    const end = new Date(y, m - 1, d + 1, 0, 0, 0);
+    return { title: e.title, start, end, allDay: true, resource: e };
+  }
+  const [sh, sm] = (e.time_start ?? '00:00:00').split(':').map(Number);
+  const [eh, em] = (e.time_end ?? '23:59:59').split(':').map(Number);
+  const start = new Date(y, m - 1, d, sh, sm, 0);
+  const end = new Date(y, m - 1, d, eh, em, 0);
+  return { title: e.title, start, end, allDay: false, resource: e };
+}
+
+export function CalendarView({
+  events,
+  view,
+  onView,
+  date,
+  onNavigate,
+  onSelectEvent,
+}: {
+  events: CalendarEvent[];
+  view: View;
+  onView: (v: View) => void;
+  date: Date;
+  onNavigate: (d: Date) => void;
+  onSelectEvent: (e: CalendarEvent) => void;
+}) {
+  const rbcEvents = events.map(toRbc);
+  return (
+    <div className="h-[70vh]">
+      <Calendar
+        localizer={localizer}
+        events={rbcEvents}
+        views={[Views.WEEK, Views.MONTH]}
+        view={view}
+        onView={onView}
+        date={date}
+        onNavigate={onNavigate}
+        min={new Date(0, 0, 0, 6, 0, 0)}
+        max={new Date(0, 0, 0, 22, 0, 0)}
+        onSelectEvent={(rbc) => onSelectEvent((rbc as RbcEvent).resource)}
+        eventPropGetter={(rbc) => ({
+          className:
+            (rbc as RbcEvent).resource.kind === 'enrollment'
+              ? 'rbc-event-enrollment'
+              : 'rbc-event-unavailability',
+        })}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Add the CSS overrides**
+
+Create `frontend/src/components/calendar/calendar-overrides.css`:
+
+```css
+/* Minimal Tailwind-friendly overrides for react-big-calendar's base styles. */
+
+.rbc-event-enrollment {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border: none;
+}
+
+.rbc-event-unavailability {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  border: none;
+}
+
+.rbc-today {
+  background-color: hsl(var(--accent));
+}
+
+.rbc-toolbar button {
+  color: hsl(var(--foreground));
+}
+
+.rbc-toolbar button.rbc-active {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+```
+
+If during implementation the rendered calendar still has visually broken styling (e.g., header text invisible against the theme), append targeted fixes here. Don't try to override more than necessary.
+
+- [ ] **Step 6: Re-run; confirm 3 PASS**
+
+```bash
+npm run test -- CalendarView
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 7: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 38 passed (35 + 3); typecheck clean, lint clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/package.json frontend/package-lock.json frontend/src/components/calendar/CalendarView.tsx frontend/src/components/calendar/CalendarView.test.tsx frontend/src/components/calendar/calendar-overrides.css
+git commit -m "feat(frontend): CalendarView wrapping react-big-calendar
+
+Week + month views with controlled view/date, fixed 6:00–22:00 time
+range, event class dispatch by kind. Maps our flat CalendarEvent
+shape to react-big-calendar's {start,end,allDay,resource} model."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 6 — `CalendarEventPopover` + mutation wiring (TDD)
+
+**Files:**
+- Create: `frontend/src/components/calendar/CalendarEventPopover.tsx`
+- Create: `frontend/src/components/calendar/CalendarEventPopover.test.tsx`
+
+End state: Popover renders enrollment or unavailability details, dispatches the right mutation, suppresses delete on enrollment-linked blocks. ~4 tests.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `frontend/src/components/calendar/CalendarEventPopover.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CalendarEventPopover } from './CalendarEventPopover';
+import type { CalendarEvent } from '@/lib/types';
+
+const enrollment: CalendarEvent = {
+  id: 'enrollment:42:2026-04-29',
+  kind: 'enrollment',
+  date: '2026-04-29',
+  time_start: '16:00:00',
+  time_end: '17:00:00',
+  all_day: false,
+  title: 'T-Ball',
+  enrollment_id: 42,
+  offering_id: 7,
+  status: 'enrolled',
+};
+
+const enrollmentLinkedBlock: CalendarEvent = {
+  id: 'unavailability:21:2026-04-29',
+  kind: 'unavailability',
+  date: '2026-04-29',
+  time_start: '16:00:00',
+  time_end: '17:00:00',
+  all_day: false,
+  title: 'T-Ball',
+  block_id: 21,
+  source: 'enrollment',
+  from_enrollment_id: 42,
+};
+
+const standaloneBlock: CalendarEvent = {
+  id: 'unavailability:20:2026-04-29',
+  kind: 'unavailability',
+  date: '2026-04-29',
+  time_start: '08:30:00',
+  time_end: '15:00:00',
+  all_day: false,
+  title: 'School',
+  block_id: 20,
+  source: 'school',
+  from_enrollment_id: null,
+};
+
+function renderPopover(event: CalendarEvent | null, onClose = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <CalendarEventPopover kidId={1} event={event} open={event !== null} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CalendarEventPopover', () => {
+  it('renders enrollment details + Cancel enrollment button', () => {
+    renderPopover(enrollment);
+    expect(screen.getByText(/T-Ball/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel enrollment/i })).toBeInTheDocument();
+  });
+
+  it('renders standalone block details + Delete block button', () => {
+    renderPopover(standaloneBlock);
+    expect(screen.getByText(/School/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete block/i })).toBeInTheDocument();
+  });
+
+  it('suppresses Delete on enrollment-linked blocks and shows hint', () => {
+    renderPopover(enrollmentLinkedBlock);
+    expect(screen.queryByRole('button', { name: /delete block/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/cancel the enrollment/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose after a successful Cancel enrollment', async () => {
+    const onClose = vi.fn();
+    renderPopover(enrollment, onClose);
+    await userEvent.click(screen.getByRole('button', { name: /cancel enrollment/i }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm FAIL**
+
+```bash
+npm run test -- CalendarEventPopover
+```
+
+- [ ] **Step 3: Implement the popover**
+
+Create `frontend/src/components/calendar/CalendarEventPopover.tsx`:
+
+```tsx
+import { useState, useEffect } from 'react';
+import { Popover, PopoverContent } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { ErrorBanner } from '@/components/common/ErrorBanner';
+import type { CalendarEvent } from '@/lib/types';
+import { useCancelEnrollment, useDeleteUnavailability } from '@/lib/mutations';
+
+export function CalendarEventPopover({
+  kidId,
+  event,
+  open,
+  onClose,
+}: {
+  kidId: number;
+  event: CalendarEvent | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const cancel = useCancelEnrollment();
+  const del = useDeleteUnavailability();
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const inFlight = cancel.isPending || del.isPending;
+
+  useEffect(() => {
+    setErrorMsg(null);
+    cancel.reset();
+    del.reset();
+    // event identity is the only stable signal we're showing a different event;
+    // mutation refs are recreated each render so they cannot be in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event?.id]);
+
+  if (!event) return null;
+
+  const handleCancel = () => {
+    setErrorMsg(null);
+    cancel.mutate(
+      { kidId, enrollmentId: event.enrollment_id! },
+      {
+        onSuccess: onClose,
+        onError: (err) => setErrorMsg(err.message || 'Failed to cancel enrollment'),
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    setErrorMsg(null);
+    del.mutate(
+      { kidId, blockId: event.block_id! },
+      {
+        onSuccess: onClose,
+        onError: (err) => setErrorMsg(err.message || 'Failed to delete block'),
+      },
+    );
+  };
+
+  const isEnrollment = event.kind === 'enrollment';
+  const isLinkedBlock =
+    event.kind === 'unavailability' && event.from_enrollment_id != null;
+
+  return (
+    <Popover open={open} onOpenChange={(o) => !o && !inFlight && onClose()}>
+      <PopoverContent className="w-80 space-y-3">
+        <div>
+          <div className="font-medium">{event.title}</div>
+          <div className="text-xs text-muted-foreground">
+            {event.all_day
+              ? 'All day'
+              : `${event.time_start?.slice(0, 5)}–${event.time_end?.slice(0, 5)}`}
+          </div>
+          {event.kind === 'unavailability' && (
+            <div className="text-xs text-muted-foreground">Source: {event.source}</div>
+          )}
+        </div>
+
+        {errorMsg && <ErrorBanner message={errorMsg} />}
+
+        {isEnrollment && (
+          <Button onClick={handleCancel} disabled={inFlight} variant="destructive">
+            Cancel enrollment
+          </Button>
+        )}
+        {!isEnrollment && !isLinkedBlock && (
+          <Button onClick={handleDelete} disabled={inFlight} variant="destructive">
+            Delete block
+          </Button>
+        )}
+        {isLinkedBlock && (
+          <p className="text-xs text-muted-foreground">
+            This block was created by your enrollment. Cancel the enrollment to remove it.
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+(Verify `@/components/ui/popover` exists; if not, run `npx shadcn@latest add popover` from `frontend/`. Most shadcn projects include it; check `frontend/src/components/ui/` first.)
+
+- [ ] **Step 4: Re-run; confirm PASS**
+
+```bash
+npm run test -- CalendarEventPopover
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 42 passed (38 + 4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/components/calendar/CalendarEventPopover.tsx frontend/src/components/calendar/CalendarEventPopover.test.tsx
+git commit -m "feat(frontend): CalendarEventPopover with cancel/delete actions
+
+Click an enrollment → Cancel enrollment; click a standalone
+unavailability block → Delete block; click an enrollment-linked
+block → no destructive action, helper text directs to cancel the
+enrollment instead. Inline ErrorBanner on mutation failure."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 7 — Route wiring + KidTabs entry
+
+**Files:**
+- Create: `frontend/src/routes/kids.$id.calendar.tsx`
+- Modify: `frontend/src/components/layout/KidTabs.tsx`
+
+End state: `/kids/$id/calendar` renders. KidTabs has a Calendar tab.
+
+- [ ] **Step 1: Add the Calendar tab to KidTabs**
+
+In `frontend/src/components/layout/KidTabs.tsx`, extend the `tabs` array:
+
+```ts
+const tabs = [
+  { to: '/kids/$id/matches', label: 'Matches' },
+  { to: '/kids/$id/watchlist', label: 'Watchlist' },
+  { to: '/kids/$id/calendar', label: 'Calendar' },
+] as const;
+```
+
+- [ ] **Step 2: Implement the route**
+
+Create `frontend/src/routes/kids.$id.calendar.tsx`:
+
+```tsx
+import { useState, useMemo } from 'react';
+import { createFileRoute } from '@tanstack/react-router';
+import { startOfWeek, addDays, startOfMonth, endOfMonth, format } from 'date-fns';
+import type { View } from 'react-big-calendar';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorBanner } from '@/components/common/ErrorBanner';
+import { useKid, useKidCalendar } from '@/lib/queries';
+import { KidTabs } from '@/components/layout/KidTabs';
+import { CalendarView } from '@/components/calendar/CalendarView';
+import { CalendarEventPopover } from '@/components/calendar/CalendarEventPopover';
+import type { CalendarEvent } from '@/lib/types';
+
+export const Route = createFileRoute('/kids/$id/calendar')({ component: KidCalendarPage });
+
+const BUFFER_DAYS = 3;
+
+function rangeFor(view: View, cursor: Date): { from: string; to: string } {
+  if (view === 'month') {
+    const monthStart = startOfMonth(cursor);
+    const monthEnd = endOfMonth(cursor);
+    const weekStart = startOfWeek(monthStart, { weekStartsOn: 0 });
+    return {
+      from: format(addDays(weekStart, -BUFFER_DAYS), 'yyyy-MM-dd'),
+      to: format(addDays(monthEnd, 7 + BUFFER_DAYS), 'yyyy-MM-dd'),
+    };
+  }
+  // week
+  const weekStart = startOfWeek(cursor, { weekStartsOn: 0 });
+  return {
+    from: format(addDays(weekStart, -BUFFER_DAYS), 'yyyy-MM-dd'),
+    to: format(addDays(weekStart, 7 + BUFFER_DAYS), 'yyyy-MM-dd'),
+  };
+}
+
+function KidCalendarPage() {
+  const { id } = Route.useParams();
+  const kidId = Number(id);
+  const kid = useKid(kidId);
+
+  const [view, setView] = useState<View>('week');
+  const [cursor, setCursor] = useState<Date>(new Date());
+  const { from, to } = useMemo(() => rangeFor(view, cursor), [view, cursor]);
+
+  const calendar = useKidCalendar({ kidId, from, to });
+  const [selected, setSelected] = useState<CalendarEvent | null>(null);
+
+  if (kid.isLoading) return <Skeleton className="h-32 w-full" />;
+  if (kid.isError) {
+    return <ErrorBanner message={(kid.error as Error).message} onRetry={() => kid.refetch()} />;
+  }
+  if (!kid.data) return null;
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-2">{kid.data.name}'s calendar</h1>
+      <KidTabs kidId={kidId} />
+      {calendar.isError && (
+        <ErrorBanner
+          message={(calendar.error as Error).message}
+          onRetry={() => calendar.refetch()}
+        />
+      )}
+      <CalendarView
+        events={calendar.data?.events ?? []}
+        view={view}
+        onView={setView}
+        date={cursor}
+        onNavigate={setCursor}
+        onSelectEvent={setSelected}
+      />
+      <CalendarEventPopover
+        kidId={kidId}
+        event={selected}
+        open={selected !== null}
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  );
+}
+```
+
+Note on `routeTree.gen.ts`: TanStack Router's plugin regenerates this file when the dev server runs or via `npm run build`. Check `frontend/vite.config.ts` for the `tanstackRouterVite` plugin — it generates the route tree automatically. After creating the file, run `npm run build` once to trigger regeneration if not running the dev server.
+
+- [ ] **Step 3: Run frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: still 42 passed (no new tests, but typecheck must succeed against the new route — including its codegen).
+
+If typecheck fails complaining about `'/kids/$id/calendar'` not being a known route, regenerate manually:
+
+```bash
+npm run build  # triggers TanStack Router codegen
+# then re-run typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/routes/kids.\$id.calendar.tsx frontend/src/routeTree.gen.ts frontend/src/components/layout/KidTabs.tsx
+git commit -m "feat(frontend): /kids/\$id/calendar route + KidTabs entry
+
+Route owns view (week/month) and cursor date as local state, derives
+from/to with a small lookback buffer, and feeds CalendarView +
+CalendarEventPopover. KidTabs gains the Calendar tab."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 8 — Final exit gates + manual smoke + push + PR
+
+End state: All exit criteria from spec §8 verified. Branch ready to merge.
+
+- [ ] **Step 1: Backend gates**
+
+```bash
+uv run pytest -q --no-cov && uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: 560 passed; lint/format/type clean.
+
+- [ ] **Step 2: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 42 passed; typecheck and lint clean.
+
+- [ ] **Step 3: Manual smoke**
+
+Backend in one terminal:
+
+```bash
+uv run uvicorn yas.web.app:app --reload --port 8000
+```
+
+Frontend in another:
+
+```bash
+cd frontend && npm run dev
+```
+
+Open `http://localhost:5173/kids/1/calendar` (substitute a real kid id from your local DB; create one via the UI if needed). Walk through:
+
+1. The week grid renders, 6am–10pm.
+2. If the kid has an active enrollment, an event appears on the right weekdays at the right time.
+3. Click an enrollment event → popover with details + Cancel enrollment.
+4. Click Cancel enrollment → row vanishes optimistically and popover closes. Refresh: still gone (server confirmed).
+5. Toggle view (top-right) to month → events shift to month layout.
+6. Navigate forward a month → new events load.
+7. If the kid has a school block, click it → Delete block button. Don't actually click it unless you mean to.
+8. If an enrollment-linked block exists (created by an active enrollment), click it → no Delete button; helper text shown.
+
+If any step breaks, capture the failure in a regression test before fixing.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git push -u origin phase-5c-1-kid-calendar
+gh pr create --title "phase 5c-1: per-kid calendar view (week + month)" --body "$(cat <<'EOF'
+## Summary
+- New backend endpoint GET /api/kids/{kid_id}/calendar?from=&to= aggregating enrollment + unavailability occurrences within a half-open date window
+- New pure-function expand_recurring helper at src/yas/calendar/occurrences.py
+- Frontend /kids/$id/calendar route with week + month toggle, fixed 6am–10pm time range, click-to-popover affordance
+- Two new mutations following the canonical 5b-1b pattern: useCancelEnrollment + useDeleteUnavailability
+- New dep: react-big-calendar (~25KB), exact-pinned
+
+Satisfies the v1 terminal-state criterion: "calendar page renders a week view containing offerings, enrollments, and unavailability for a single kid within 1s on a realistic dataset."
+
+## Test plan
+- [x] uv run pytest -q (560 passed; +9 unit + +8 integration)
+- [x] uv run ruff check . && uv run ruff format --check . clean
+- [x] uv run mypy src clean
+- [x] cd frontend && npm run typecheck clean
+- [x] cd frontend && npm run lint clean
+- [x] cd frontend && npm run test (42 passed; +11 new across mutations + CalendarView + CalendarEventPopover)
+- [x] Manual smoke: enrollment cancel → row vanishes optimistically; month toggle works; enrollment-linked block can't be deleted from popover
+- [ ] CI passes
+
+## Spec / plan
+- Spec: docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md
+- Plan: docs/superpowers/plans/2026-04-29-phase-5c-1-kid-calendar.md
+
+## Out of scope (deferred)
+- Match overlay + click-to-enroll (5c-2)
+- Multi-kid combined view
+- Drag-and-drop reschedule, ICS export, edit-in-place
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for CI; merge with `--squash`** (project convention).
+
+---
+
+## Notes for the implementer
+
+- **The 5b-1b mutation pattern is canonical.** Both new mutations in Task 4 follow the same shape: `cancelQueries` → snapshot → optimistic `setQueryData` → `onError` restore → awaited `onSettled` invalidate. Don't reinvent.
+- **react-big-calendar's CSS bleeds into the page**. The override file in Task 5 Step 5 is intentionally minimal. If something visually looks wrong during manual smoke, add only the targeted overrides needed — don't rewrite the library's stylesheet.
+- **TanStack Router codegen** can lag during dev. If the typecheck fails after creating the route, run `npm run build` once to regenerate `routeTree.gen.ts`.
+- **Boundary semantics matter** (spec §2.1 callout). The request window is half-open (`[from, to)`); source-row `date_start`/`date_end` are closed (both endpoints inclusive). The `expand_recurring` helper handles the conversion in one place — don't duplicate the math at call sites.
+- **`api.delete` 204 handling** in Task 4 Step 4 — verify the existing `request<T>()` doesn't blow up on an empty body. If it does, add a `if (r.status === 204) return undefined as T;` guard.
+- **No new backend deps**. Frontend gets exactly one new dep: `react-big-calendar` (and `@types/react-big-calendar` as devDep).

--- a/docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md
+++ b/docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md
@@ -40,6 +40,12 @@ This is the v1 terminal-state criterion's calendar deliverable, scoped narrowly:
 
 `GET /api/kids/{kid_id}/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD`
 
+**Boundary semantics, in one place:**
+- The request window `[from, to)` is **half-open** (inclusive `from`, exclusive `to`) — matches the existing `/api/inbox/summary` convention.
+- Enrollments included: only those with `status == 'enrolled'`. `interested`, `waitlisted`, and `cancelled` are excluded. (If a future slice needs to render waitlisted enrollments differently, add a `?include_statuses=` query param then.)
+- Unavailability included: `active == true` and the block's `[date_start, date_end]` (closed interval, both inclusive when present) overlaps `[from, to)`.
+- Source-row date bounds (`offering.start_date`/`end_date`, `block.date_start`/`date_end`) are **closed** intervals (both endpoints inclusive when set). The request window is **half-open**. The expansion helper's docstring is the source of truth.
+
 **Path params:**
 - `kid_id` (int) — must exist and belong to the household. 404 if not found.
 
@@ -117,10 +123,10 @@ def expand_recurring(
     days_of_week: list[str],   # e.g. ["mon", "wed", "fri"]
     time_start: time | None,
     time_end: time | None,
-    date_start: date | None,    # inclusive lower bound (None = unbounded)
-    date_end: date | None,      # inclusive upper bound (None = unbounded)
-    range_from: date,           # inclusive
-    range_to: date,             # exclusive
+    date_start: date | None,    # inclusive lower bound on the source row (None = unbounded)
+    date_end: date | None,      # inclusive upper bound on the source row (None = unbounded)
+    range_from: date,           # inclusive lower bound of the request window
+    range_to: date,             # exclusive upper bound of the request window
 ) -> Iterator[OccurrenceTuple]:
     """Yield (date, time_start, time_end, all_day) tuples for each
     weekday in `days_of_week` falling within the intersection of

--- a/docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md
+++ b/docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md
@@ -1,0 +1,284 @@
+# Phase 5c-1 — Per-kid Calendar View (Design)
+
+**Status:** Approved (brainstorming complete 2026-04-29).
+**Predecessor:** Phase 5b-1b (`docs/superpowers/specs/2026-04-29-phase-5b-1b-alert-close-frontend-design.md`) — established the canonical TanStack Query mutation pattern with optimistic updates and rollback. This slice copies that pattern.
+**Master design:** `docs/superpowers/specs/2026-04-21-youth-activity-scheduler-design.md` §10 — the v1 terminal-state criterion explicitly calls out: *"Calendar page renders a week view containing offerings, enrollments, and unavailability for a single kid within 1s on a realistic dataset."*
+**Succeeds into:** Phase 5c-2 (calendar with match overlay + click-to-enroll), and eventually multi-kid combined view. Both are out of scope here.
+
+## 1. Purpose and scope
+
+Add a per-kid calendar view that renders the kid's enrollments and unavailability blocks on either a week or month grid. Click an event → popover with details + a single mutation action (cancel enrollment, delete unavailability block). One new aggregated backend endpoint feeds the calendar; mutations reuse existing routes.
+
+This is the v1 terminal-state criterion's calendar deliverable, scoped narrowly: *enrolled* offerings (not all matches), *single kid* (not multi-kid overlay), week + month views with toggle. Match overlay and click-to-enroll are deferred to 5c-2 to keep this slice reviewable.
+
+### 1.1 In scope
+
+- **Backend endpoint** `GET /api/kids/{kid_id}/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD` returning a flat list of dated occurrences (enrollments and unavailability blocks) for the date range.
+- **Server-side recurring expansion**: a new pure-function helper `src/yas/calendar/occurrences.py` expands recurring patterns (`days_of_week + time_start/end + date_start/end`) into concrete date occurrences within `[from, to)`. The codebase has no existing expansion utility — matching code only checks `days_of_week` for set membership.
+- **Frontend route** `/kids/$id/calendar` using TanStack Router, fed by a new `useKidCalendar({ kidId, from, to })` query hook.
+- **`CalendarView` component** wrapping `react-big-calendar` (~25 KB) with project-specific defaults: `react-big-calendar` is the new dep; no other libraries added.
+- **Week + month views** with a controlled toggle. Default: week. Time range on week: 6:00–22:00.
+- **Event popover** with details + a single action button. Read-only popover for unavailability sourced from a still-active enrollment (the action there belongs on the enrollment popover, not the linked block).
+- **Two new mutation hooks** in `frontend/src/lib/mutations.ts`: `useCancelEnrollment`, `useDeleteUnavailability`. Both follow the canonical 5b-1b optimistic + rollback pattern.
+- **Tests** at three levels: pure-function expansion tests, integration tests for the new endpoint, frontend tests for the calendar component and mutations.
+
+### 1.2 Out of scope
+
+- **Match overlay** (rendering offerings the kid scored well on but isn't enrolled in). Deferred to 5c-2.
+- **Click-to-enroll from calendar.** Same — 5c-2.
+- **Multi-kid combined view.** Deferred.
+- **Drag-and-drop reschedule.** Out of scope; not a v1 terminal criterion.
+- **ICS export / import.** Master design §1 lists this as v1 out of scope.
+- **Holiday calendar integration.** A school unavailability block today renders every weekday in its date range; spring break is a separate `manual`/`custom` block. A real holiday-aware school calendar is a future slice.
+- **Edit-in-place from the popover.** Popover is read + cancel/delete only. Full edit lives elsewhere.
+- **Dynamic time-range clamp** on the week grid. Hard-coded 6:00–22:00 in v1; lift if a real event ever falls outside.
+- **Pagination / infinite scroll.** Calendar always queries a finite `[from, to)` range derived from the visible view.
+
+## 2. API
+
+### 2.1 New endpoint
+
+`GET /api/kids/{kid_id}/calendar?from=YYYY-MM-DD&to=YYYY-MM-DD`
+
+**Path params:**
+- `kid_id` (int) — must exist and belong to the household. 404 if not found.
+
+**Query params:**
+- `from` (date, required, inclusive) — start of the date range.
+- `to` (date, required, exclusive) — end of the date range.
+- 422 if `from >= to`.
+- 422 if the range is unreasonably large (cap at 90 days, returns 422 with explanation; the frontend never requests more than ~6 weeks).
+
+**Response shape:**
+
+```json
+{
+  "kid_id": 1,
+  "from": "2026-04-27",
+  "to": "2026-05-04",
+  "events": [
+    {
+      "id": "enrollment:42:2026-04-29",
+      "kind": "enrollment",
+      "date": "2026-04-29",
+      "time_start": "16:00:00",
+      "time_end": "17:00:00",
+      "all_day": false,
+      "title": "Lil Sluggers T-Ball",
+      "enrollment_id": 42,
+      "offering_id": 7,
+      "location_id": 3,
+      "status": "enrolled"
+    },
+    {
+      "id": "unavailability:11:2026-04-29",
+      "kind": "unavailability",
+      "date": "2026-04-29",
+      "time_start": "08:30:00",
+      "time_end": "15:00:00",
+      "all_day": false,
+      "title": "School",
+      "block_id": 11,
+      "source": "school",
+      "from_enrollment_id": null
+    }
+  ]
+}
+```
+
+**Event id:** Composite `kind:source-row-id:date` so react-big-calendar's per-event keys are stable across renders, and so the popover handler can resolve back to the source row + date.
+
+**all_day flag:** Set when `time_start IS NULL` and `time_end IS NULL` on the source row.
+
+**from_enrollment_id:** Populated for unavailability blocks whose `source_enrollment_id` is set. The popover uses this to suppress the "Delete block" action on those blocks (the user should cancel the enrollment instead).
+
+### 2.2 Existing endpoints used
+
+- `PATCH /api/enrollments/{id}` with `{ status: "cancelled" }` — already exists, used by `useCancelEnrollment`.
+- `DELETE /api/unavailability/{id}` — already exists, used by `useDeleteUnavailability`.
+
+No backend mutation work in this slice beyond the new GET endpoint.
+
+## 3. Server-side recurring expansion
+
+The codebase has no existing recurring-expansion helper. New module:
+
+```
+src/yas/calendar/
+  __init__.py
+  occurrences.py        # pure functions, no DB
+```
+
+**Public surface:**
+
+```python
+def expand_recurring(
+    *,
+    days_of_week: list[str],   # e.g. ["mon", "wed", "fri"]
+    time_start: time | None,
+    time_end: time | None,
+    date_start: date | None,    # inclusive lower bound (None = unbounded)
+    date_end: date | None,      # inclusive upper bound (None = unbounded)
+    range_from: date,           # inclusive
+    range_to: date,             # exclusive
+) -> Iterator[OccurrenceTuple]:
+    """Yield (date, time_start, time_end, all_day) tuples for each
+    weekday in `days_of_week` falling within the intersection of
+    [range_from, range_to) and [date_start, date_end].
+
+    Treats `time_start`/`time_end` both being None as an all-day event.
+    """
+```
+
+The route handler calls `expand_recurring` once per source row (enrollment's joined offering + each active unavailability block) and tags the resulting occurrences with the right kind/ids.
+
+The expansion is a pure function over date arithmetic — easy to unit-test exhaustively without a database.
+
+## 4. Frontend
+
+### 4.1 Dependency
+
+Add `react-big-calendar` (exact patch pin in `frontend/package.json`). The library ships its own CSS (`react-big-calendar/lib/css/react-big-calendar.css`) — imported once at the route level so the bundle is tree-shakable for non-calendar pages.
+
+`react-big-calendar`'s `dateFnsLocalizer` reuses our existing `date-fns` dep — no second date library.
+
+### 4.2 Route
+
+```
+frontend/src/routes/kids.$id.calendar.tsx
+```
+
+Renders:
+- A heading with the kid's name.
+- A week/month toggle (controlled).
+- A back/forward navigation pair.
+- The `<CalendarView>`.
+
+Uses the existing `useKid(id)` query for the kid name; uses a new `useKidCalendar({ kidId, from, to })` for events.
+
+### 4.3 Components
+
+Create:
+- `frontend/src/components/calendar/CalendarView.tsx` — wraps `<Calendar>` from `react-big-calendar`. Accepts events, view, cursorDate, onView, onNavigate, onSelectEvent. Adds the project-specific event class names (enrollment vs unavailability) via `eventPropGetter`.
+- `frontend/src/components/calendar/CalendarEventPopover.tsx` — renders details + action button. Inline `<ErrorBanner>` on mutation error. Closes itself on successful mutation.
+
+The popover anchors via Radix's `Popover.Trigger` wrapped around react-big-calendar's event element. Selection state lives in the route (`selected: CalendarEvent | null`) to keep the popover controlled and testable.
+
+### 4.4 Query hook
+
+`frontend/src/lib/queries.ts` gains:
+
+```ts
+export function useKidCalendar({
+  kidId,
+  from,
+  to,
+}: {
+  kidId: number;
+  from: string;  // YYYY-MM-DD
+  to: string;
+}) {
+  return useQuery({
+    queryKey: ['kids', kidId, 'calendar', from, to],
+    queryFn: () =>
+      api.get<KidCalendarResponse>(
+        `/api/kids/${kidId}/calendar?from=${from}&to=${to}`,
+      ),
+    enabled: Number.isFinite(kidId),
+  });
+}
+```
+
+Cache key prefix `['kids', kidId, 'calendar']` is what mutations invalidate — see §4.6.
+
+### 4.5 Visible date range
+
+The route computes `from`/`to` from the calendar's controlled `view + cursorDate`:
+- Week view: `from = startOfWeek(cursor)`; `to = startOfWeek(cursor) + 7d`.
+- Month view: `from = startOfMonth(cursor) - <leading days>`; `to = endOfMonth(cursor) + <trailing days>`. (Includes the surrounding partial weeks the month grid renders.)
+
+A small lookback buffer (3 days each side) is added so navigating one cell doesn't always trigger a refetch. The cache key tracks the actual `from`/`to`, so adjacent ranges are independently cached.
+
+### 4.6 Mutations
+
+`frontend/src/lib/mutations.ts` extended with two hooks. Both follow the canonical 5b-1b shape: `onMutate` cancels in-flight queries, snapshots all matching caches, applies optimistic update; `onError` restores from snapshots; `onSettled` awaits invalidation.
+
+```ts
+export function useCancelEnrollment() { /* PATCH /api/enrollments/{id} { status: 'cancelled' } */ }
+export function useDeleteUnavailability() { /* DELETE /api/unavailability/{id} */ }
+```
+
+**Optimistic surgery details:**
+- `useCancelEnrollment`: removes from cached calendar all events whose `kind == 'enrollment' && enrollment_id == X`. Also removes any unavailability events with `from_enrollment_id == X` (the backend cancels the linked block; we mirror it in the cache so the UI doesn't briefly show a now-orphaned block).
+- `useDeleteUnavailability`: removes events where `kind == 'unavailability' && block_id == X`.
+- Both invalidate the prefix `['kids', kidId, 'calendar']`. The mutation's input includes `kidId` so the snapshot loop can be precise (no need to walk every kid's cache).
+
+### 4.7 Time range and styling
+
+- Week view: `min={6:00}`, `max={22:00}`. Hard-coded.
+- Enrollment events: `bg-primary text-primary-foreground` (or theme equivalent).
+- Unavailability events: `bg-muted text-muted-foreground`.
+- All-day events render in react-big-calendar's all-day strip on the week view, and span the cell in the month view (library default).
+- Overlapping events at the same time render side-by-side in week view (library default).
+- The library's CSS is imported at the route level; we override the few classes that conflict with our Tailwind v4 theme via a small CSS module or `@layer` block in `globals.css`. (TBD during implementation; spec leaves the exact override list for the plan.)
+
+## 5. Edge cases
+
+- **Cancelled enrollment between fetch and click.** Mutation returns 404; rollback restores; banner shows. User refreshes.
+- **Unavailability block tied to a still-active enrollment.** Popover suppresses the "Delete block" action and shows a hint: *"This block was created by your '{title}' enrollment. Cancel the enrollment to remove it."*
+- **All-day event overlapping a timed event.** react-big-calendar handles natively (all-day strip + grid).
+- **Empty calendar (no enrollments, no unavailability).** Calendar grid renders normally with zero events. No empty-state copy needed; the grid itself is the empty state.
+- **Range > 90 days.** Backend returns 422; the frontend never requests more, so this is purely a backend defensive bound.
+- **Recurring offering whose `date_end < range_from` or `date_start >= range_to`.** Returns no occurrences; the expansion helper handles this without iteration.
+- **Block with `time_start IS NULL` and `time_end IS NOT NULL` (or vice versa).** Treated as malformed; expansion helper skips with a log warning. Existing data shouldn't have this shape (model allows it but UI never produces it).
+
+## 6. Testing
+
+Backend:
+1. `tests/unit/test_calendar_occurrences.py` — pure-function tests for `expand_recurring`. Cases: weekly recurring within range; date_start/date_end clipping; range clipping; all-day; empty `days_of_week`; range_from == range_to.
+2. `tests/integration/test_api_kids_calendar.py` — endpoint smoke + correctness:
+   - 404 for unknown kid_id.
+   - 422 for `from >= to` and for ranges > 90 days.
+   - Returns enrollment occurrences with correct `enrollment_id`, `offering_id`, `status: 'enrolled'`.
+   - Returns unavailability occurrences with `from_enrollment_id` populated for enrollment-linked blocks.
+   - Cancelled enrollments are excluded.
+   - Inactive blocks (`active=false`) are excluded.
+   - Other kids' events are excluded.
+   - Expansion correctness: a Mon/Wed/Fri offering in a Mon–Sun range returns exactly 3 occurrences with the correct dates and times.
+
+Frontend:
+3. `frontend/src/components/calendar/CalendarView.test.tsx` — events render; clicking an event opens the popover; week/month toggle reflects in the rendered grid (assert via library-rendered DOM).
+4. `frontend/src/components/calendar/CalendarEventPopover.test.tsx` — renders enrollment details with "Cancel enrollment" button; renders unavailability details; suppresses delete on enrollment-linked blocks.
+5. `frontend/src/lib/mutations.test.tsx` (extend) — `useCancelEnrollment` removes all enrollment + linked-block events optimistically; rolls back on 500. `useDeleteUnavailability` removes the matching block; rolls back.
+6. MSW handlers in `frontend/src/test/handlers.ts`: `GET /api/kids/:id/calendar`, `PATCH /api/enrollments/:id`, `DELETE /api/unavailability/:id`.
+
+Manual smoke (before merge):
+- Navigate to `/kids/1/calendar`; see week view with school block + an enrolled offering.
+- Click offering → popover with Cancel enrollment → click → row vanishes optimistically.
+- Toggle to month view → cursor next month → events present.
+- Click a school block (no `from_enrollment_id`) → Delete block; click → vanishes.
+- Click an enrollment-linked block → no Delete button; helper text shown.
+
+## 7. Open questions
+
+None blocking. All six brainstorming decisions are recorded in §1–§4:
+
+- **Q1** (events on calendar): enrollments + unavailability only. §1.1.
+- **Q2** (single vs multi-kid): single-kid only. §1.1, 1.2.
+- **Q3** (week vs month): both with toggle. §4.2, 4.3.
+- **Q4** (click behavior): popover with Cancel enrollment / Delete block actions. §4.3.
+- **Q5** (time range): fixed 6:00–22:00 in week view. §4.7.
+- **Q6** (library): `react-big-calendar`. §4.1.
+
+## 8. Exit criteria
+
+Phase 5c-1 is complete when:
+
+- The new endpoint is implemented, tested, and matches the response shape in §2.1.
+- `expand_recurring` is implemented and exhaustively unit-tested.
+- The frontend calendar route renders enrollments + unavailability for a kid; week and month toggle works; popover renders and dispatches the correct mutation.
+- `useCancelEnrollment` and `useDeleteUnavailability` follow the canonical 5b-1b pattern (optimistic + rollback + awaited invalidation).
+- All backend gates green (`pytest`, `ruff`, `mypy`).
+- All frontend gates green (`vitest`, `tsc --noEmit`, ESLint, format check).
+- Manual smoke: enrollment cancel → row vanishes; week/month toggle works; enrollment-linked block can't be deleted from the popover.
+- v1 terminal-state calendar criterion satisfied: *"calendar page renders a week view containing offerings, enrollments, and unavailability for a single kid within 1s on a realistic dataset."* (We satisfy "offerings" via enrollments — the offering data is denormalized into each enrollment occurrence's `title`/`offering_id`.)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@tanstack/react-query": "5.100.6",
         "@tanstack/react-router": "1.168.25",
+        "@types/react-big-calendar": "1.16.3",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "date-fns": "4.1.0",
         "lucide-react": "1.14.0",
         "radix-ui": "1.4.3",
         "react": "19.2.5",
+        "react-big-calendar": "1.19.4",
         "react-dom": "19.2.5",
         "tailwind-merge": "3.5.0",
         "tw-animate-css": "1.4.0"
@@ -315,7 +317,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -873,6 +874,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -2498,6 +2509,18 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -3556,6 +3579,12 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/date-arithmetic": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/date-arithmetic/-/date-arithmetic-4.1.4.tgz",
+      "integrity": "sha512-p9eZ2X9B80iKiTW4ukVj8B4K6q9/+xFtQ5MGYA5HWToY9nL4EkhV9+6ftT2VHpVMEZb5Tv00Iel516bVdO+yRw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3594,14 +3623,30 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-big-calendar": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-big-calendar/-/react-big-calendar-1.16.3.tgz",
+      "integrity": "sha512-CR+5BKMhlr/wPgsp+sXOeNKNkoU1h/+6H1XoWuL7xnurvzGRQv/EnM8jPS9yxxBvXI8pjQBaJcI7RTSGiewG/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/date-arithmetic": "*",
+        "@types/prop-types": "*",
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -3629,6 +3674,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -4458,7 +4509,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -4470,6 +4526,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4500,7 +4562,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4539,6 +4600,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
@@ -5005,6 +5076,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/globals": {
       "version": "17.5.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
@@ -5121,6 +5197,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5214,7 +5299,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -5577,6 +5661,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5594,6 +5702,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -5616,6 +5733,12 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -5641,6 +5764,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mrmime": {
@@ -5769,6 +5913,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6028,6 +6181,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6142,6 +6312,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.4.tgz",
+      "integrity": "sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-big-calendar/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
@@ -6161,6 +6368,32 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -6757,6 +6990,21 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -7087,6 +7335,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webpack-virtual-modules": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,12 +17,14 @@
   "dependencies": {
     "@tanstack/react-query": "5.100.6",
     "@tanstack/react-router": "1.168.25",
+    "@types/react-big-calendar": "1.16.3",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.1.0",
     "lucide-react": "1.14.0",
     "radix-ui": "1.4.3",
     "react": "19.2.5",
+    "react-big-calendar": "1.19.4",
     "react-dom": "19.2.5",
     "tailwind-merge": "3.5.0",
     "tw-animate-css": "1.4.0"

--- a/frontend/src/components/calendar/CalendarEventPopover.test.tsx
+++ b/frontend/src/components/calendar/CalendarEventPopover.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CalendarEventPopover } from './CalendarEventPopover';
+import type { CalendarEvent } from '@/lib/types';
+
+const enrollment: CalendarEvent = {
+  id: 'enrollment:42:2026-04-29',
+  kind: 'enrollment',
+  date: '2026-04-29',
+  time_start: '16:00:00',
+  time_end: '17:00:00',
+  all_day: false,
+  title: 'T-Ball',
+  enrollment_id: 42,
+  offering_id: 7,
+  status: 'enrolled',
+};
+
+const enrollmentLinkedBlock: CalendarEvent = {
+  id: 'unavailability:21:2026-04-29',
+  kind: 'unavailability',
+  date: '2026-04-29',
+  time_start: '16:00:00',
+  time_end: '17:00:00',
+  all_day: false,
+  title: 'T-Ball',
+  block_id: 21,
+  source: 'enrollment',
+  from_enrollment_id: 42,
+};
+
+const standaloneBlock: CalendarEvent = {
+  id: 'unavailability:20:2026-04-29',
+  kind: 'unavailability',
+  date: '2026-04-29',
+  time_start: '08:30:00',
+  time_end: '15:00:00',
+  all_day: false,
+  title: 'School',
+  block_id: 20,
+  source: 'school',
+  from_enrollment_id: null,
+};
+
+function renderPopover(event: CalendarEvent | null, onClose = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <CalendarEventPopover kidId={1} event={event} open={event !== null} onClose={onClose} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CalendarEventPopover', () => {
+  it('renders enrollment details + Cancel enrollment button', () => {
+    renderPopover(enrollment);
+    expect(screen.getByText(/T-Ball/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel enrollment/i })).toBeInTheDocument();
+  });
+
+  it('renders standalone block details + Delete block button', () => {
+    renderPopover(standaloneBlock);
+    expect(screen.getByText(/School/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete block/i })).toBeInTheDocument();
+  });
+
+  it('suppresses Delete on enrollment-linked blocks and shows hint', () => {
+    renderPopover(enrollmentLinkedBlock);
+    expect(screen.queryByRole('button', { name: /delete block/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/cancel the enrollment/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose after a successful Cancel enrollment', async () => {
+    const onClose = vi.fn();
+    renderPopover(enrollment, onClose);
+    await userEvent.click(screen.getByRole('button', { name: /cancel enrollment/i }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/calendar/CalendarEventPopover.tsx
+++ b/frontend/src/components/calendar/CalendarEventPopover.tsx
@@ -1,0 +1,118 @@
+import { startTransition, useEffect, useState } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { ErrorBanner } from '@/components/common/ErrorBanner';
+import type { CalendarEvent } from '@/lib/types';
+import { useCancelEnrollment, useDeleteUnavailability } from '@/lib/mutations';
+
+export function CalendarEventPopover({
+  kidId,
+  event,
+  open,
+  onClose,
+}: {
+  kidId: number;
+  event: CalendarEvent | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const cancel = useCancelEnrollment();
+  const del = useDeleteUnavailability();
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const inFlight = cancel.isPending || del.isPending;
+
+  // Reset mutation + error state whenever the selected event changes.
+  // event.id is the only stable signal; mutation refs are recreated each render.
+  useEffect(() => {
+    startTransition(() => {
+      setErrorMsg(null);
+    });
+    cancel.reset();
+    del.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event?.id]);
+
+  const handleCancel = () => {
+    if (!event?.enrollment_id) return;
+    setErrorMsg(null);
+    cancel.mutate(
+      { kidId, enrollmentId: event.enrollment_id },
+      {
+        onSuccess: onClose,
+        onError: (err) => setErrorMsg(err.message || 'Failed to cancel enrollment'),
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    if (!event?.block_id) return;
+    setErrorMsg(null);
+    del.mutate(
+      { kidId, blockId: event.block_id },
+      {
+        onSuccess: onClose,
+        onError: (err) => setErrorMsg(err.message || 'Failed to delete block'),
+      },
+    );
+  };
+
+  const isEnrollment = event?.kind === 'enrollment';
+  const isLinkedBlock =
+    event?.kind === 'unavailability' && event.from_enrollment_id != null;
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(o) => {
+        // Suppress user-initiated dismiss while a mutation is in-flight.
+        if (inFlight && !o) return;
+        if (!o) onClose();
+      }}
+    >
+      <SheetContent>
+        {event && (
+          <>
+            <SheetHeader>
+              <SheetTitle>{event.title}</SheetTitle>
+              <SheetDescription>
+                {event.all_day
+                  ? 'All day'
+                  : `${event.time_start?.slice(0, 5)}–${event.time_end?.slice(0, 5)}`}
+              </SheetDescription>
+            </SheetHeader>
+
+            {errorMsg && (
+              <div className="mt-4">
+                <ErrorBanner message={errorMsg} />
+              </div>
+            )}
+
+            <div className="mt-6 flex gap-2">
+              {isEnrollment && (
+                <Button onClick={handleCancel} disabled={inFlight} variant="destructive">
+                  Cancel enrollment
+                </Button>
+              )}
+              {!isEnrollment && !isLinkedBlock && (
+                <Button onClick={handleDelete} disabled={inFlight} variant="destructive">
+                  Delete block
+                </Button>
+              )}
+              {isLinkedBlock && (
+                <p className="text-xs text-muted-foreground">
+                  This block was created by your enrollment. Cancel the enrollment to remove it.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/calendar/CalendarView.test.tsx
+++ b/frontend/src/components/calendar/CalendarView.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CalendarView } from './CalendarView';
+import type { CalendarEvent } from '@/lib/types';
+
+const events: CalendarEvent[] = [
+  {
+    id: 'enrollment:1:2026-04-29',
+    kind: 'enrollment',
+    date: '2026-04-29',
+    time_start: '16:00:00',
+    time_end: '17:00:00',
+    all_day: false,
+    title: 'T-Ball',
+    enrollment_id: 1,
+    offering_id: 7,
+    status: 'enrolled',
+  },
+];
+
+describe('CalendarView', () => {
+  it('renders an event title in the grid', () => {
+    render(
+      <CalendarView
+        events={events}
+        view="week"
+        onView={vi.fn()}
+        date={new Date('2026-04-29T12:00:00Z')}
+        onNavigate={vi.fn()}
+        onSelectEvent={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/T-Ball/i)).toBeInTheDocument();
+  });
+
+  it('calls onSelectEvent when an event is clicked', async () => {
+    const onSelectEvent = vi.fn();
+    render(
+      <CalendarView
+        events={events}
+        view="week"
+        onView={vi.fn()}
+        date={new Date('2026-04-29T12:00:00Z')}
+        onNavigate={vi.fn()}
+        onSelectEvent={onSelectEvent}
+      />,
+    );
+    await userEvent.click(screen.getByText(/T-Ball/i));
+    expect(onSelectEvent).toHaveBeenCalledTimes(1);
+    expect((onSelectEvent.mock.calls[0] as [CalendarEvent])[0].id).toBe('enrollment:1:2026-04-29');
+  });
+
+  it('renders the same events in month view', () => {
+    render(
+      <CalendarView
+        events={events}
+        view="month"
+        onView={vi.fn()}
+        date={new Date('2026-04-29T12:00:00Z')}
+        onNavigate={vi.fn()}
+        onSelectEvent={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/T-Ball/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,81 @@
+import { Calendar, dateFnsLocalizer, Views, type View } from 'react-big-calendar';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import { enUS } from 'date-fns/locale';
+import type { CalendarEvent } from '@/lib/types';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import './calendar-overrides.css';
+
+const locales = { 'en-US': enUS };
+const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+
+interface RbcEvent {
+  title: string;
+  start: Date;
+  end: Date;
+  allDay: boolean;
+  resource: CalendarEvent;
+}
+
+function parseDateParts(dateStr: string): [number, number, number] {
+  const parts = dateStr.split('-').map(Number);
+  return [parts[0] ?? 0, parts[1] ?? 1, parts[2] ?? 1];
+}
+
+function parseTimeParts(timeStr: string): [number, number] {
+  const parts = timeStr.split(':').map(Number);
+  return [parts[0] ?? 0, parts[1] ?? 0];
+}
+
+function toRbc(e: CalendarEvent): RbcEvent {
+  const [y, m, d] = parseDateParts(e.date);
+  if (e.all_day) {
+    const start = new Date(y, m - 1, d, 0, 0, 0);
+    const end = new Date(y, m - 1, d + 1, 0, 0, 0);
+    return { title: e.title, start, end, allDay: true, resource: e };
+  }
+  const [sh, sm] = parseTimeParts(e.time_start ?? '00:00:00');
+  const [eh, em] = parseTimeParts(e.time_end ?? '23:59:59');
+  const start = new Date(y, m - 1, d, sh, sm, 0);
+  const end = new Date(y, m - 1, d, eh, em, 0);
+  return { title: e.title, start, end, allDay: false, resource: e };
+}
+
+export function CalendarView({
+  events,
+  view,
+  onView,
+  date,
+  onNavigate,
+  onSelectEvent,
+}: {
+  events: CalendarEvent[];
+  view: View;
+  onView: (v: View) => void;
+  date: Date;
+  onNavigate: (d: Date) => void;
+  onSelectEvent: (e: CalendarEvent) => void;
+}) {
+  const rbcEvents = events.map(toRbc);
+  return (
+    <div className="h-[70vh]">
+      <Calendar
+        localizer={localizer}
+        events={rbcEvents}
+        views={[Views.WEEK, Views.MONTH]}
+        view={view}
+        onView={onView}
+        date={date}
+        onNavigate={onNavigate}
+        min={new Date(0, 0, 0, 6, 0, 0)}
+        max={new Date(0, 0, 0, 22, 0, 0)}
+        onSelectEvent={(rbc) => onSelectEvent((rbc as RbcEvent).resource)}
+        eventPropGetter={(rbc) => ({
+          className:
+            (rbc as RbcEvent).resource.kind === 'enrollment'
+              ? 'rbc-event-enrollment'
+              : 'rbc-event-unavailability',
+        })}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/calendar/calendar-overrides.css
+++ b/frontend/src/components/calendar/calendar-overrides.css
@@ -1,0 +1,26 @@
+/* Minimal Tailwind-friendly overrides for react-big-calendar's base styles. */
+
+.rbc-event-enrollment {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border: none;
+}
+
+.rbc-event-unavailability {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  border: none;
+}
+
+.rbc-today {
+  background-color: hsl(var(--accent));
+}
+
+.rbc-toolbar button {
+  color: hsl(var(--foreground));
+}
+
+.rbc-toolbar button.rbc-active {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}

--- a/frontend/src/components/layout/KidTabs.tsx
+++ b/frontend/src/components/layout/KidTabs.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 const tabs = [
   { to: '/kids/$id/matches', label: 'Matches' },
   { to: '/kids/$id/watchlist', label: 'Watchlist' },
+  { to: '/kids/$id/calendar', label: 'Calendar' },
 ] as const;
 
 export function KidTabs({ kidId }: { kidId: number }) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,6 +18,9 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     }
     throw new ApiError(r.status, body);
   }
+  if (r.status === 204) {
+    return undefined as T;
+  }
   return r.json() as Promise<T>;
 }
 
@@ -30,5 +33,14 @@ export const api = {
       method: 'POST',
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
+  },
+  patch<T>(path: string, body?: unknown) {
+    return request<T>(path, {
+      method: 'PATCH',
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  },
+  delete<T = void>(path: string) {
+    return request<T>(path, { method: 'DELETE' });
   },
 };

--- a/frontend/src/lib/mutations.test.tsx
+++ b/frontend/src/lib/mutations.test.tsx
@@ -3,8 +3,8 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/server';
-import { useCloseAlert, useReopenAlert } from './mutations';
-import type { InboxSummary } from './types';
+import { useCloseAlert, useReopenAlert, useCancelEnrollment, useDeleteUnavailability } from './mutations';
+import type { InboxSummary, KidCalendarResponse } from './types';
 
 function makeWrapper(qc: QueryClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -109,5 +109,180 @@ describe('useReopenAlert', () => {
     const reopened = after!.alerts[0]!;
     expect(reopened.closed_at).toBeNull();
     expect(reopened.close_reason).toBeNull();
+  });
+});
+
+const seedCal = (events: KidCalendarResponse['events']): KidCalendarResponse => ({
+  kid_id: 1,
+  from: '2026-04-27',
+  to: '2026-05-04',
+  events,
+});
+
+describe('useCancelEnrollment', () => {
+  it('removes all enrollment occurrences and linked-block occurrences for that enrollment', async () => {
+    const qc = new QueryClient();
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04'],
+      seedCal([
+        {
+          id: 'enrollment:42:2026-04-28',
+          kind: 'enrollment',
+          date: '2026-04-28',
+          time_start: '16:00:00',
+          time_end: '17:00:00',
+          all_day: false,
+          title: 'T-Ball',
+          enrollment_id: 42,
+          offering_id: 7,
+          status: 'enrolled',
+        },
+        {
+          id: 'unavailability:21:2026-04-28',
+          kind: 'unavailability',
+          date: '2026-04-28',
+          time_start: '16:00:00',
+          time_end: '17:00:00',
+          all_day: false,
+          title: 'T-Ball',
+          block_id: 21,
+          source: 'enrollment',
+          from_enrollment_id: 42,
+        },
+        {
+          id: 'unavailability:20:2026-04-28',
+          kind: 'unavailability',
+          date: '2026-04-28',
+          time_start: '08:30:00',
+          time_end: '15:00:00',
+          all_day: false,
+          title: 'School',
+          block_id: 20,
+          source: 'school',
+          from_enrollment_id: null,
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useCancelEnrollment(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current.mutateAsync({ kidId: 1, enrollmentId: 42 });
+    });
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toHaveLength(1);
+    expect(after!.events[0]!.block_id).toBe(20);
+  });
+
+  it('rolls back on server error', async () => {
+    server.use(
+      http.patch('/api/enrollments/:id', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+    );
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const original = seedCal([
+      {
+        id: 'enrollment:42:2026-04-28',
+        kind: 'enrollment',
+        date: '2026-04-28',
+        time_start: '16:00:00',
+        time_end: '17:00:00',
+        all_day: false,
+        title: 'T-Ball',
+        enrollment_id: 42,
+        offering_id: 7,
+        status: 'enrolled',
+      },
+    ]);
+    qc.setQueryData(['kids', 1, 'calendar', '2026-04-27', '2026-05-04'], original);
+
+    const { result } = renderHook(() => useCancelEnrollment(), { wrapper: makeWrapper(qc) });
+    await act(async () => {
+      await result.current
+        .mutateAsync({ kidId: 1, enrollmentId: 42 })
+        .catch(() => {});
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toHaveLength(1);
+    expect(after!.events[0]!.enrollment_id).toBe(42);
+  });
+});
+
+describe('useDeleteUnavailability', () => {
+  it('removes the matching unavailability event from cache', async () => {
+    const qc = new QueryClient();
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04'],
+      seedCal([
+        {
+          id: 'unavailability:20:2026-04-28',
+          kind: 'unavailability',
+          date: '2026-04-28',
+          time_start: '08:30:00',
+          time_end: '15:00:00',
+          all_day: false,
+          title: 'School',
+          block_id: 20,
+          source: 'school',
+          from_enrollment_id: null,
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useDeleteUnavailability(), {
+      wrapper: makeWrapper(qc),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ kidId: 1, blockId: 20 });
+    });
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toEqual([]);
+  });
+
+  it('rolls back on server error', async () => {
+    server.use(
+      http.delete('/api/unavailability/:id', () =>
+        HttpResponse.json({ detail: 'boom' }, { status: 500 }),
+      ),
+    );
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const original = seedCal([
+      {
+        id: 'unavailability:20:2026-04-28',
+        kind: 'unavailability',
+        date: '2026-04-28',
+        time_start: '08:30:00',
+        time_end: '15:00:00',
+        all_day: false,
+        title: 'School',
+        block_id: 20,
+        source: 'school',
+        from_enrollment_id: null,
+      },
+    ]);
+    qc.setQueryData(['kids', 1, 'calendar', '2026-04-27', '2026-05-04'], original);
+
+    const { result } = renderHook(() => useDeleteUnavailability(), {
+      wrapper: makeWrapper(qc),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ kidId: 1, blockId: 20 }).catch(() => {});
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04',
+    ]);
+    expect(after?.events).toHaveLength(1);
   });
 });

--- a/frontend/src/lib/mutations.ts
+++ b/frontend/src/lib/mutations.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { api } from './api';
-import type { CloseReason, InboxAlert, InboxSummary } from './types';
+import type { CloseReason, InboxAlert, InboxSummary, KidCalendarResponse } from './types';
 
 const keyIncludesClosed = (key: QueryKey): boolean =>
   key.length >= 4 && key[3] === 'with-closed';
@@ -71,6 +71,85 @@ export function useReopenAlert() {
 
     onSettled: async () => {
       await qc.invalidateQueries({ queryKey: ['inbox', 'summary'] });
+    },
+  });
+}
+
+interface CancelEnrollmentInput {
+  kidId: number;
+  enrollmentId: number;
+}
+
+export function useCancelEnrollment() {
+  const qc = useQueryClient();
+  type Ctx = {
+    snapshots: ReadonlyArray<readonly [QueryKey, KidCalendarResponse | undefined]>;
+  };
+  return useMutation<unknown, Error, CancelEnrollmentInput, Ctx>({
+    mutationFn: ({ enrollmentId }) =>
+      api.patch(`/api/enrollments/${enrollmentId}`, { status: 'cancelled' }),
+
+    onMutate: async ({ kidId, enrollmentId }) => {
+      await qc.cancelQueries({ queryKey: ['kids', kidId, 'calendar'] });
+      const snapshots = qc.getQueriesData<KidCalendarResponse>({
+        queryKey: ['kids', kidId, 'calendar'],
+      });
+
+      for (const [key, data] of snapshots) {
+        if (!data) continue;
+        const filtered = data.events.filter(
+          (e) =>
+            e.enrollment_id !== enrollmentId &&
+            e.from_enrollment_id !== enrollmentId,
+        );
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async (_data, _err, { kidId }) => {
+      await qc.invalidateQueries({ queryKey: ['kids', kidId, 'calendar'] });
+    },
+  });
+}
+
+interface DeleteUnavailabilityInput {
+  kidId: number;
+  blockId: number;
+}
+
+export function useDeleteUnavailability() {
+  const qc = useQueryClient();
+  type Ctx = {
+    snapshots: ReadonlyArray<readonly [QueryKey, KidCalendarResponse | undefined]>;
+  };
+  return useMutation<unknown, Error, DeleteUnavailabilityInput, Ctx>({
+    mutationFn: ({ blockId }) => api.delete(`/api/unavailability/${blockId}`),
+
+    onMutate: async ({ kidId, blockId }) => {
+      await qc.cancelQueries({ queryKey: ['kids', kidId, 'calendar'] });
+      const snapshots = qc.getQueriesData<KidCalendarResponse>({
+        queryKey: ['kids', kidId, 'calendar'],
+      });
+
+      for (const [key, data] of snapshots) {
+        if (!data) continue;
+        const filtered = data.events.filter((e) => e.block_id !== blockId);
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async (_data, _err, { kidId }) => {
+      await qc.invalidateQueries({ queryKey: ['kids', kidId, 'calendar'] });
     },
   });
 }

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -6,6 +6,7 @@ import type {
   Household,
   InboxSummary,
   KidBrief,
+  KidCalendarResponse,
   KidDetail,
   Match,
   Site,
@@ -91,5 +92,24 @@ export function useAlertRouting() {
   return useQuery({
     queryKey: ['alert_routing'],
     queryFn: () => api.get<AlertRouting[]>('/api/alert_routing'),
+  });
+}
+
+export function useKidCalendar({
+  kidId,
+  from,
+  to,
+}: {
+  kidId: number;
+  from: string;
+  to: string;
+}) {
+  return useQuery({
+    queryKey: ['kids', kidId, 'calendar', from, to],
+    queryFn: () =>
+      api.get<KidCalendarResponse>(
+        `/api/kids/${kidId}/calendar?from=${from}&to=${to}`,
+      ),
+    enabled: Number.isFinite(kidId) && !!from && !!to,
   });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -161,3 +161,31 @@ export interface Household {
   quiet_hours_end: string | null;
   daily_llm_cost_cap_usd: number;
 }
+
+export type CalendarEventKind = 'enrollment' | 'unavailability';
+
+export interface CalendarEvent {
+  id: string;            // composite "kind:source-id:date"
+  kind: CalendarEventKind;
+  date: string;          // YYYY-MM-DD
+  time_start: string | null;   // "HH:MM:SS" or null for all-day
+  time_end: string | null;
+  all_day: boolean;
+  title: string;
+  // enrollment-only:
+  enrollment_id?: number | null;
+  offering_id?: number | null;
+  location_id?: number | null;
+  status?: string | null;
+  // unavailability-only:
+  block_id?: number | null;
+  source?: string | null;
+  from_enrollment_id?: number | null;
+}
+
+export interface KidCalendarResponse {
+  kid_id: number;
+  from: string;  // YYYY-MM-DD
+  to: string;
+  events: CalendarEvent[];
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SitesIndexRouteImport } from './routes/sites.index'
 import { Route as SitesIdRouteImport } from './routes/sites.$id'
 import { Route as KidsIdWatchlistRouteImport } from './routes/kids.$id.watchlist'
 import { Route as KidsIdMatchesRouteImport } from './routes/kids.$id.matches'
+import { Route as KidsIdCalendarRouteImport } from './routes/kids.$id.calendar'
 
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
@@ -46,12 +47,18 @@ const KidsIdMatchesRoute = KidsIdMatchesRouteImport.update({
   path: '/kids/$id/matches',
   getParentRoute: () => rootRouteImport,
 } as any)
+const KidsIdCalendarRoute = KidsIdCalendarRouteImport.update({
+  id: '/kids/$id/calendar',
+  path: '/kids/$id/calendar',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
   '/sites/$id': typeof SitesIdRoute
   '/sites/': typeof SitesIndexRoute
+  '/kids/$id/calendar': typeof KidsIdCalendarRoute
   '/kids/$id/matches': typeof KidsIdMatchesRoute
   '/kids/$id/watchlist': typeof KidsIdWatchlistRoute
 }
@@ -60,6 +67,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/sites/$id': typeof SitesIdRoute
   '/sites': typeof SitesIndexRoute
+  '/kids/$id/calendar': typeof KidsIdCalendarRoute
   '/kids/$id/matches': typeof KidsIdMatchesRoute
   '/kids/$id/watchlist': typeof KidsIdWatchlistRoute
 }
@@ -69,6 +77,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/sites/$id': typeof SitesIdRoute
   '/sites/': typeof SitesIndexRoute
+  '/kids/$id/calendar': typeof KidsIdCalendarRoute
   '/kids/$id/matches': typeof KidsIdMatchesRoute
   '/kids/$id/watchlist': typeof KidsIdWatchlistRoute
 }
@@ -79,6 +88,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sites/$id'
     | '/sites/'
+    | '/kids/$id/calendar'
     | '/kids/$id/matches'
     | '/kids/$id/watchlist'
   fileRoutesByTo: FileRoutesByTo
@@ -87,6 +97,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sites/$id'
     | '/sites'
+    | '/kids/$id/calendar'
     | '/kids/$id/matches'
     | '/kids/$id/watchlist'
   id:
@@ -95,6 +106,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/sites/$id'
     | '/sites/'
+    | '/kids/$id/calendar'
     | '/kids/$id/matches'
     | '/kids/$id/watchlist'
   fileRoutesById: FileRoutesById
@@ -104,6 +116,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   SitesIdRoute: typeof SitesIdRoute
   SitesIndexRoute: typeof SitesIndexRoute
+  KidsIdCalendarRoute: typeof KidsIdCalendarRoute
   KidsIdMatchesRoute: typeof KidsIdMatchesRoute
   KidsIdWatchlistRoute: typeof KidsIdWatchlistRoute
 }
@@ -152,6 +165,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof KidsIdMatchesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/kids/$id/calendar': {
+      id: '/kids/$id/calendar'
+      path: '/kids/$id/calendar'
+      fullPath: '/kids/$id/calendar'
+      preLoaderRoute: typeof KidsIdCalendarRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -160,6 +180,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   SitesIdRoute: SitesIdRoute,
   SitesIndexRoute: SitesIndexRoute,
+  KidsIdCalendarRoute: KidsIdCalendarRoute,
   KidsIdMatchesRoute: KidsIdMatchesRoute,
   KidsIdWatchlistRoute: KidsIdWatchlistRoute,
 }

--- a/frontend/src/routes/kids.$id.calendar.tsx
+++ b/frontend/src/routes/kids.$id.calendar.tsx
@@ -1,0 +1,78 @@
+import { useState, useMemo } from 'react';
+import { createFileRoute } from '@tanstack/react-router';
+import { startOfWeek, addDays, startOfMonth, endOfMonth, format } from 'date-fns';
+import type { View } from 'react-big-calendar';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorBanner } from '@/components/common/ErrorBanner';
+import { useKid, useKidCalendar } from '@/lib/queries';
+import { KidTabs } from '@/components/layout/KidTabs';
+import { CalendarView } from '@/components/calendar/CalendarView';
+import { CalendarEventPopover } from '@/components/calendar/CalendarEventPopover';
+import type { CalendarEvent } from '@/lib/types';
+
+export const Route = createFileRoute('/kids/$id/calendar')({ component: KidCalendarPage });
+
+const BUFFER_DAYS = 3;
+
+function rangeFor(view: View, cursor: Date): { from: string; to: string } {
+  if (view === 'month') {
+    const monthStart = startOfMonth(cursor);
+    const monthEnd = endOfMonth(cursor);
+    const weekStart = startOfWeek(monthStart, { weekStartsOn: 0 });
+    return {
+      from: format(addDays(weekStart, -BUFFER_DAYS), 'yyyy-MM-dd'),
+      to: format(addDays(monthEnd, 7 + BUFFER_DAYS), 'yyyy-MM-dd'),
+    };
+  }
+  const weekStart = startOfWeek(cursor, { weekStartsOn: 0 });
+  return {
+    from: format(addDays(weekStart, -BUFFER_DAYS), 'yyyy-MM-dd'),
+    to: format(addDays(weekStart, 7 + BUFFER_DAYS), 'yyyy-MM-dd'),
+  };
+}
+
+function KidCalendarPage() {
+  const { id } = Route.useParams();
+  const kidId = Number(id);
+  const kid = useKid(kidId);
+
+  const [view, setView] = useState<View>('week');
+  const [cursor, setCursor] = useState<Date>(new Date());
+  const { from, to } = useMemo(() => rangeFor(view, cursor), [view, cursor]);
+
+  const calendar = useKidCalendar({ kidId, from, to });
+  const [selected, setSelected] = useState<CalendarEvent | null>(null);
+
+  if (kid.isLoading) return <Skeleton className="h-32 w-full" />;
+  if (kid.isError) {
+    return <ErrorBanner message={(kid.error as Error).message} onRetry={() => kid.refetch()} />;
+  }
+  if (!kid.data) return null;
+
+  return (
+    <div>
+      <h1 className="text-xl font-semibold mb-2">{kid.data.name}'s calendar</h1>
+      <KidTabs kidId={kidId} />
+      {calendar.isError && (
+        <ErrorBanner
+          message={(calendar.error as Error).message}
+          onRetry={() => calendar.refetch()}
+        />
+      )}
+      <CalendarView
+        events={calendar.data?.events ?? []}
+        view={view}
+        onView={setView}
+        date={cursor}
+        onNavigate={setCursor}
+        onSelectEvent={setSelected}
+      />
+      <CalendarEventPopover
+        kidId={kidId}
+        event={selected}
+        open={selected !== null}
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -61,4 +61,26 @@ export const handlers = [
       close_reason: null,
     });
   }),
+  http.get('/api/kids/:id/calendar', ({ params, request }) => {
+    const url = new URL(request.url);
+    return HttpResponse.json({
+      kid_id: Number(params.id),
+      from: url.searchParams.get('from'),
+      to: url.searchParams.get('to'),
+      events: [],
+    });
+  }),
+  http.patch('/api/enrollments/:id', async ({ params, request }) => {
+    const body = (await request.json()) as { status?: string };
+    return HttpResponse.json({
+      id: Number(params.id),
+      kid_id: 1,
+      offering_id: 1,
+      status: body.status ?? 'cancelled',
+      enrolled_at: null,
+      notes: null,
+      created_at: '2026-04-29T12:00:00Z',
+    });
+  }),
+  http.delete('/api/unavailability/:id', () => new HttpResponse(null, { status: 204 })),
 ];

--- a/src/yas/calendar/occurrences.py
+++ b/src/yas/calendar/occurrences.py
@@ -1,0 +1,80 @@
+"""Pure-function expansion of recurring weekly patterns into per-date occurrences.
+
+No DB, no HTTP — call sites pass the row's pattern fields and a request window
+and get back concrete occurrences within the intersection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import date, time, timedelta
+
+# Map weekday name → date.weekday() value (Mon=0..Sun=6).
+_WEEKDAY: dict[str, int] = {
+    "mon": 0,
+    "tue": 1,
+    "wed": 2,
+    "thu": 3,
+    "fri": 4,
+    "sat": 5,
+    "sun": 6,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Occurrence:
+    """A concrete dated event derived from a recurring pattern."""
+
+    date: date
+    time_start: time | None
+    time_end: time | None
+    all_day: bool
+
+
+def expand_recurring(
+    *,
+    days_of_week: list[str],
+    time_start: time | None,
+    time_end: time | None,
+    date_start: date | None,
+    date_end: date | None,
+    range_from: date,
+    range_to: date,
+) -> Iterator[Occurrence]:
+    """Yield occurrences for each weekday in `days_of_week` within the
+    intersection of [range_from, range_to) (half-open) and
+    [date_start, date_end] (closed, both endpoints inclusive when set).
+
+    A row with both `time_start` and `time_end` set produces timed
+    occurrences; both None produces all-day occurrences. A partial
+    (one set, one None) is treated as malformed and yields nothing.
+    """
+
+    if (time_start is None) != (time_end is None):
+        return
+    all_day = time_start is None and time_end is None
+
+    target_weekdays = {_WEEKDAY[name.lower()] for name in days_of_week if name.lower() in _WEEKDAY}
+    if not target_weekdays:
+        return
+
+    lo = range_from
+    if date_start is not None and date_start > lo:
+        lo = date_start
+    hi = range_to  # exclusive
+    if date_end is not None:
+        hi_from_source = date_end + timedelta(days=1)
+        if hi_from_source < hi:
+            hi = hi_from_source
+
+    cursor = lo
+    while cursor < hi:
+        if cursor.weekday() in target_weekdays:
+            yield Occurrence(
+                date=cursor,
+                time_start=time_start,
+                time_end=time_end,
+                all_day=all_day,
+            )
+        cursor += timedelta(days=1)

--- a/src/yas/web/app.py
+++ b/src/yas/web/app.py
@@ -57,6 +57,7 @@ def create_app(
         unavailability_router,
         watchlist_router,
     )
+    from yas.web.routes.kid_calendar import router as kid_calendar_router
 
     app.include_router(alert_routing_router)
     app.include_router(alerts_router)
@@ -66,6 +67,7 @@ def create_app(
     app.include_router(household_router)
     app.include_router(inbox_router)
     app.include_router(kids_router)
+    app.include_router(kid_calendar_router)
     app.include_router(watchlist_router)
     app.include_router(unavailability_router)
     app.include_router(enrollments_router)

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, time
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -117,5 +117,9 @@ async def get_kid_calendar(
                     )
                 )
 
-        events.sort(key=lambda e: (e.date, e.time_start or ""))
+        # Sort by (date, time_start). time_start is `time | None`; coerce
+        # all-day events to `time.min` so we always compare time-to-time.
+        # Mixing `time` and `str` in the sort key crashes at runtime when
+        # both an all-day and a timed event fall on the same date.
+        events.sort(key=lambda e: (e.date, e.time_start or time.min))
         return KidCalendarOut(kid_id=kid_id, from_=from_, to=to, events=events)

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -1,0 +1,121 @@
+"""GET /api/kids/{kid_id}/calendar — aggregated per-kid event view."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from yas.calendar.occurrences import expand_recurring
+from yas.db.models import Enrollment, Kid, Offering, UnavailabilityBlock
+from yas.db.models._types import EnrollmentStatus
+from yas.db.session import session_scope
+from yas.web.routes.kid_calendar_schemas import CalendarEventOut, KidCalendarOut
+
+router = APIRouter(prefix="/api/kids", tags=["kids"])
+
+_MAX_RANGE_DAYS = 90
+
+
+def _engine(req: Request) -> AsyncEngine:
+    engine: AsyncEngine = req.app.state.yas.engine
+    return engine
+
+
+@router.get("/{kid_id}/calendar", response_model=KidCalendarOut, response_model_by_alias=True)
+async def get_kid_calendar(
+    request: Request,
+    kid_id: int,
+    from_: Annotated[date, Query(alias="from")],
+    to: Annotated[date, Query()],
+) -> KidCalendarOut:
+    if from_ >= to:
+        raise HTTPException(status_code=422, detail="from must be before to")
+    if (to - from_).days > _MAX_RANGE_DAYS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"range exceeds {_MAX_RANGE_DAYS}-day cap",
+        )
+
+    async with session_scope(_engine(request)) as s:
+        kid = (await s.execute(select(Kid).where(Kid.id == kid_id))).scalar_one_or_none()
+        if kid is None:
+            raise HTTPException(status_code=404, detail=f"kid {kid_id} not found")
+
+        events: list[CalendarEventOut] = []
+
+        enrollment_rows = (
+            await s.execute(
+                select(Enrollment, Offering)
+                .join(Offering, Offering.id == Enrollment.offering_id)
+                .where(Enrollment.kid_id == kid_id)
+                .where(Enrollment.status == EnrollmentStatus.enrolled.value)
+            )
+        ).all()
+        for enrollment, offering in enrollment_rows:
+            for occ in expand_recurring(
+                days_of_week=list(offering.days_of_week or []),
+                time_start=offering.time_start,
+                time_end=offering.time_end,
+                date_start=offering.start_date,
+                date_end=offering.end_date,
+                range_from=from_,
+                range_to=to,
+            ):
+                events.append(
+                    CalendarEventOut(
+                        id=f"enrollment:{enrollment.id}:{occ.date.isoformat()}",
+                        kind="enrollment",
+                        date=occ.date,
+                        time_start=occ.time_start,
+                        time_end=occ.time_end,
+                        all_day=occ.all_day,
+                        title=offering.name,
+                        enrollment_id=enrollment.id,
+                        offering_id=offering.id,
+                        location_id=offering.location_id,
+                        status=enrollment.status,
+                    )
+                )
+
+        block_rows = (
+            (
+                await s.execute(
+                    select(UnavailabilityBlock)
+                    .where(UnavailabilityBlock.kid_id == kid_id)
+                    .where(UnavailabilityBlock.active.is_(True))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for block in block_rows:
+            for occ in expand_recurring(
+                days_of_week=list(block.days_of_week or []),
+                time_start=block.time_start,
+                time_end=block.time_end,
+                date_start=block.date_start,
+                date_end=block.date_end,
+                range_from=from_,
+                range_to=to,
+            ):
+                events.append(
+                    CalendarEventOut(
+                        id=f"unavailability:{block.id}:{occ.date.isoformat()}",
+                        kind="unavailability",
+                        date=occ.date,
+                        time_start=occ.time_start,
+                        time_end=occ.time_end,
+                        all_day=occ.all_day,
+                        title=block.label or block.source,
+                        block_id=block.id,
+                        source=block.source,
+                        from_enrollment_id=block.source_enrollment_id,
+                    )
+                )
+
+        events.sort(key=lambda e: (e.date, e.time_start or ""))
+        return KidCalendarOut(kid_id=kid_id, from_=from_, to=to, events=events)

--- a/src/yas/web/routes/kid_calendar_schemas.py
+++ b/src/yas/web/routes/kid_calendar_schemas.py
@@ -1,0 +1,40 @@
+"""Pydantic models for GET /api/kids/{kid_id}/calendar."""
+
+from __future__ import annotations
+
+from datetime import date, time
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CalendarEventOut(BaseModel):
+    id: str
+    kind: Literal["enrollment", "unavailability"]
+    date: date
+    time_start: time | None = None
+    time_end: time | None = None
+    all_day: bool
+    title: str
+    enrollment_id: int | None = None
+    offering_id: int | None = None
+    location_id: int | None = None
+    status: str | None = None
+    block_id: int | None = None
+    source: str | None = None
+    from_enrollment_id: int | None = None
+
+
+class KidCalendarOut(BaseModel):
+    """Python's `from` keyword conflict resolved via Pydantic alias.
+
+    `from_` is the Python attribute; FastAPI emits `from` on the wire
+    because the route handler uses `response_model_by_alias=True`.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    kid_id: int
+    from_: date = Field(alias="from")
+    to: date
+    events: list[CalendarEventOut]

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -1,0 +1,222 @@
+"""Integration tests for GET /api/kids/{kid_id}/calendar."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from yas.db.base import Base
+from yas.db.models import (
+    Enrollment,
+    Kid,
+    Offering,
+    Page,
+    Site,
+    UnavailabilityBlock,
+)
+from yas.db.models._types import (
+    EnrollmentStatus,
+    OfferingStatus,
+    UnavailabilitySource,
+)
+from yas.db.session import create_engine_for, session_scope
+from yas.web.app import create_app
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("YAS_ANTHROPIC_API_KEY", "sk-test")
+    url = f"sqlite+aiosqlite:///{tmp_path}/c.db"
+    monkeypatch.setenv("YAS_DATABASE_URL", url)
+    engine = create_engine_for(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    app = create_app(engine=engine, fetcher=None, llm=None, geocoder=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c, engine
+    await engine.dispose()
+
+
+async def _seed_kid_with_enrollment(engine, *, kid_id=1, offering_id=1):
+    async with session_scope(engine) as s:
+        s.add(Kid(id=kid_id, name="Sam", dob=date(2019, 5, 1)))
+        s.add(Site(id=1, name="X", base_url="https://x"))
+        await s.flush()
+        s.add(Page(id=1, site_id=1, url="https://x/p"))
+        await s.flush()
+        s.add(
+            Offering(
+                id=offering_id,
+                site_id=1,
+                page_id=1,
+                name="T-Ball",
+                normalized_name="t-ball",
+                days_of_week=["tue", "thu"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+        await s.flush()
+        s.add(
+            Enrollment(
+                id=10,
+                kid_id=kid_id,
+                offering_id=offering_id,
+                status=EnrollmentStatus.enrolled.value,
+                enrolled_at=datetime.now(UTC),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_returns_404_for_unknown_kid(client):
+    c, _ = client
+    r = await c.get("/api/kids/9999/calendar?from=2026-04-27&to=2026-05-04")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_returns_422_when_from_not_before_to(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    r = await c.get("/api/kids/1/calendar?from=2026-05-04&to=2026-04-27")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_returns_422_when_range_exceeds_90_days(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    r = await c.get("/api/kids/1/calendar?from=2026-01-01&to=2026-04-15")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_returns_enrolled_offering_occurrences(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kid_id"] == 1
+    assert body["from"] == "2026-04-27"
+    assert body["to"] == "2026-05-04"
+    enrollment_events = [e for e in body["events"] if e["kind"] == "enrollment"]
+    # Tue 2026-04-28 + Thu 2026-04-30; offering's date range is broader.
+    assert len(enrollment_events) == 2
+    dates = sorted(e["date"] for e in enrollment_events)
+    assert dates == ["2026-04-28", "2026-04-30"]
+    e = enrollment_events[0]
+    assert e["enrollment_id"] == 10
+    assert e["offering_id"] == 1
+    assert e["status"] == "enrolled"
+    assert e["title"] == "T-Ball"
+    assert e["time_start"] == "16:00:00"
+    assert e["all_day"] is False
+
+
+@pytest.mark.asyncio
+async def test_excludes_cancelled_enrollments(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        e = (await s.execute(select(Enrollment).where(Enrollment.id == 10))).scalar_one()
+        e.status = EnrollmentStatus.cancelled.value
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    assert [e for e in body["events"] if e["kind"] == "enrollment"] == []
+
+
+@pytest.mark.asyncio
+async def test_returns_unavailability_blocks_with_from_enrollment_id(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        s.add(
+            UnavailabilityBlock(
+                id=20,
+                kid_id=1,
+                source=UnavailabilitySource.school.value,
+                label="School",
+                days_of_week=["mon", "tue", "wed", "thu", "fri"],
+                time_start=time(8, 30),
+                time_end=time(15, 0),
+                date_start=date(2026, 1, 1),
+                date_end=date(2026, 6, 30),
+                active=True,
+            )
+        )
+        s.add(
+            UnavailabilityBlock(
+                id=21,
+                kid_id=1,
+                source=UnavailabilitySource.enrollment.value,
+                label="T-Ball",
+                days_of_week=["tue", "thu"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                date_start=date(2026, 4, 1),
+                date_end=date(2026, 6, 30),
+                active=True,
+                source_enrollment_id=10,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    school = [e for e in body["events"] if e["kind"] == "unavailability" and e["block_id"] == 20]
+    assert len(school) == 5  # Mon..Fri
+    assert school[0]["from_enrollment_id"] is None
+    enrollment_block = [
+        e for e in body["events"] if e["kind"] == "unavailability" and e["block_id"] == 21
+    ]
+    assert len(enrollment_block) == 2  # Tue, Thu
+    assert enrollment_block[0]["from_enrollment_id"] == 10
+
+
+@pytest.mark.asyncio
+async def test_excludes_inactive_blocks(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        s.add(
+            UnavailabilityBlock(
+                id=22,
+                kid_id=1,
+                source=UnavailabilitySource.manual.value,
+                days_of_week=["wed"],
+                time_start=time(13, 0),
+                time_end=time(14, 0),
+                date_start=date(2026, 4, 1),
+                date_end=date(2026, 6, 30),
+                active=False,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    assert all(e.get("block_id") != 22 for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_excludes_other_kids_events(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    async with session_scope(engine) as s:
+        s.add(Kid(id=2, name="Riley", dob=date(2017, 3, 1)))
+        await s.flush()
+        s.add(
+            Enrollment(
+                id=11,
+                kid_id=2,
+                offering_id=1,
+                status=EnrollmentStatus.enrolled.value,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    assert all(e.get("enrollment_id") != 11 for e in body["events"])

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -220,3 +220,39 @@ async def test_excludes_other_kids_events(client):
     r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
     body = r.json()
     assert all(e.get("enrollment_id") != 11 for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_sort_handles_all_day_and_timed_events_on_same_date(client):
+    """Regression: sort key must not mix `time` and `str` (or `None`).
+
+    All-day events have time_start == None. Timed events have time_start
+    set. If both fall on the same date, the sort key fires a tuple
+    comparison that crashes if we don't coerce to a single comparable type.
+    """
+    c, engine = client
+    await _seed_kid_with_enrollment(engine)
+    async with session_scope(engine) as s:
+        # All-day manual block on 2026-04-28 (Tuesday — same date as the T-Ball enrollment).
+        s.add(
+            UnavailabilityBlock(
+                id=30,
+                kid_id=1,
+                source=UnavailabilitySource.manual.value,
+                label="Day off",
+                days_of_week=["tue"],
+                time_start=None,
+                time_end=None,
+                date_start=date(2026, 4, 1),
+                date_end=date(2026, 6, 30),
+                active=True,
+            )
+        )
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    assert r.status_code == 200
+    body = r.json()
+    same_date = [e for e in body["events"] if e["date"] == "2026-04-28"]
+    # One enrollment (timed) + one all-day block on Tuesday.
+    assert len(same_date) == 2
+    assert any(e["all_day"] is True for e in same_date)
+    assert any(e["all_day"] is False for e in same_date)

--- a/tests/unit/test_calendar_occurrences.py
+++ b/tests/unit/test_calendar_occurrences.py
@@ -1,0 +1,161 @@
+"""Pure-function tests for the calendar recurring-expansion helper."""
+
+from __future__ import annotations
+
+from datetime import date, time
+
+from yas.calendar.occurrences import Occurrence, expand_recurring
+
+
+def _occ(
+    d: tuple[int, int, int], start: tuple[int, int] | None, end: tuple[int, int] | None
+) -> Occurrence:
+    return Occurrence(
+        date=date(*d),
+        time_start=time(*start) if start else None,
+        time_end=time(*end) if end else None,
+        all_day=start is None and end is None,
+    )
+
+
+def test_weekly_recurring_within_range_returns_correct_dates():
+    out = list(
+        expand_recurring(
+            days_of_week=["mon", "wed", "fri"],
+            time_start=time(16, 0),
+            time_end=time(17, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == [
+        _occ((2026, 4, 27), (16, 0), (17, 0)),
+        _occ((2026, 4, 29), (16, 0), (17, 0)),
+        _occ((2026, 5, 1), (16, 0), (17, 0)),
+    ]
+
+
+def test_date_start_clips_lower_bound():
+    out = list(
+        expand_recurring(
+            days_of_week=["tue"],
+            time_start=time(10, 0),
+            time_end=time(11, 0),
+            date_start=date(2026, 4, 28),
+            date_end=None,
+            range_from=date(2026, 4, 21),
+            range_to=date(2026, 5, 5),
+        )
+    )
+    assert [o.date for o in out] == [date(2026, 4, 28)]
+
+
+def test_date_end_clips_upper_bound_inclusive():
+    out = list(
+        expand_recurring(
+            days_of_week=["tue"],
+            time_start=time(10, 0),
+            time_end=time(11, 0),
+            date_start=None,
+            date_end=date(2026, 4, 28),
+            range_from=date(2026, 4, 21),
+            range_to=date(2026, 5, 12),
+        )
+    )
+    assert [o.date for o in out] == [date(2026, 4, 21), date(2026, 4, 28)]
+
+
+def test_range_to_is_exclusive():
+    out = list(
+        expand_recurring(
+            days_of_week=["mon"],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 4, 27),
+        )
+    )
+    assert out == []
+
+
+def test_all_day_when_both_times_none():
+    out = list(
+        expand_recurring(
+            days_of_week=["sat"],
+            time_start=None,
+            time_end=None,
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 25),
+            range_to=date(2026, 4, 26),
+        )
+    )
+    assert len(out) == 1
+    assert out[0].all_day is True
+    assert out[0].time_start is None
+    assert out[0].time_end is None
+
+
+def test_empty_days_of_week_returns_no_occurrences():
+    out = list(
+        expand_recurring(
+            days_of_week=[],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == []
+
+
+def test_days_of_week_case_insensitive():
+    out = list(
+        expand_recurring(
+            days_of_week=["MON", "Wed"],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert [o.date for o in out] == [date(2026, 4, 27), date(2026, 4, 29)]
+
+
+def test_source_outside_request_window_returns_no_occurrences():
+    out = list(
+        expand_recurring(
+            days_of_week=["mon"],
+            time_start=time(9, 0),
+            time_end=time(10, 0),
+            date_start=date(2026, 1, 1),
+            date_end=date(2026, 1, 31),
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == []
+
+
+def test_malformed_partial_time_skipped():
+    """time_start without time_end (or vice versa) is malformed; helper skips."""
+    out = list(
+        expand_recurring(
+            days_of_week=["mon"],
+            time_start=time(9, 0),
+            time_end=None,
+            date_start=None,
+            date_end=None,
+            range_from=date(2026, 4, 27),
+            range_to=date(2026, 5, 4),
+        )
+    )
+    assert out == []


### PR DESCRIPTION
## Summary

- **Backend:** new endpoint `GET /api/kids/{id}/calendar?from=&to=` aggregating enrollment + unavailability occurrences within a half-open date window. Pure-function `expand_recurring` helper at `src/yas/calendar/occurrences.py` (9 unit tests). 90-day defensive range cap.
- **Frontend:** `/kids/$id/calendar` route with week + month toggle, fixed 6am–10pm time range, click-to-action affordance via Sheet (matches the canonical `AlertDetailDrawer` pattern from 5b-1b).
- **Two new mutations** following the canonical 5b-1b optimistic + rollback pattern: `useCancelEnrollment` (also strips linked-block events from the cache) + `useDeleteUnavailability`.
- **New dep:** `react-big-calendar` 1.19.4 (~25 KB, exact-pinned) + `@types/react-big-calendar` 1.16.3.
- **Worker change deferred:** none in this slice — calendar reads, doesn't drive new background work.

Satisfies the v1 terminal-state criterion in master design §10: *"calendar page renders a week view containing offerings, enrollments, and unavailability for a single kid within 1s on a realistic dataset."*

## Test plan

- [x] uv run pytest -q (560 passed; +9 unit + +8 integration on top of the 543 baseline)
- [x] uv run ruff check . && uv run ruff format --check . clean
- [x] uv run mypy src clean
- [x] cd frontend && npm run typecheck clean
- [x] cd frontend && npm run lint clean (--max-warnings 0)
- [x] cd frontend && npm run test (42 passed; +11 new across mutations + CalendarView + CalendarEventPopover)
- [ ] CI passes
- [ ] Manual smoke (in-browser): enrollment cancel → row vanishes optimistically; week→month toggle works; enrollment-linked block can't be deleted from popover

## One implementation deviation worth flagging

The plan specified shadcn `Popover` for the click-action surface; we used `Sheet` instead. Reasons: (a) no `Popover` primitive exists in this project's `components/ui/`, and (b) anchoring a popover to a `react-big-calendar` event element is awkward because rbc owns event rendering. `Sheet` matches the canonical `AlertDetailDrawer` pattern from 5b-1b, reuses an existing primitive, and avoids adding a new shadcn dep.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-04-29-phase-5c-1-kid-calendar-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-phase-5c-1-kid-calendar.md`

## Out of scope (deferred)

- Match overlay + click-to-enroll from calendar (5c-2)
- Multi-kid combined view
- Drag-and-drop reschedule
- ICS export / import
- Holiday-calendar integration (school blocks render every weekday in their range)
- Edit-in-place (popover is cancel/delete only)

## Summary by Sourcery

Introduce a per-kid calendar feature spanning backend and frontend, including an aggregated calendar API and a new calendar page with event actions.

New Features:
- Add backend endpoint to serve per-kid calendar data by aggregating enrollment and unavailability occurrences over a date range.
- Add frontend /kids/$id/calendar route with a calendar UI showing a kid’s events in week or month view and an event details sheet.
- Introduce optimistic mutations to cancel enrollments and delete unavailability blocks directly from the calendar.

Enhancements:
- Add a reusable recurring-occurrence expansion helper to generate dated events from weekly patterns.
- Extend shared frontend API utilities and query hooks to support calendar data fetching and generic PATCH/DELETE requests.
- Wire the new calendar view into existing kid navigation via KidTabs.

Build:
- Add react-big-calendar and its type declarations as new pinned frontend dependencies.

Documentation:
- Add design and implementation plan documents describing the per-kid calendar feature, API, and frontend behavior.

Tests:
- Add unit tests for the recurring expansion helper and integration tests for the calendar API endpoint.
- Add frontend tests for the new calendar view, event popover, and optimistic mutation hooks.