### PR TITLE
phase 5d-1: site/offering alert mute (one-click)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-phase-5d-1-site-offering-mute.md
+++ b/docs/superpowers/plans/2026-04-29-phase-5d-1-site-offering-mute.md
@@ -1,0 +1,1737 @@
+# Phase 5d-1 — Site/Offering Alert Mute Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `Site.muted_until` and `Offering.muted_until` into the alert-firing pipeline + calendar match overlay, then ship a `<MuteButton>` UI primitive in three placements (site detail, matches list, calendar popover).
+
+**Architecture:** Six functions in `enqueuer.py` gain mute checks via two helpers (`_is_muted` for offering-targeted, `_is_site_muted` for site-targeted). One new `PATCH /api/offerings/{id}` route. Calendar match-overlay query gains two more `or_(...muted_until is null OR <= now)` clauses. Frontend gets one new presentational primitive (popover with 4-button duration picker), two mutation hooks following the canonical 5b-1b/5c-1 pattern, and three placement edits.
+
+**Tech Stack:** SQLAlchemy 2.x async, FastAPI, Pydantic v2, pytest-asyncio, React 19, TanStack Query 5, `radix-ui` 1.4.3 (Popover primitive — already installed), `date-fns`, MSW, Vitest + RTL.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md`
+
+**Project conventions:**
+- All deps already pinned to exact patch. **No new deps in this slice.**
+- All commits signed via 1Password SSH agent. Set `SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"` before each `git commit` in fresh shells. Verify with `git cat-file commit HEAD | grep -q '^gpgsig '`.
+- Branch already created: `phase-5d-1-site-offering-mute`. Do NOT commit to `main`.
+- Backend gates: `uv run pytest -q --no-cov`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src`.
+- Frontend gates from `frontend/`: `npm run typecheck`, `npm run lint`, `npm run test`.
+- Backend baseline: 567 tests. Frontend baseline: 49 tests (10 files).
+- Python 3.14 (PEP 758 — `except A, B:` is valid syntax, don't flag).
+
+---
+
+## File Structure
+
+**Modify — backend:**
+- `src/yas/alerts/enqueuer.py` — add `_is_muted` + `_is_site_muted` helpers; gate the 6 enqueue functions.
+- `src/yas/web/routes/kid_calendar.py` — extend match-overlay query with two new `or_(...)` clauses.
+- `src/yas/web/app.py` — register the new offerings router.
+
+**Create — backend:**
+- `src/yas/web/routes/offerings.py` — `PATCH /api/offerings/{id}` with `OfferingPatch` and `OfferingMuteOut` schemas inline.
+- `tests/integration/test_alerts_enqueuer_mute.py` — gate tests for all 6 enqueue functions.
+- `tests/integration/test_api_offerings.py` — PATCH happy/404/422 + persistence.
+
+**Modify — backend tests:**
+- `tests/integration/test_api_kids_calendar.py` — extend with mute exclusion tests.
+
+**Create — frontend:**
+- `frontend/src/lib/mute.ts` — `FOREVER_SENTINEL`, `muteUntilFromDuration`, `isMuted`.
+- `frontend/src/lib/mute.test.ts` — unit tests for the helpers.
+- `frontend/src/components/common/MuteButton.tsx` — Popover-based UI primitive.
+- `frontend/src/components/common/MuteButton.test.tsx` — render + interaction tests.
+
+**Modify — frontend:**
+- `frontend/src/lib/mutations.ts` — add `useUpdateSiteMute`, `useUpdateOfferingMute`.
+- `frontend/src/lib/mutations.test.tsx` — extend with the two new hooks.
+- `frontend/src/test/handlers.ts` — add `PATCH /api/sites/:id` and `PATCH /api/offerings/:id` MSW stubs.
+- `frontend/src/routes/sites.$id.tsx` — wire `<MuteButton>` in the header.
+- `frontend/src/routes/kids.$id.matches.tsx` — wire `<MuteButton>` per match row.
+- `frontend/src/components/calendar/CalendarEventPopover.tsx` — add Mute on the match branch.
+- `frontend/src/components/calendar/CalendarEventPopover.test.tsx` — extend with mute test.
+
+---
+
+## Task 1 — Backend: enqueuer mute gates (TDD)
+
+**Files:**
+- Modify: `src/yas/alerts/enqueuer.py`
+- Create: `tests/integration/test_alerts_enqueuer_mute.py`
+
+End state: `_is_muted` + `_is_site_muted` helpers exist; 6 enqueue functions gated. ~10 new tests pass; existing 567 backend tests still pass.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/integration/test_alerts_enqueuer_mute.py`:
+
+```python
+"""Mute gate tests for src/yas/alerts/enqueuer.py."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from yas.alerts.enqueuer import (
+    enqueue_crawl_failed,
+    enqueue_new_match,
+    enqueue_schedule_posted,
+    enqueue_site_stagnant,
+    enqueue_watchlist_hit,
+)
+from yas.db.base import Base
+from yas.db.models import Alert, Kid, Offering, Page, Site, WatchlistEntry
+from yas.db.models._types import AlertType, OfferingStatus
+from yas.db.session import session_scope
+
+
+async def _make_engine(tmp_path: Any) -> Any:
+    url = f"sqlite+aiosqlite:///{tmp_path}/m.db"
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine
+
+
+async def _seed(
+    engine: Any,
+    *,
+    site_muted_until: datetime | None = None,
+    offering_muted_until: datetime | None = None,
+) -> tuple[int, int, int]:
+    async with session_scope(engine) as s:
+        s.add(Kid(id=1, name="Sam", dob=date(2019, 5, 1)))
+        s.add(
+            Site(
+                id=1,
+                name="X",
+                base_url="https://x",
+                muted_until=site_muted_until,
+            )
+        )
+        await s.flush()
+        s.add(Page(id=1, site_id=1, url="https://x/p"))
+        await s.flush()
+        s.add(
+            Offering(
+                id=1,
+                site_id=1,
+                page_id=1,
+                name="T-Ball",
+                normalized_name="t-ball",
+                days_of_week=["tue"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+                muted_until=offering_muted_until,
+            )
+        )
+    return 1, 1, 1  # kid_id, offering_id, site_id
+
+
+@pytest.mark.asyncio
+async def test_new_match_skipped_when_offering_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, offering_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(
+            s, kid_id=1, offering_id=1, score=0.9, reasons={}
+        )
+    assert result is None
+    async with session_scope(engine) as s:
+        alerts = (await s.execute(select(Alert))).scalars().all()
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_new_match_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(
+            s, kid_id=1, offering_id=1, score=0.9, reasons={}
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_new_match_enqueues_when_both_unmuted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    await _seed(engine)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(
+            s, kid_id=1, offering_id=1, score=0.9, reasons={}
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_new_match_enqueues_when_mute_in_past(tmp_path):
+    engine = await _make_engine(tmp_path)
+    past = datetime.now(UTC) - timedelta(days=1)
+    await _seed(engine, offering_muted_until=past)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(
+            s, kid_id=1, offering_id=1, score=0.9, reasons={}
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_watchlist_hit_skipped_when_offering_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, offering_muted_until=future)
+    async with session_scope(engine) as s:
+        s.add(
+            WatchlistEntry(
+                id=99, kid_id=1, query="t-ball", active=True
+            )
+        )
+    async with session_scope(engine) as s:
+        # enqueue_watchlist_hit returns int (not Optional). With mute, the
+        # spec says skip → return must signal "not enqueued". Per spec, we
+        # extend the function to also return None when muted (consistent
+        # with enqueue_new_match).
+        result = await enqueue_watchlist_hit(
+            s,
+            kid_id=1,
+            offering_id=1,
+            watchlist_entry_id=99,
+            reasons={},
+        )
+    assert result is None
+    async with session_scope(engine) as s:
+        alerts = (
+            (await s.execute(select(Alert).where(Alert.type == AlertType.watchlist_hit.value)))
+            .scalars()
+            .all()
+        )
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_watchlist_hit_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        s.add(WatchlistEntry(id=99, kid_id=1, query="t-ball", active=True))
+    async with session_scope(engine) as s:
+        result = await enqueue_watchlist_hit(
+            s,
+            kid_id=1,
+            offering_id=1,
+            watchlist_entry_id=99,
+            reasons={},
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_posted_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_schedule_posted(
+            s, page_id=1, site_id=1, summary="3 new offerings"
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_crawl_failed_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_crawl_failed(
+            s, site_id=1, consecutive_failures=3, last_error="timeout"
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_site_stagnant_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_site_stagnant(s, site_id=1, days_silent=15)
+    assert result is None
+```
+
+(Signatures verified at plan time: `enqueue_schedule_posted(page_id, site_id, summary)`, `enqueue_crawl_failed(site_id, consecutive_failures, last_error)`, `enqueue_site_stagnant(site_id, days_silent)`.)
+
+The reg-opens countdown function (`enqueue_registration_countdowns`) is more elaborate and is tested separately in **Step 6** below.
+
+- [ ] **Step 2: Run; confirm all FAIL**
+
+```bash
+uv run pytest tests/integration/test_alerts_enqueuer_mute.py -q --no-cov
+```
+
+Expected: 9 failed (no mute gating yet — alerts get enqueued).
+
+- [ ] **Step 3: Implement helpers in enqueuer.py**
+
+In `src/yas/alerts/enqueuer.py`, after the existing `_kid_alert_on` helper (around line 101) and before `enqueue_new_match`, add:
+
+```python
+async def _is_muted(session: AsyncSession, *, offering_id: int) -> bool:
+    """True if the offering or its parent site is currently muted.
+
+    Used by offering-targeted enqueue functions (new_match, watchlist_hit,
+    reg-opens variants).
+    """
+    now = datetime.now(UTC)
+    row = (
+        await session.execute(
+            select(Offering.muted_until, Site.muted_until)
+            .join(Site, Site.id == Offering.site_id)
+            .where(Offering.id == offering_id)
+        )
+    ).one_or_none()
+    if row is None:
+        return False
+    o_muted, s_muted = row
+    return (o_muted is not None and o_muted > now) or (s_muted is not None and s_muted > now)
+
+
+async def _is_site_muted(session: AsyncSession, *, site_id: int) -> bool:
+    """True if the site is currently muted.
+
+    Used by site-targeted enqueue functions (schedule_posted, crawl_failed,
+    site_stagnant).
+    """
+    now = datetime.now(UTC)
+    s_muted = (
+        await session.execute(select(Site.muted_until).where(Site.id == site_id))
+    ).scalar_one_or_none()
+    return s_muted is not None and s_muted > now
+```
+
+- [ ] **Step 4: Gate `enqueue_new_match` and `enqueue_watchlist_hit`**
+
+In `enqueue_new_match`, after the existing `_kid_alert_on` check, add:
+
+```python
+    if not _kid_alert_on(kid, "new_match", default=True):
+        return None
+    if await _is_muted(session, offering_id=offering_id):
+        return None
+```
+
+Update `enqueue_watchlist_hit`. Currently the function returns `int` (always enqueues). Change the return type annotation to `int | None` and add the gate at the top:
+
+```python
+async def enqueue_watchlist_hit(
+    session: AsyncSession,
+    *,
+    kid_id: int,
+    offering_id: int,
+    watchlist_entry_id: int,
+    reasons: dict[str, Any],
+) -> int | None:
+    """Insert or update a watchlist_hit alert. Bypasses kid.alert_on (the user
+    added the watchlist entry explicitly) but is suppressed by Site/Offering
+    mute (the user has since changed their mind)."""
+    if await _is_muted(session, offering_id=offering_id):
+        return None
+    dk = dedup_key_for(...)
+    ...
+```
+
+This **changes the return type** of `enqueue_watchlist_hit` from `int` to `int | None`. Search for callers:
+
+```bash
+grep -rn "enqueue_watchlist_hit" src/yas/ tests/
+```
+
+Verify each caller handles `None` correctly. If a caller does `id_ = await enqueue_watchlist_hit(...)` and uses `id_` afterwards without a `None` check, fix that caller (e.g., `if id_ is not None: ...`). Most call sites likely just call the function for side-effect and ignore the return — those are fine.
+
+- [ ] **Step 5: Gate `enqueue_schedule_posted`, `enqueue_crawl_failed`, `enqueue_site_stagnant`**
+
+For each of the three site-targeted functions, add at the top (before `dk = dedup_key_for(...)`):
+
+```python
+    if await _is_site_muted(session, site_id=site_id):
+        return None
+```
+
+If any of these functions currently has return type `int`, change to `int | None`.
+
+- [ ] **Step 6: Gate `enqueue_registration_countdowns` and add its test**
+
+`enqueue_registration_countdowns` is structured differently — it loops over `(AlertType, offset)` pairs and inserts up to 3 alerts per call. The mute check should be ONCE at the top of the function (not per countdown variant), since they all target the same offering:
+
+```python
+async def enqueue_registration_countdowns(
+    session: AsyncSession,
+    *,
+    kid_id: int,
+    offering_id: int,
+) -> list[int]:
+    """..."""
+    if await _is_muted(session, offering_id=offering_id):
+        return []
+    # ...existing body...
+```
+
+(Verify the actual signature in the current file. If the function name or signature differs, follow the existing shape.)
+
+Append a test to `tests/integration/test_alerts_enqueuer_mute.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_reg_opens_countdowns_skipped_when_offering_muted(tmp_path):
+    """All three reg-opens variants are gated by a single mute check."""
+    from yas.alerts.enqueuer import enqueue_registration_countdowns
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, offering_muted_until=future)
+    # Set offering's registration_opens_at so the function would normally fire.
+    async with session_scope(engine) as s:
+        offering = (
+            await s.execute(select(Offering).where(Offering.id == 1))
+        ).scalar_one()
+        offering.registration_opens_at = datetime.now(UTC) + timedelta(hours=2)
+    async with session_scope(engine) as s:
+        result = await enqueue_registration_countdowns(s, kid_id=1, offering_id=1)
+    assert result == []
+    async with session_scope(engine) as s:
+        alerts = (await s.execute(select(Alert))).scalars().all()
+    assert alerts == []
+```
+
+- [ ] **Step 7: Re-run; confirm all 10 PASS + existing tests green**
+
+```bash
+uv run pytest tests/integration/test_alerts_enqueuer_mute.py -q --no-cov
+uv run pytest -q --no-cov
+```
+
+Expected: 10 new passed; 577 total (567 + 10).
+
+- [ ] **Step 8: Backend gates**
+
+```bash
+uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: clean. If `enqueue_watchlist_hit` callers had to be updated (Step 4), mypy will catch any missed sites.
+
+- [ ] **Step 9: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git add src/yas/alerts/enqueuer.py tests/integration/test_alerts_enqueuer_mute.py
+# also stage any caller updates from Step 4
+git commit -m "feat(alerts): mute gates in enqueuer for site + offering paths
+
+Wires Site.muted_until and Offering.muted_until into the alert pipeline.
+Six enqueue functions gated:
+
+- new_match, watchlist_hit, registration_countdowns: gated on
+  Offering.muted_until OR Site.muted_until.
+- schedule_posted, crawl_failed, site_stagnant: gated on Site.muted_until.
+
+Two helpers (_is_muted, _is_site_muted) factor the SQL. Watchlist_hit's
+return type widened from int to int | None — callers that ignored the
+return continue to work; any caller that read the int to do further
+work would be flagged by mypy."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 2 — Backend: PATCH /api/offerings/{id} (TDD)
+
+**Files:**
+- Create: `src/yas/web/routes/offerings.py`
+- Create: `tests/integration/test_api_offerings.py`
+- Modify: `src/yas/web/app.py`
+
+End state: `PATCH /api/offerings/{id}` route accepts `{ muted_until: datetime | null }`. ~5 new tests pass.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/integration/test_api_offerings.py`:
+
+```python
+"""Integration tests for PATCH /api/offerings/{id}."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from yas.db.base import Base
+from yas.db.models import Offering, Page, Site
+from yas.db.models._types import OfferingStatus
+from yas.db.session import create_engine_for, session_scope
+from yas.web.app import create_app
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("YAS_ANTHROPIC_API_KEY", "sk-test")
+    url = f"sqlite+aiosqlite:///{tmp_path}/o.db"
+    monkeypatch.setenv("YAS_DATABASE_URL", url)
+    engine = create_engine_for(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with session_scope(engine) as s:
+        s.add(Site(id=1, name="X", base_url="https://x"))
+        await s.flush()
+        s.add(Page(id=1, site_id=1, url="https://x/p"))
+        await s.flush()
+        s.add(
+            Offering(
+                id=1,
+                site_id=1,
+                page_id=1,
+                name="T-Ball",
+                normalized_name="t-ball",
+                days_of_week=["tue"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    app = create_app(engine=engine, fetcher=None, llm=None, geocoder=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c, engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_404_for_unknown_id(client):
+    c, _ = client
+    r = await c.patch("/api/offerings/9999", json={"muted_until": None})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_422_for_unknown_field(client):
+    c, _ = client
+    r = await c.patch("/api/offerings/1", json={"unknown_field": "value"})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_sets_muted_until(client):
+    c, engine = client
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    r = await c.patch("/api/offerings/1", json={"muted_until": future})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["muted_until"] is not None
+    async with session_scope(engine) as s:
+        o = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+    assert o.muted_until is not None
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_clears_muted_until(client):
+    c, engine = client
+    # First mute it.
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    await c.patch("/api/offerings/1", json={"muted_until": future})
+    # Then clear.
+    r = await c.patch("/api/offerings/1", json={"muted_until": None})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["muted_until"] is None
+    async with session_scope(engine) as s:
+        o = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+    assert o.muted_until is None
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_empty_body_does_not_clear_muted_until(client):
+    """An empty PATCH body must not null out the muted_until field."""
+    c, engine = client
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    await c.patch("/api/offerings/1", json={"muted_until": future})
+    # Empty PATCH.
+    r = await c.patch("/api/offerings/1", json={})
+    assert r.status_code == 200
+    async with session_scope(engine) as s:
+        o = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+    assert o.muted_until is not None  # preserved
+```
+
+- [ ] **Step 2: Run; confirm all 5 FAIL** (route doesn't exist):
+
+```bash
+uv run pytest tests/integration/test_api_offerings.py -q --no-cov
+```
+
+- [ ] **Step 3: Create the route**
+
+Create `src/yas/web/routes/offerings.py`:
+
+```python
+"""CRUD for /api/offerings — initial scope: mute toggle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from yas.db.models import Offering
+from yas.db.session import session_scope
+
+router = APIRouter(prefix="/api/offerings", tags=["offerings"])
+
+
+def _engine(req: Request) -> AsyncEngine:
+    engine: AsyncEngine = req.app.state.yas.engine
+    return engine
+
+
+class OfferingPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    muted_until: datetime | None = None
+
+
+class OfferingMuteOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    name: str
+    site_id: int
+    muted_until: datetime | None
+
+
+@router.patch("/{offering_id}", response_model=OfferingMuteOut)
+async def update_offering(
+    request: Request,
+    offering_id: int,
+    payload: OfferingPatch,
+) -> OfferingMuteOut:
+    async with session_scope(_engine(request)) as s:
+        offering = (
+            await s.execute(select(Offering).where(Offering.id == offering_id))
+        ).scalar_one_or_none()
+        if offering is None:
+            raise HTTPException(status_code=404, detail=f"offering {offering_id} not found")
+        if "muted_until" in payload.model_fields_set:
+            offering.muted_until = payload.muted_until
+        await s.flush()
+        await s.refresh(offering)
+        return OfferingMuteOut.model_validate(offering)
+```
+
+- [ ] **Step 4: Register router**
+
+In `src/yas/web/app.py`, find the existing `app.include_router(...)` block and add a parallel pair:
+
+- Add to imports: `from yas.web.routes.offerings import router as offerings_router`
+- Add: `app.include_router(offerings_router)`
+
+Place it next to `enrollments_router` for grouping consistency.
+
+- [ ] **Step 5: Re-run; confirm 5 PASS**
+
+```bash
+uv run pytest tests/integration/test_api_offerings.py -q --no-cov
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Full backend gates**
+
+```bash
+uv run pytest -q --no-cov && uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: 582 passed (577 + 5); ruff/format/mypy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git add src/yas/web/routes/offerings.py src/yas/web/app.py tests/integration/test_api_offerings.py
+git commit -m "feat(api): PATCH /api/offerings/{id} for mute toggle
+
+Initial scope is just muted_until. Uses Pydantic v2's model_fields_set
+guard so an empty PATCH body does not null the field. Refreshes the
+ORM object after flush to keep response timestamp consistent on
+SQLite (5b-1a tz-roundtrip pattern)."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 3 — Backend: calendar match-overlay mute filter (TDD)
+
+**Files:**
+- Modify: `src/yas/web/routes/kid_calendar.py`
+- Modify: `tests/integration/test_api_kids_calendar.py`
+
+End state: Calendar match overlay excludes muted offerings + offerings whose site is muted. ~3 new tests pass.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/integration/test_api_kids_calendar.py`. The file already imports `Match`, `Offering`, `Site`, `OfferingStatus`, `EnrollmentStatus`, has `_seed_kid_with_enrollment` and `_seed_match` helpers. Append:
+
+```python
+@pytest.mark.asyncio
+async def test_match_overlay_excludes_muted_offerings(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    future = datetime.now(UTC) + timedelta(days=30)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+                muted_until=future,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    assert all(e["kind"] != "match" for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_match_overlay_excludes_offering_whose_site_is_muted(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    future = datetime.now(UTC) + timedelta(days=30)
+    async with session_scope(engine) as s:
+        # Mute the existing Site (id=1, seeded by helper).
+        site = (await s.execute(select(Site).where(Site.id == 1))).scalar_one()
+        site.muted_until = future
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    assert all(e["kind"] != "match" for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_match_overlay_includes_offering_whose_mute_expired(client):
+    """A muted_until in the past doesn't suppress the match."""
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    past = datetime.now(UTC) - timedelta(days=1)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+                muted_until=past,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    matches = [e for e in body["events"] if e["kind"] == "match"]
+    assert len(matches) == 1
+```
+
+`Site` should already be imported in this test file. If not, add `Site` to the existing `from yas.db.models import ...` line.
+
+- [ ] **Step 2: Run; confirm 3 FAIL**
+
+```bash
+uv run pytest tests/integration/test_api_kids_calendar.py -q --no-cov -k "muted"
+```
+
+- [ ] **Step 3: Update the calendar query**
+
+In `src/yas/web/routes/kid_calendar.py`:
+
+a. Add `or_` to the existing sqlalchemy import:
+```python
+from sqlalchemy import or_, select
+```
+
+b. In the `if include_matches:` block, extend the `select(Match, Offering)` query (the existing query already joins Offering; it also needs to join Site for the mute check, OR use a scalar subquery on Site.muted_until — joining is simpler):
+
+```python
+            match_rows = (
+                await s.execute(
+                    select(Match, Offering)
+                    .join(Offering, Offering.id == Match.offering_id)
+                    .join(Site, Site.id == Offering.site_id)            # add
+                    .where(Match.kid_id == kid_id)
+                    .where(Match.score >= _MATCH_THRESHOLD)
+                    .where(~Match.offering_id.in_(committed_offering_ids))
+                    .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= now))   # add
+                    .where(or_(Site.muted_until.is_(None), Site.muted_until <= now))           # add
+                )
+            ).all()
+```
+
+`Site` should already be imported at the top of `kid_calendar.py` (it's used elsewhere in the file). If not, add it.
+
+The `now` variable is captured at the top of the route handler — reuse it (do NOT call `datetime.now(UTC)` per row).
+
+- [ ] **Step 4: Re-run; confirm all 3 PASS**
+
+```bash
+uv run pytest tests/integration/test_api_kids_calendar.py -q --no-cov
+```
+
+Expected: 18 passed (existing 15 + new 3).
+
+- [ ] **Step 5: Backend gates**
+
+```bash
+uv run pytest -q --no-cov && uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: 585 passed (582 + 3); clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git add src/yas/web/routes/kid_calendar.py tests/integration/test_api_kids_calendar.py
+git commit -m "feat(api): exclude muted offerings + sites from calendar match overlay
+
+Two new or_(muted_until is null OR muted_until <= now) clauses on the
+match-merge query. Reuses the route handler's existing 'now' variable
+(captured once)."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 4 — Frontend: mute helpers + types + MSW handlers
+
+**Files:**
+- Create: `frontend/src/lib/mute.ts`
+- Create: `frontend/src/lib/mute.test.ts`
+- Modify: `frontend/src/test/handlers.ts`
+
+End state: Pure-function mute helpers tested. MSW handlers exist for both PATCH routes. Existing 49 frontend tests still pass; +6 new mute helper tests.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `frontend/src/lib/mute.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { FOREVER_SENTINEL, isMuted, muteUntilFromDuration } from './mute';
+
+describe('muteUntilFromDuration', () => {
+  it('returns the forever sentinel for "forever"', () => {
+    expect(muteUntilFromDuration('forever')).toBe(FOREVER_SENTINEL);
+  });
+
+  it('returns now + 7 days for "7d"', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(muteUntilFromDuration('7d', now)).toBe('2026-05-06T12:00:00.000Z');
+  });
+
+  it('returns now + 30 days for "30d"', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(muteUntilFromDuration('30d', now)).toBe('2026-05-29T12:00:00.000Z');
+  });
+
+  it('returns now + 90 days for "90d"', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(muteUntilFromDuration('90d', now)).toBe('2026-07-28T12:00:00.000Z');
+  });
+});
+
+describe('isMuted', () => {
+  it('returns false for null', () => {
+    expect(isMuted(null)).toBe(false);
+  });
+
+  it('returns false for past timestamps', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(isMuted('2026-04-28T12:00:00Z', now)).toBe(false);
+  });
+
+  it('returns true for future timestamps', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(isMuted('2026-05-01T12:00:00Z', now)).toBe(true);
+  });
+
+  it('returns true for the forever sentinel', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(isMuted(FOREVER_SENTINEL, now)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm 8 FAIL** (module doesn't exist):
+
+```bash
+cd frontend && npm run test -- mute
+```
+
+- [ ] **Step 3: Implement helpers**
+
+Create `frontend/src/lib/mute.ts`:
+
+```ts
+export const FOREVER_SENTINEL = '3000-01-01T00:00:00.000Z';
+
+export type MuteDuration = '7d' | '30d' | '90d' | 'forever';
+
+const DAYS: Record<Exclude<MuteDuration, 'forever'>, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
+
+export function muteUntilFromDuration(
+  duration: MuteDuration,
+  now: Date = new Date(),
+): string {
+  if (duration === 'forever') return FOREVER_SENTINEL;
+  const out = new Date(now);
+  out.setDate(out.getDate() + DAYS[duration]);
+  return out.toISOString();
+}
+
+export function isMuted(
+  mutedUntil: string | null,
+  now: Date = new Date(),
+): boolean {
+  if (mutedUntil == null) return false;
+  return new Date(mutedUntil) > now;
+}
+```
+
+- [ ] **Step 4: Re-run; confirm 8 PASS**
+
+```bash
+cd frontend && npm run test -- mute
+```
+
+- [ ] **Step 5: Add MSW handlers**
+
+In `frontend/src/test/handlers.ts`, append:
+
+```ts
+http.patch('/api/sites/:id', async ({ params, request }) => {
+  const body = (await request.json()) as { muted_until?: string | null };
+  return HttpResponse.json({
+    id: Number(params.id),
+    name: 'X',
+    base_url: 'https://x',
+    adapter: 'llm',
+    needs_browser: false,
+    active: true,
+    default_cadence_s: 86400,
+    muted_until: body.muted_until ?? null,
+    pages: [],
+  });
+}),
+http.patch('/api/offerings/:id', async ({ params, request }) => {
+  const body = (await request.json()) as { muted_until?: string | null };
+  return HttpResponse.json({
+    id: Number(params.id),
+    name: 'T-Ball',
+    site_id: 1,
+    muted_until: body.muted_until ?? null,
+  });
+}),
+```
+
+- [ ] **Step 6: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 57 passed (49 + 8); clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/lib/mute.ts frontend/src/lib/mute.test.ts frontend/src/test/handlers.ts
+git commit -m "feat(frontend): mute helpers + MSW handlers for site/offering mute
+
+Pure-function muteUntilFromDuration + isMuted. FOREVER_SENTINEL is
+year 3000 to keep the data model uniform (no nullable sentinel).
+MSW handlers stub both PATCH routes."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 5 — Frontend: `<MuteButton>` component (TDD)
+
+**Files:**
+- Create: `frontend/src/components/common/MuteButton.tsx`
+- Create: `frontend/src/components/common/MuteButton.test.tsx`
+
+End state: `<MuteButton>` is a Popover-based primitive. ~5 new tests pass.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `frontend/src/components/common/MuteButton.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MuteButton } from './MuteButton';
+import { FOREVER_SENTINEL } from '@/lib/mute';
+
+describe('MuteButton', () => {
+  it('renders "Mute" when not muted (null)', () => {
+    render(<MuteButton mutedUntil={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /mute/i })).toBeInTheDocument();
+  });
+
+  it('renders "Mute" when mute timestamp is in the past', () => {
+    const now = new Date();
+    const past = new Date(now.getTime() - 86_400_000).toISOString();
+    render(<MuteButton mutedUntil={past} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /^mute$/i })).toBeInTheDocument();
+  });
+
+  it('renders "Muted until ..." when mute timestamp is in the future', () => {
+    const now = new Date();
+    const future = new Date(now.getTime() + 7 * 86_400_000).toISOString();
+    render(<MuteButton mutedUntil={future} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /muted until/i })).toBeInTheDocument();
+  });
+
+  it('clicking a duration option calls onChange with a future ISO timestamp', async () => {
+    const onChange = vi.fn();
+    render(<MuteButton mutedUntil={null} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /mute/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /7 days/i }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const arg = onChange.mock.calls[0][0];
+    expect(typeof arg).toBe('string');
+    expect(new Date(arg).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('clicking "Forever" calls onChange with the sentinel', async () => {
+    const onChange = vi.fn();
+    render(<MuteButton mutedUntil={null} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /mute/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /forever/i }));
+    expect(onChange).toHaveBeenCalledWith(FOREVER_SENTINEL);
+  });
+
+  it('clicking "Unmute" calls onChange with null', async () => {
+    const onChange = vi.fn();
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    render(<MuteButton mutedUntil={future} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /muted until/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /unmute/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm 6 FAIL**
+
+```bash
+cd frontend && npm run test -- MuteButton
+```
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/common/MuteButton.tsx`:
+
+```tsx
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { Popover } from 'radix-ui';
+import { Button } from '@/components/ui/button';
+import { isMuted, muteUntilFromDuration, type MuteDuration } from '@/lib/mute';
+import { cn } from '@/lib/utils';
+
+interface MuteButtonProps {
+  mutedUntil: string | null;
+  onChange: (mutedUntil: string | null) => void;
+  isPending?: boolean;
+  size?: 'default' | 'sm';
+}
+
+const DURATION_LABELS: Array<{ value: MuteDuration; label: string }> = [
+  { value: '7d', label: '7 days' },
+  { value: '30d', label: '30 days' },
+  { value: '90d', label: '90 days' },
+  { value: 'forever', label: 'Forever' },
+];
+
+export function MuteButton({
+  mutedUntil,
+  onChange,
+  isPending,
+  size = 'default',
+}: MuteButtonProps) {
+  const [open, setOpen] = useState(false);
+  const muted = isMuted(mutedUntil);
+  const label = muted
+    ? `Muted until ${format(new Date(mutedUntil!), 'MMM d')}`
+    : 'Mute';
+
+  const handle = (next: string | null) => {
+    setOpen(false);
+    onChange(next);
+  };
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button
+          size={size}
+          variant={muted ? 'outline' : 'ghost'}
+          disabled={isPending}
+        >
+          {label}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          className={cn(
+            'z-50 rounded-md border border-border bg-popover p-1 shadow-md',
+            'min-w-[10rem] text-sm',
+          )}
+          sideOffset={4}
+          align="end"
+        >
+          {muted ? (
+            <button
+              role="menuitem"
+              type="button"
+              className="block w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+              onClick={() => handle(null)}
+            >
+              Unmute
+            </button>
+          ) : (
+            DURATION_LABELS.map(({ value, label: dLabel }) => (
+              <button
+                key={value}
+                role="menuitem"
+                type="button"
+                className="block w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+                onClick={() => handle(muteUntilFromDuration(value))}
+              >
+                {dLabel}
+              </button>
+            ))
+          )}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+```
+
+Notes:
+- The `Popover` import is the unified `radix-ui` package's namespace (verify the import shape; if `import { Popover } from 'radix-ui'` doesn't work, fall back to `import * as Popover from 'radix-ui/popover'` or check package docs).
+- The `Button` component supports `size` and `variant` props in this codebase. Check its current variants if `'ghost'` doesn't exist (fall back to `'outline'`/`'default'`).
+
+- [ ] **Step 4: Re-run; confirm 6 PASS**
+
+```bash
+cd frontend && npm run test -- MuteButton
+```
+
+If the Popover doesn't render in the test environment (radix Popover.Portal can be finicky in jsdom), the typical fix is to add `<Popover.Anchor>` or use a fixed-position content wrapper. The test's `userEvent.click` triggers the trigger; the portal must mount its children somewhere in the document. If tests fail with "menuitem not found," check:
+1. Is the test environment using `happy-dom` or `jsdom`?
+2. Does the `Popover.Portal` need a specific container prop?
+
+If `Popover.Portal` causes test issues, drop it (render content inline). It's a usability concern in real DOM but not for the test.
+
+- [ ] **Step 5: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 63 passed (57 + 6); clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/components/common/MuteButton.tsx frontend/src/components/common/MuteButton.test.tsx
+git commit -m "feat(frontend): MuteButton presentational primitive
+
+Popover with 4 duration options when unmuted; Unmute action when muted.
+Pure presentation: parent supplies onChange callback. Uses radix-ui's
+Popover primitive directly (no shadcn wrapper)."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 6 — Frontend: mutation hooks (TDD)
+
+**Files:**
+- Modify: `frontend/src/lib/mutations.ts`
+- Modify: `frontend/src/lib/mutations.test.tsx`
+
+End state: `useUpdateSiteMute` + `useUpdateOfferingMute` follow the canonical pattern. ~3 new tests pass.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `frontend/src/lib/mutations.test.tsx`:
+
+```tsx
+import { useUpdateOfferingMute, useUpdateSiteMute } from './mutations';
+
+describe('useUpdateSiteMute', () => {
+  it('PATCHes /api/sites/{id} with the muted_until payload', async () => {
+    const qc = new QueryClient();
+    const { result } = renderHook(() => useUpdateSiteMute(), {
+      wrapper: makeWrapper(qc),
+    });
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    await act(async () => {
+      await result.current.mutateAsync({ siteId: 1, mutedUntil: future });
+    });
+    expect(result.current.isSuccess).toBe(true);
+  });
+});
+
+describe('useUpdateOfferingMute', () => {
+  it('removes match events for the offering optimistically when muting', async () => {
+    const qc = new QueryClient();
+    const matchEvent = {
+      id: 'match:7:2026-04-29',
+      kind: 'match' as const,
+      date: '2026-04-29',
+      time_start: '17:00:00',
+      time_end: '18:00:00',
+      all_day: false,
+      title: 'Soccer',
+      offering_id: 7,
+      score: 0.85,
+    };
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches'],
+      seedCal([matchEvent]),
+    );
+
+    const { result } = renderHook(() => useUpdateOfferingMute(), {
+      wrapper: makeWrapper(qc),
+    });
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    await act(async () => {
+      await result.current.mutateAsync({ offeringId: 7, mutedUntil: future });
+    });
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches',
+    ]);
+    expect(after?.events).toEqual([]);
+  });
+
+  it('does not perform optimistic surgery on unmute (mutedUntil=null)', async () => {
+    const qc = new QueryClient();
+    const matchEvent = {
+      id: 'match:7:2026-04-29',
+      kind: 'match' as const,
+      date: '2026-04-29',
+      time_start: '17:00:00',
+      time_end: '18:00:00',
+      all_day: false,
+      title: 'Soccer',
+      offering_id: 7,
+      score: 0.85,
+    };
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches'],
+      seedCal([matchEvent]),
+    );
+
+    const { result } = renderHook(() => useUpdateOfferingMute(), {
+      wrapper: makeWrapper(qc),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ offeringId: 7, mutedUntil: null });
+    });
+
+    // The match event remains until invalidation refetches it (and our MSW
+    // handler always returns matches when include_matches=true). The
+    // optimistic surgery did not run.
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches',
+    ]);
+    // Either the cache is unchanged from optimistic-skip (event present)
+    // OR invalidation has already refetched. Both are acceptable; the test
+    // asserts no crash + mutation completed successfully.
+    expect(result.current.isSuccess).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm tests FAIL** (hooks not exported):
+
+```bash
+cd frontend && npm run test -- mutations
+```
+
+- [ ] **Step 3: Implement hooks**
+
+Append to `frontend/src/lib/mutations.ts`:
+
+```ts
+interface UpdateSiteMuteInput {
+  siteId: number;
+  mutedUntil: string | null;
+}
+
+export function useUpdateSiteMute() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, UpdateSiteMuteInput>({
+    mutationFn: ({ siteId, mutedUntil }) =>
+      api.patch(`/api/sites/${siteId}`, { muted_until: mutedUntil }),
+
+    onSettled: async (_d, _e, { siteId }) => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['sites'] }),
+        qc.invalidateQueries({ queryKey: ['sites', siteId] }),
+        qc.invalidateQueries({ queryKey: ['kids'] }),
+      ]);
+    },
+  });
+}
+
+interface UpdateOfferingMuteInput {
+  offeringId: number;
+  mutedUntil: string | null;
+}
+
+export function useUpdateOfferingMute() {
+  const qc = useQueryClient();
+  type Ctx = {
+    snapshots: ReadonlyArray<readonly [QueryKey, KidCalendarResponse | undefined]>;
+  };
+  return useMutation<unknown, Error, UpdateOfferingMuteInput, Ctx>({
+    mutationFn: ({ offeringId, mutedUntil }) =>
+      api.patch(`/api/offerings/${offeringId}`, { muted_until: mutedUntil }),
+
+    onMutate: async ({ offeringId, mutedUntil }) => {
+      // Optimistic match removal only when muting; on unmute, no surgery.
+      if (mutedUntil == null) return { snapshots: [] };
+
+      await qc.cancelQueries({ queryKey: ['kids'] });
+      const allKidsQueries = qc.getQueriesData<KidCalendarResponse>({
+        queryKey: ['kids'],
+      });
+      const calendarSnapshots = allKidsQueries.filter(
+        ([key]) => key.length >= 3 && key[2] === 'calendar',
+      );
+
+      for (const [key, data] of calendarSnapshots) {
+        if (!data) continue;
+        const filtered = data.events.filter(
+          (e) => !(e.kind === 'match' && e.offering_id === offeringId),
+        );
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots: calendarSnapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['matches'] }),
+        qc.invalidateQueries({ queryKey: ['kids'] }),
+      ]);
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Re-run; confirm new tests PASS**
+
+```bash
+cd frontend && npm run test -- mutations
+```
+
+Expected: 3 new + 11 from prior phases = 14 mutation tests pass.
+
+- [ ] **Step 5: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 66 passed (63 + 3); clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/lib/mutations.ts frontend/src/lib/mutations.test.tsx
+git commit -m "feat(frontend): useUpdateSiteMute + useUpdateOfferingMute
+
+Both follow the canonical pattern. Site mute: minimal — invalidate
+sites + kids (the calendar match overlay depends on site mute).
+Offering mute: optimistic match removal across all calendar variants
+when muting; no surgery on unmute. Both await invalidation."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 7 — Frontend: wire `<MuteButton>` in three placements
+
+**Files:**
+- Modify: `frontend/src/routes/sites.$id.tsx`
+- Modify: `frontend/src/routes/kids.$id.matches.tsx`
+- Modify: `frontend/src/components/calendar/CalendarEventPopover.tsx`
+- Modify: `frontend/src/components/calendar/CalendarEventPopover.test.tsx`
+
+End state: Mute button appears on site detail, in matches list, and in calendar match popover. ~1 new test for the popover branch.
+
+- [ ] **Step 1: Wire site detail**
+
+Read `frontend/src/routes/sites.$id.tsx` to find the page header. Add:
+
+```tsx
+import { MuteButton } from '@/components/common/MuteButton';
+import { useUpdateSiteMute } from '@/lib/mutations';
+```
+
+In the page component:
+
+```tsx
+const muteSite = useUpdateSiteMute();
+// ...
+<MuteButton
+  mutedUntil={site.muted_until ?? null}
+  onChange={(mutedUntil) => muteSite.mutate({ siteId, mutedUntil })}
+  isPending={muteSite.isPending}
+/>
+```
+
+Place next to the site name heading. The Site type already has `muted_until: string | null`.
+
+- [ ] **Step 2: Extend `OfferingSummary` with `muted_until` (REQUIRED — not present today)**
+
+Verified at plan time: `OfferingSummary` in `src/yas/web/routes/matches_schemas.py` does NOT include `muted_until`. It must be added so the matches list can read it.
+
+a. In `src/yas/web/routes/matches_schemas.py`, add to `OfferingSummary`:
+```python
+muted_until: datetime | None = None
+```
+
+b. The route handler in `src/yas/web/routes/matches.py` constructs `offering_data` by iterating `OfferingSummary.model_fields`. Verify the iteration picks up the new field automatically (it should — Pydantic v2 includes all declared fields). If the route uses an explicit exclusion list (e.g., `if k not in (...)`) update that list. Re-run `tests/integration/test_api_matches.py` (or equivalent) to confirm the field appears in responses with the right value.
+
+c. In `frontend/src/lib/types.ts`, append to the `OfferingSummary` interface:
+```ts
+muted_until: string | null;
+```
+
+d. Run backend gates and frontend typecheck — both should remain clean.
+
+Commit this sub-step separately:
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git add src/yas/web/routes/matches_schemas.py frontend/src/lib/types.ts
+# include matches.py if you needed to update the iteration logic
+git commit -m "feat(api): expose muted_until on OfferingSummary
+
+Required for the matches list MuteButton wiring in 5d-1."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+- [ ] **Step 2b: Wire matches list**
+
+Read `frontend/src/routes/kids.$id.matches.tsx`. Each match row currently renders the offering name + score.
+
+Wire:
+
+```tsx
+import { MuteButton } from '@/components/common/MuteButton';
+import { useUpdateOfferingMute } from '@/lib/mutations';
+
+// inside the page component:
+const muteOffering = useUpdateOfferingMute();
+
+// inside the row render:
+<MuteButton
+  size="sm"
+  mutedUntil={match.offering.muted_until ?? null}
+  onChange={(mutedUntil) =>
+    muteOffering.mutate({ offeringId: match.offering.id, mutedUntil })
+  }
+  isPending={muteOffering.isPending}
+/>
+```
+
+- [ ] **Step 3: Wire calendar popover (TDD)**
+
+First, append a test to `frontend/src/components/calendar/CalendarEventPopover.test.tsx`:
+
+```tsx
+it('renders Mute button on match events', () => {
+  renderPopover(matchEvent);
+  expect(screen.getByRole('button', { name: /^mute$/i })).toBeInTheDocument();
+});
+```
+
+Run:
+```bash
+cd frontend && npm run test -- CalendarEventPopover
+```
+Expected: 1 fail.
+
+Then update `frontend/src/components/calendar/CalendarEventPopover.tsx`. Add the import:
+
+```tsx
+import { MuteButton } from '@/components/common/MuteButton';
+import { useUpdateOfferingMute } from '@/lib/mutations';
+```
+
+In the component body, alongside the existing mutations:
+
+```tsx
+const muteOffering = useUpdateOfferingMute();
+```
+
+Update `inFlight`:
+
+```tsx
+const inFlight = cancel.isPending || del.isPending || enroll.isPending || muteOffering.isPending;
+```
+
+In the `useEffect` reset block, also reset:
+
+```tsx
+muteOffering.reset();
+```
+
+Add a handler:
+
+```tsx
+const handleMute = (mutedUntil: string | null) => {
+  if (!event?.offering_id) return;
+  setErrorMsg(null);
+  muteOffering.mutate(
+    { offeringId: event.offering_id, mutedUntil },
+    {
+      onSuccess: onClose,
+      onError: (err) => setErrorMsg(err.message || 'Failed to update mute'),
+    },
+  );
+};
+```
+
+In the match-branch action `<div>`, add the MuteButton next to Enroll + View details:
+
+```tsx
+{isMatch && (
+  <>
+    <Button onClick={handleEnroll} disabled={inFlight}>
+      Enroll
+    </Button>
+    {/* mutedUntil hardcoded null: muted matches are filtered out
+        server-side (spec Q4), so the popover never shows a muted match.
+        The button always renders the duration picker, never Unmute. */}
+    <MuteButton
+      mutedUntil={null}
+      onChange={handleMute}
+      isPending={muteOffering.isPending}
+    />
+    {event.registration_url && (
+      <a ...>View details ↗</a>
+    )}
+  </>
+)}
+```
+
+- [ ] **Step 4: Run all popover tests**
+
+```bash
+cd frontend && npm run test -- CalendarEventPopover
+```
+
+Expected: 8 passed (7 from prior + 1 new).
+
+- [ ] **Step 5: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 67 passed (66 + 1); clean. (If Step 2 required schema extension, expect a slightly different total — verify by counting after the gates run.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+cd /Users/owine/Git/youth-activity-scheduler
+git add frontend/src/routes/sites.\$id.tsx 'frontend/src/routes/kids.$id.matches.tsx' frontend/src/components/calendar/CalendarEventPopover.tsx frontend/src/components/calendar/CalendarEventPopover.test.tsx
+# also add any backend schema changes from Step 2 (matches_schemas.py + types.ts)
+git commit -m "feat(frontend): wire MuteButton in site detail, matches list, calendar popover
+
+Three placements per spec §4. Calendar popover always shows Mute (not
+Unmute) because muted matches don't appear on the calendar in the
+first place — server filters them out."
+git cat-file commit HEAD | grep -q '^gpgsig ' && echo signed
+```
+
+---
+
+## Task 8 — Final exit gates + manual smoke + push + PR
+
+End state: All exit criteria from spec §10 verified.
+
+- [ ] **Step 1: Backend gates**
+
+```bash
+uv run pytest -q --no-cov && uv run ruff check . && uv run ruff format --check . && uv run mypy src
+```
+
+Expected: 585 passed; clean.
+
+- [ ] **Step 2: Frontend gates**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 67 passed; clean.
+
+- [ ] **Step 3: Manual smoke**
+
+In one terminal:
+```bash
+YAS_DATABASE_URL="sqlite+aiosqlite:///$(pwd)/data/activities.db" YAS_ANTHROPIC_API_KEY=sk-test uv run uvicorn --factory yas.web.app:create_app --port 8080
+```
+
+(Note: the project's `create_app` is a factory, not a module-level `app` — use `--factory`.)
+
+In another:
+```bash
+cd frontend && npm run dev
+```
+
+Walk through:
+1. Navigate to `/sites/1` (use a real site id). Click Mute → 7 days. Button label flips to "Muted until {date}". Click again → Unmute. Button reverts to "Mute".
+2. Navigate to `/kids/1/matches`. Mute a match. Row's button label flips. Match remains in the list.
+3. Navigate to `/kids/1/calendar`. Toggle "Show matches". The match you muted in step 2 should NOT appear.
+4. Click another match (one not muted). Popover opens with Enroll + Mute buttons + (optional) View details. Click Mute → 30 days. Match disappears from grid optimistically. Popover closes.
+5. Backend: query `/api/alerts` directly to confirm no new_match alerts have fired for the muted offering since the mute.
+
+If anything breaks, capture the failure in a regression test before fixing.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+git push -u origin phase-5d-1-site-offering-mute
+gh pr create --title "phase 5d-1: site/offering alert mute (one-click)" --body "$(cat <<'EOF'
+## Summary
+
+- **Backend:** wired `Site.muted_until` and `Offering.muted_until` into the alert pipeline (6 enqueue functions gated). New `PATCH /api/offerings/{id}` route. Calendar match overlay now excludes muted offerings + offerings whose site is muted.
+- **Frontend:** new `<MuteButton>` primitive (popover with 4-option duration picker + Unmute action). Two new mutation hooks following the canonical pattern. Wired in three placements: site detail, matches list, calendar event popover.
+
+Closes the v1 terminal-state criterion: *"User can disable alerts from a specific site or offering with one click."* — v1 functional scope is now complete.
+
+## Test plan
+
+- [x] uv run pytest -q (585 passed; +18 backend tests)
+- [x] uv run ruff check . && uv run ruff format --check . clean
+- [x] uv run mypy src clean
+- [x] cd frontend && npm run typecheck clean
+- [x] cd frontend && npm run lint clean
+- [x] cd frontend && npm run test (67 passed; +18 frontend tests)
+- [ ] CI passes
+- [ ] Manual smoke: mute a site → no new alerts; mute a match → vanishes from calendar; unmute → returns
+
+## Spec / plan
+
+- Spec: `docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md`
+- Plan: `docs/superpowers/plans/2026-04-29-phase-5d-1-site-offering-mute.md`
+
+## Out of scope (deferred)
+
+- Mute reasons / notes
+- Per-channel mute
+- Bulk mute / multi-select
+- Auto-unmute notifications
+- Mute history audit log
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for CI; merge with `--squash`** (project convention).
+
+---
+
+## Notes for the implementer
+
+- **`enqueue_watchlist_hit` return type widens.** From `int` to `int | None`. Most call sites ignore the return; mypy will catch any that don't. Update them by adding `if id_ is not None:` guards or by simply ignoring the return.
+- **The `_is_muted` helper is offering-targeted** (joins Site automatically). The `_is_site_muted` helper is site-targeted. Don't conflate them; the wrong helper produces wrong gates.
+- **Frontend `useUpdateOfferingMute` only does optimistic surgery on mute, not on unmute.** Unmuting a match wouldn't add it back to the calendar without a server round-trip anyway (we don't know the score, the offering metadata, etc.), so the invalidate handles it.
+- **MuteButton's `Popover.Portal`** can be tricky in jsdom. If tests fail at "menuitem not found" the simplest fix is to drop the Portal (render content inline). Verify in real DOM during smoke.
+- **Year-3000 sentinel** for forever-mute is intentional — keeps the data model uniform (`muted_until` is always either null or a comparable timestamp). Don't add a separate boolean column.
+- **No new backend deps. No new frontend deps.** `radix-ui` 1.4.3 is already pinned.
+- **Sites/Offerings test_api_offerings.py** uses the existing test pattern from `test_api_kids_calendar.py` — `client` fixture with `tmp_path` SQLite, `_seed`-style helpers. Follow that style.

--- a/docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md
+++ b/docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md
@@ -1,0 +1,413 @@
+# Phase 5d-1 — Site/Offering Alert Mute (Design)
+
+**Status:** Approved (brainstorming complete 2026-04-29).
+**Predecessors (already merged):**
+- Phase 5b-1b — canonical TanStack Query mutation pattern.
+- Phase 5c-2 — calendar match overlay (this slice extends its filter logic).
+**Master design:** `docs/superpowers/specs/2026-04-21-youth-activity-scheduler-design.md` §10. Closes the v1 terminal-state criterion: *"User can disable alerts from a specific site or offering with one click."*
+**Succeeds into:** No immediate successor planned. After this slice, v1 is functionally complete.
+
+## 1. Purpose and scope
+
+Wire `Site.muted_until` and `Offering.muted_until` (model columns that already exist) into the alert-firing pipeline and the calendar match overlay, then build a single small UI primitive (`<MuteButton>`) that ships in three places: site detail page, matches list, calendar match popover.
+
+`Site.muted_until` is partially honored today (crawl scheduler skips muted sites; site-stagnant detector skips muted sites). `Offering.muted_until` is an orphan column with no enforcement. Neither has UI affordances.
+
+### 1.1 In scope
+
+- **Backend alert pipeline** — extend `enqueue_new_match` and `enqueue_watchlist_hit` in `src/yas/alerts/enqueuer.py` to skip alerts when either the offering or its parent site is currently muted.
+- **Backend offering route** — new `PATCH /api/offerings/{offering_id}` accepting `{ muted_until: datetime | null }`. Initial scope is mute only; future fields land in the same patch.
+- **Backend calendar overlay filter** — extend `GET /api/kids/{id}/calendar?include_matches=true` to exclude muted offerings (and offerings whose site is muted).
+- **Frontend `<MuteButton>` component** — popover with 4 duration options (7d / 30d / 90d / forever) when unmuted; "Muted until {date}" + Unmute action when muted. Pure UI; the parent owns the mutation.
+- **Two mutation hooks** — `useUpdateSiteMute`, `useUpdateOfferingMute`. Follow the canonical 5b-1b/5c-1 pattern (cancelQueries → snapshot → optimistic where helpful → onError restore → awaited onSettled invalidate).
+- **Three UI placements** — site detail page (`sites.$id.tsx`), matches list (`kids.$id.matches.tsx`), calendar event popover (match branch only).
+
+### 1.2 Out of scope
+
+- **Mute reasons or notes.** No `mute_reason` column. The user can remember.
+- **Per-channel mute.** No "no push but yes email" granularity. v1 stays on the existing routing model.
+- **Bulk mute / multi-select.** Single-row clicks only.
+- **Auto-unmute notifications.** No "muted offerings about to unmute" reminder.
+- **Mute history audit log.** The `muted_until` column is the source of truth.
+- **"Show muted" toggle on the matches page.** Matches list shows everything regardless of mute (it's the find/manage surface). Mute affects alerts and calendar visibility, not matches list visibility.
+- **Mute on enrolled offerings as a UI affordance.** The data layer handles it correctly (enrolled offerings produce no future new_match alerts anyway because the matcher excludes them); we don't surface a mute button on enrollment events. The matches list and site detail page can still mute an offering you happen to be enrolled in — that's harmless.
+
+## 2. Mute semantics (Q1: A — suppress all alerts)
+
+A row whose `muted_until` is set to a future timestamp is "muted." When evaluating whether to fire an alert about an offering:
+
+```
+muted := (offering.muted_until > now) OR (offering.site.muted_until > now)
+if muted: skip
+```
+
+This applies to **`new_match`** and **`watchlist_hit`** alert types. Watchlist hits previously bypassed `kid.alert_on` because the user explicitly added the watchlist entry — mute is a stronger signal ("user changed their mind") and overrides. The function's docstring will be updated to reflect this.
+
+`schedule_posted` (site-level, not offering-level) is gated by `Site.muted_until` only — already covered by the existing site-level mute path conceptually, but **not yet implemented** in the enqueuer. Add the same gate there.
+
+`site_stagnant` already honors `Site.muted_until` via `src/yas/alerts/detectors/site_stagnant.py:26`. No change needed.
+
+`reg_opens_24h` / `reg_opens_1h` / `reg_opens_now` — these alerts fire for matches whose offering has `registration_opens_at` set. Apply the same `_is_muted` gate. (The enqueuer file has these paths; identify them during implementation and gate uniformly.)
+
+`crawl_failed` — site-level operational alert. Should also respect site mute (a site muted because it's broken shouldn't keep alerting that it's broken).
+
+`digest`, `no_matches_for_kid`, `push_cap` — kid- or system-level, not site/offering-targeted. No change.
+
+## 3. Mute duration (Q2: B — duration picker, 4 options)
+
+The UI picker offers four buttons:
+
+| Label | `muted_until` value |
+|---|---|
+| 7 days | `now() + 7 days` |
+| 30 days | `now() + 30 days` |
+| 90 days | `now() + 90 days` |
+| Forever | `3000-01-01T00:00:00Z` (sentinel constant) |
+
+Forever is a sentinel rather than `NULL`-or-true-forever to keep the data model uniform. The frontend `isMuted(mutedUntil)` helper just compares to `now`; the year-3000 sentinel is functionally indistinguishable from "true forever" within any plausible app lifetime. Unmuting writes `null`.
+
+Date math lives in `frontend/src/lib/mute.ts`:
+
+```ts
+export const FOREVER_SENTINEL = '3000-01-01T00:00:00Z';
+
+export function muteUntilFromDuration(duration: '7d' | '30d' | '90d' | 'forever', now: Date = new Date()): string {
+  if (duration === 'forever') return FOREVER_SENTINEL;
+  const days = { '7d': 7, '30d': 30, '90d': 90 }[duration];
+  const out = new Date(now);
+  out.setDate(out.getDate() + days);
+  return out.toISOString();
+}
+
+export function isMuted(mutedUntil: string | null, now: Date = new Date()): boolean {
+  if (mutedUntil == null) return false;
+  return new Date(mutedUntil) > now;
+}
+```
+
+## 4. UI placement (Q3: B)
+
+### 4.1 `<MuteButton>` component
+
+`frontend/src/components/common/MuteButton.tsx` — the only new presentational primitive in this slice.
+
+```tsx
+interface MuteButtonProps {
+  mutedUntil: string | null;       // ISO timestamp or null
+  onChange: (mutedUntil: string | null) => void;  // null = unmute
+  isPending?: boolean;
+  size?: 'default' | 'sm';
+}
+```
+
+Renders a Popover trigger button:
+- **Unmuted**: button label "Mute". Click opens picker with 4 duration buttons. Selecting one calls `onChange(muteUntilFromDuration(...))`.
+- **Muted**: button label "Muted until {Mar 28}" (formatted with `date-fns`). Click opens menu with single "Unmute" action calling `onChange(null)`.
+
+Uses the unified `radix-ui` package's Popover primitive (`import { Popover } from 'radix-ui'`) directly — no shadcn wrapper because the project doesn't have one in `components/ui/` yet, and the radix primitive is sufficient for this small popover. Style via Tailwind classes consistent with existing `Button` + Sheet primitives.
+
+The component is purely presentational. Mutation, error handling, optimistic state belong to the parent.
+
+### 4.2 Site detail page
+
+`frontend/src/routes/sites.$id.tsx` — gains `<MuteButton>` in the page header alongside the site name. Wires to `useUpdateSiteMute` (Section 5).
+
+### 4.3 Matches list
+
+`frontend/src/routes/kids.$id.matches.tsx` — each match row gains a small (`size="sm"`) `<MuteButton>` on the right side. Wires to `useUpdateOfferingMute`. Muting a match in the list updates the row's button label but does NOT remove the row from the list (matches page is the find/manage surface).
+
+### 4.4 Calendar event popover (match branch only)
+
+`frontend/src/components/calendar/CalendarEventPopover.tsx` — the `kind === 'match'` branch gains a `<MuteButton>` alongside the existing Enroll button + View details link. Wires to `useUpdateOfferingMute`.
+
+After clicking a duration, the calendar query gets invalidated (Section 6); on the next render, the muted offering's match events vanish from the calendar (per Q4: muted offerings hidden from match overlay), and the popover closes when its `event` becomes null upstream. To prevent a flicker (popover open with no event), the mutation hook does NOT close the popover synchronously — the parent route handles selection cleanup via the existing `selected !== null` plumbing. Actually, for cleanest UX: after a successful mute mutation, the popover's `onSuccess` callback clears the local selection and closes the popover. Same pattern as the existing Enroll branch.
+
+The popover does NOT show an Unmute button on muted matches because muted matches don't appear on the calendar in the first place. To unmute an offering, the user goes to the matches list or site detail page.
+
+## 5. Mutation hooks
+
+`frontend/src/lib/mutations.ts` adds two hooks. Same canonical shape as the existing `useCancelEnrollment`, etc.
+
+### 5.1 `useUpdateSiteMute`
+
+```ts
+interface UpdateSiteMuteInput {
+  siteId: number;
+  mutedUntil: string | null;   // ISO timestamp or null
+}
+
+export function useUpdateSiteMute() {
+  const qc = useQueryClient();
+  type Ctx = { /* no optimistic cache surgery for site mute — just invalidate */ };
+  return useMutation<unknown, Error, UpdateSiteMuteInput, Ctx>({
+    mutationFn: ({ siteId, mutedUntil }) =>
+      api.patch(`/api/sites/${siteId}`, { muted_until: mutedUntil }),
+
+    onSettled: async (_d, _e, { siteId }) => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['sites'] }),
+        qc.invalidateQueries({ queryKey: ['sites', siteId] }),
+        qc.invalidateQueries({ queryKey: ['kids'] }),  // calendar match overlay depends on this
+      ]);
+    },
+  });
+}
+```
+
+No optimistic surgery: the `MuteButton`'s local `isPending` covers visual feedback; site/offering rows don't need pre-confirmation removal.
+
+### 5.2 `useUpdateOfferingMute`
+
+```ts
+interface UpdateOfferingMuteInput {
+  offeringId: number;
+  mutedUntil: string | null;
+}
+
+export function useUpdateOfferingMute() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, UpdateOfferingMuteInput, { snapshots: ... }>({
+    mutationFn: ({ offeringId, mutedUntil }) =>
+      api.patch(`/api/offerings/${offeringId}`, { muted_until: mutedUntil }),
+
+    onMutate: async ({ offeringId, mutedUntil }) => {
+      // Optimistic: when muting (mutedUntil != null), remove match events for
+      // this offering from cached calendar variants — same pattern as
+      // useEnrollOffering. When unmuting (mutedUntil == null), no surgery.
+      if (mutedUntil == null) return { snapshots: [] };
+      await qc.cancelQueries({ queryKey: ['kids'] });
+      const snapshots = qc.getQueriesData<KidCalendarResponse>({ queryKey: ['kids'] });
+      for (const [key, data] of snapshots) {
+        if (!data) continue;
+        if (key[2] !== 'calendar') continue;
+        const filtered = data.events.filter(
+          (e) => !(e.kind === 'match' && e.offering_id === offeringId),
+        );
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots?.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['matches'] }),
+        qc.invalidateQueries({ queryKey: ['kids'] }),
+      ]);
+    },
+  });
+}
+```
+
+The optimistic match-removal mirrors `useEnrollOffering` from 5c-2 — same problem (remove a match from the calendar grid before server confirms).
+
+## 6. Backend changes
+
+### 6.1 Enqueuer gate
+
+`src/yas/alerts/enqueuer.py` adds:
+
+```python
+async def _is_muted(session: AsyncSession, *, offering_id: int) -> bool:
+    """True if the offering or its parent site is currently muted."""
+    now = datetime.now(UTC)
+    row = (
+        await session.execute(
+            select(Offering.muted_until, Site.muted_until)
+            .join(Site, Site.id == Offering.site_id)
+            .where(Offering.id == offering_id)
+        )
+    ).one_or_none()
+    if row is None:
+        return False
+    o_muted, s_muted = row
+    return (o_muted is not None and o_muted > now) or (s_muted is not None and s_muted > now)
+
+
+async def _is_site_muted(session: AsyncSession, *, site_id: int) -> bool:
+    """True if the site is currently muted."""
+    now = datetime.now(UTC)
+    s_muted = (
+        await session.execute(select(Site.muted_until).where(Site.id == site_id))
+    ).scalar_one_or_none()
+    return s_muted is not None and s_muted > now
+```
+
+Insertion points:
+- `enqueue_new_match` — call `_is_muted(session, offering_id=offering_id)` after the `_kid_alert_on` check; return None if muted.
+- `enqueue_watchlist_hit` — same insertion.
+- `enqueue_schedule_posted` — call `_is_site_muted(session, site_id=site_id)`; return None if muted.
+- Reg-opens enqueue paths (find them during implementation; gate the same way as new_match).
+- `enqueue_crawl_failed` (or whatever fires `crawl_failed`) — gate on `_is_site_muted`.
+
+### 6.2 Offering route
+
+New file `src/yas/web/routes/offerings.py`:
+
+```python
+"""CRUD for /api/offerings — initial scope: mute toggle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from yas.db.models import Offering
+from yas.db.session import session_scope
+
+router = APIRouter(prefix="/api/offerings", tags=["offerings"])
+
+
+def _engine(req: Request) -> AsyncEngine:
+    engine: AsyncEngine = req.app.state.yas.engine
+    return engine
+
+
+class OfferingPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    muted_until: datetime | None = None
+
+
+class OfferingMuteOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    name: str
+    site_id: int
+    muted_until: datetime | None
+
+
+@router.patch("/{offering_id}", response_model=OfferingMuteOut)
+async def update_offering(
+    request: Request,
+    offering_id: int,
+    payload: OfferingPatch,
+) -> OfferingMuteOut:
+    async with session_scope(_engine(request)) as s:
+        offering = (
+            await s.execute(select(Offering).where(Offering.id == offering_id))
+        ).scalar_one_or_none()
+        if offering is None:
+            raise HTTPException(status_code=404, detail=f"offering {offering_id} not found")
+        if "muted_until" in payload.model_fields_set:
+            offering.muted_until = payload.muted_until
+        await s.flush()
+        await s.refresh(offering)
+        return OfferingMuteOut.model_validate(offering)
+```
+
+Register the router in `src/yas/web/app.py` alongside the others.
+
+The `model_fields_set` guard is so a future `PATCH` body that doesn't include `muted_until` won't accidentally null it out. (Pydantic v2 idiom.)
+
+The `await s.refresh(offering)` after flush mirrors the SQLite-tz-roundtrip lesson from 5b-1a: returning the just-refreshed row keeps response timestamps consistent with what comes back on the next read.
+
+### 6.3 Calendar match-overlay filter
+
+`src/yas/web/routes/kid_calendar.py` — extend the `select(Match, Offering)` query in the `if include_matches:` block:
+
+```python
+from sqlalchemy import or_, select  # add or_ to imports if not already there
+
+# inside the include_matches block:
+match_rows = (
+    await s.execute(
+        select(Match, Offering)
+        .join(Offering, Offering.id == Match.offering_id)
+        .join(Site, Site.id == Offering.site_id)
+        .where(Match.kid_id == kid_id)
+        .where(Match.score >= _MATCH_THRESHOLD)
+        .where(~Match.offering_id.in_(committed_offering_ids))
+        .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= datetime.now(UTC)))
+        .where(or_(Site.muted_until.is_(None), Site.muted_until <= datetime.now(UTC)))
+    )
+).all()
+```
+
+(Use the `now` variable already in scope at the top of the route handler — capture once, reuse.)
+
+### 6.4 No new dependencies
+
+All work in this slice uses existing libraries.
+
+## 7. Edge cases
+
+- **Mute date in the past**: `_is_muted` returns false; effectively unmuted. Treat past-dated mutes as expired. The frontend's "Forever" sentinel (year 3000) avoids this ambiguity; if a mute happens to expire while the popover is open, the next render correctly shows it as unmuted.
+- **Site muted, individual offering also muted**: either condition suffices; no precedence needed.
+- **Mute an enrolled offering**: data-layer no-op (the matcher already excludes enrolled offerings from match production, and enrollment events on the calendar don't depend on mute). UI doesn't surface a mute button on enrollment events.
+- **Concurrent mute clicks**: `isPending` disables the button; second click ignored.
+- **Calendar match popover open on a match that just got muted in another tab**: stale render; no auto-refetch on calendar route. Acceptable for single-household.
+- **`Offering.muted_until` set in the past via direct API**: `_is_muted` correctly treats as unmuted. UI's `isMuted` helper agrees.
+- **Race: site mute → offering on that site has a pending watchlist_hit alert that was already inserted**: existing alerts in the queue fire normally (the worker's delivery loop doesn't re-check mute state — by design, it's a delivery system, not a policy engine). Mute affects future enqueues only. This matches how 5b-1b's worker change handles closed alerts (filtered at the worker query level for closed; for mute we filter at enqueue time).
+
+Wait — that's actually a question. Should the worker also re-check mute at delivery time? The 5b-1b worker change filtered out closed alerts at the worker query. Mute is similar in spirit. Decision: NO, mute filters at enqueue time only. Reasoning:
+1. If a user mutes a site, they don't want NEW alerts. Pending alerts for the site/offering may already represent something the user wants to know about (the user enqueued the watchlist).
+2. Symmetry with 5b-1a/b: close was specifically a user-driven "I'm done with this alert"; the worker filter on `closed_at IS NULL` was specifically for that lifecycle. Mute is a different mechanism (suppressing future enqueues), not a per-alert state.
+3. Adding a worker-side mute check duplicates logic for limited benefit.
+
+Document this explicitly in the spec so a future reviewer doesn't think it's an oversight.
+
+## 8. Testing
+
+Backend:
+1. `tests/integration/test_alerts_enqueuer.py` (extend) —
+   - `enqueue_new_match` returns None when offering muted, when site muted, when both muted; enqueues normally when both unmuted; enqueues normally when `muted_until` in the past.
+   - Same coverage for `enqueue_watchlist_hit`.
+   - `enqueue_schedule_posted` returns None when site muted.
+   - (Reg-opens variants similar.)
+2. `tests/integration/test_api_offerings.py` (new) — `PATCH /api/offerings/{id}`:
+   - 404 for unknown id.
+   - 422 when body has unknown fields (Pydantic `extra="forbid"`).
+   - Setting `muted_until` to a future timestamp persists.
+   - Setting `muted_until` to null clears the field.
+   - Empty body: no change to `muted_until` (model_fields_set guard).
+3. `tests/integration/test_api_kids_calendar.py` (extend) —
+   - Match overlay excludes a muted offering.
+   - Match overlay excludes an offering whose site is muted.
+   - Match overlay includes an offering whose `muted_until` is in the past.
+
+Frontend:
+4. `frontend/src/lib/mute.test.ts` (new) — pure-function tests for `muteUntilFromDuration` (4 durations) and `isMuted` (null, past, future, sentinel).
+5. `frontend/src/components/common/MuteButton.test.tsx` (new) —
+   - Renders "Mute" when `mutedUntil` is null or in the past.
+   - Renders "Muted until {date}" when `mutedUntil` is in the future.
+   - Clicking a duration option fires `onChange` with the right ISO string.
+   - Clicking Unmute fires `onChange(null)`.
+6. `frontend/src/lib/mutations.test.tsx` (extend) — `useUpdateSiteMute` and `useUpdateOfferingMute`: PATCH fires with right payload; `useUpdateOfferingMute` optimistic match-removal works; rollback on error.
+7. MSW handlers: `PATCH /api/sites/:id` (already exists?) and `PATCH /api/offerings/:id` (new).
+
+Manual smoke (before merge):
+- Mute a site from sites detail → site row reflects state.
+- Wait/seed a new_match condition → no alert fires (verify via /api/alerts list).
+- Mute an offering from matches list → button label flips.
+- Toggle "Show matches" on calendar → muted offering's match doesn't appear.
+- Unmute → match returns.
+
+## 9. Open questions
+
+None blocking. All four brainstorming decisions captured:
+
+- **Q1** (mute scope): suppresses ALL alerts touching site/offering. §2.
+- **Q2** (duration): 4-option picker (7d/30d/90d/forever). §3.
+- **Q3** (UI placement): site detail + matches list + calendar popover. §4.
+- **Q4** (calendar match overlay): muted offerings hidden. §6.3.
+
+## 10. Exit criteria
+
+Phase 5d-1 is complete when:
+
+- `Offering.muted_until` is enforced in `enqueue_new_match`, `enqueue_watchlist_hit`, and reg-opens variants; `Site.muted_until` is enforced in those + `enqueue_schedule_posted` + `enqueue_crawl_failed` (where applicable).
+- `PATCH /api/offerings/{offering_id}` works and is tested.
+- Calendar match overlay excludes muted offerings (and offerings whose site is muted).
+- `<MuteButton>` is implemented, tested, and used in three placements (site detail, matches list, calendar popover).
+- `useUpdateSiteMute` and `useUpdateOfferingMute` follow the canonical pattern.
+- All backend gates green.
+- All frontend gates green.
+- Manual smoke verified.
+- Closes the v1 terminal-state criterion: *"User can disable alerts from a specific site or offering with one click."*

--- a/docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md
+++ b/docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md
@@ -120,7 +120,7 @@ The component is purely presentational. Mutation, error handling, optimistic sta
 
 `frontend/src/components/calendar/CalendarEventPopover.tsx` — the `kind === 'match'` branch gains a `<MuteButton>` alongside the existing Enroll button + View details link. Wires to `useUpdateOfferingMute`.
 
-After clicking a duration, the calendar query gets invalidated (Section 6); on the next render, the muted offering's match events vanish from the calendar (per Q4: muted offerings hidden from match overlay), and the popover closes when its `event` becomes null upstream. To prevent a flicker (popover open with no event), the mutation hook does NOT close the popover synchronously — the parent route handles selection cleanup via the existing `selected !== null` plumbing. Actually, for cleanest UX: after a successful mute mutation, the popover's `onSuccess` callback clears the local selection and closes the popover. Same pattern as the existing Enroll branch.
+After clicking a duration, the popover's `onSuccess` callback clears the local selection and closes the popover (same pattern as the existing Enroll branch). The mutation also invalidates the calendar query so when the popover re-opens later, the muted offering's match events are gone (per Q4: muted offerings hidden from match overlay).
 
 The popover does NOT show an Unmute button on muted matches because muted matches don't appear on the calendar in the first place. To unmute an offering, the user goes to the matches list or site detail page.
 
@@ -236,12 +236,13 @@ async def _is_site_muted(session: AsyncSession, *, site_id: int) -> bool:
     return s_muted is not None and s_muted > now
 ```
 
-Insertion points:
-- `enqueue_new_match` — call `_is_muted(session, offering_id=offering_id)` after the `_kid_alert_on` check; return None if muted.
-- `enqueue_watchlist_hit` — same insertion.
-- `enqueue_schedule_posted` — call `_is_site_muted(session, site_id=site_id)`; return None if muted.
-- Reg-opens enqueue paths (find them during implementation; gate the same way as new_match).
-- `enqueue_crawl_failed` (or whatever fires `crawl_failed`) — gate on `_is_site_muted`.
+Insertion points (all in `src/yas/alerts/enqueuer.py`):
+- `enqueue_new_match` (offering-targeted) — call `_is_muted(session, offering_id=offering_id)` after the `_kid_alert_on` check; return None if muted.
+- `enqueue_watchlist_hit` (offering-targeted) — same insertion.
+- `enqueue_registration_countdowns` (offering-targeted) — gate via `_is_muted` once per offering, before the inner loop emits the three countdown variants.
+- `enqueue_schedule_posted` (site-targeted) — call `_is_site_muted(session, site_id=site_id)`; return None if muted.
+- `enqueue_crawl_failed` (site-targeted) — same `_is_site_muted` gate.
+- `enqueue_site_stagnant` (site-targeted) — already gated upstream by the detector (`alerts/detectors/site_stagnant.py:26`), but adding the same `_is_site_muted` gate here is harmless defense-in-depth and keeps the enqueuer module uniform. Decision: add it.
 
 ### 6.2 Offering route
 
@@ -312,8 +313,10 @@ The `await s.refresh(offering)` after flush mirrors the SQLite-tz-roundtrip less
 
 `src/yas/web/routes/kid_calendar.py` — extend the `select(Match, Offering)` query in the `if include_matches:` block:
 
+The route handler already captures `now = datetime.now(UTC)` once at the top — reuse it (don't call `datetime.now(UTC)` per row):
+
 ```python
-from sqlalchemy import or_, select  # add or_ to imports if not already there
+from sqlalchemy import or_, select  # add or_ to imports
 
 # inside the include_matches block:
 match_rows = (
@@ -324,13 +327,11 @@ match_rows = (
         .where(Match.kid_id == kid_id)
         .where(Match.score >= _MATCH_THRESHOLD)
         .where(~Match.offering_id.in_(committed_offering_ids))
-        .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= datetime.now(UTC)))
-        .where(or_(Site.muted_until.is_(None), Site.muted_until <= datetime.now(UTC)))
+        .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= now))
+        .where(or_(Site.muted_until.is_(None), Site.muted_until <= now))
     )
 ).all()
 ```
-
-(Use the `now` variable already in scope at the top of the route handler — capture once, reuse.)
 
 ### 6.4 No new dependencies
 
@@ -344,14 +345,10 @@ All work in this slice uses existing libraries.
 - **Concurrent mute clicks**: `isPending` disables the button; second click ignored.
 - **Calendar match popover open on a match that just got muted in another tab**: stale render; no auto-refetch on calendar route. Acceptable for single-household.
 - **`Offering.muted_until` set in the past via direct API**: `_is_muted` correctly treats as unmuted. UI's `isMuted` helper agrees.
-- **Race: site mute → offering on that site has a pending watchlist_hit alert that was already inserted**: existing alerts in the queue fire normally (the worker's delivery loop doesn't re-check mute state — by design, it's a delivery system, not a policy engine). Mute affects future enqueues only. This matches how 5b-1b's worker change handles closed alerts (filtered at the worker query level for closed; for mute we filter at enqueue time).
-
-Wait — that's actually a question. Should the worker also re-check mute at delivery time? The 5b-1b worker change filtered out closed alerts at the worker query. Mute is similar in spirit. Decision: NO, mute filters at enqueue time only. Reasoning:
-1. If a user mutes a site, they don't want NEW alerts. Pending alerts for the site/offering may already represent something the user wants to know about (the user enqueued the watchlist).
-2. Symmetry with 5b-1a/b: close was specifically a user-driven "I'm done with this alert"; the worker filter on `closed_at IS NULL` was specifically for that lifecycle. Mute is a different mechanism (suppressing future enqueues), not a per-alert state.
-3. Adding a worker-side mute check duplicates logic for limited benefit.
-
-Document this explicitly in the spec so a future reviewer doesn't think it's an oversight.
+- **Race: site mute → offering on that site has a pending alert already inserted**: pending alerts in the queue fire normally. **Decision: mute filters at enqueue time only; the delivery worker does NOT re-check mute.** Rationale:
+  1. If a user mutes a site, they want NO new alerts. A pending alert was enqueued before the mute and may represent something the user explicitly asked about (e.g., a watchlist hit). Suppressing it at delivery time would feel surprising.
+  2. Symmetry with 5b-1a/b is intentionally only partial: `closed_at IS NULL` is a per-alert lifecycle state and the worker correctly gates on it. Mute is a per-row-on-Site/Offering policy, not a per-alert state.
+  3. A worker-side mute check would duplicate logic for limited benefit and complicate the queue invariants.
 
 ## 8. Testing
 
@@ -380,7 +377,7 @@ Frontend:
    - Clicking a duration option fires `onChange` with the right ISO string.
    - Clicking Unmute fires `onChange(null)`.
 6. `frontend/src/lib/mutations.test.tsx` (extend) — `useUpdateSiteMute` and `useUpdateOfferingMute`: PATCH fires with right payload; `useUpdateOfferingMute` optimistic match-removal works; rollback on error.
-7. MSW handlers: `PATCH /api/sites/:id` (already exists?) and `PATCH /api/offerings/:id` (new).
+7. MSW handlers: `PATCH /api/sites/:id` (NOT yet in `frontend/src/test/handlers.ts` — add) and `PATCH /api/offerings/:id` (new).
 
 Manual smoke (before merge):
 - Mute a site from sites detail → site row reflects state.

--- a/frontend/src/components/calendar/CalendarEventPopover.test.tsx
+++ b/frontend/src/components/calendar/CalendarEventPopover.test.tsx
@@ -72,6 +72,11 @@ const matchEventNoUrl: CalendarEvent = {
 };
 
 describe('CalendarEventPopover (match events)', () => {
+  it('renders Mute button on match events', () => {
+    renderPopover(matchEvent);
+    expect(screen.getByRole('button', { name: /^mute$/i })).toBeInTheDocument();
+  });
+
   it('renders match details + Enroll button + View details link', () => {
     renderPopover(matchEvent);
     expect(screen.getByText(/Soccer/i)).toBeInTheDocument();

--- a/frontend/src/components/calendar/CalendarEventPopover.tsx
+++ b/frontend/src/components/calendar/CalendarEventPopover.tsx
@@ -9,7 +9,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { ErrorBanner } from '@/components/common/ErrorBanner';
 import type { CalendarEvent } from '@/lib/types';
-import { useCancelEnrollment, useDeleteUnavailability, useEnrollOffering } from '@/lib/mutations';
+import { useCancelEnrollment, useDeleteUnavailability, useEnrollOffering, useUpdateOfferingMute } from '@/lib/mutations';
+import { MuteButton } from '@/components/common/MuteButton';
 
 export function CalendarEventPopover({
   kidId,
@@ -25,8 +26,9 @@ export function CalendarEventPopover({
   const cancel = useCancelEnrollment();
   const del = useDeleteUnavailability();
   const enroll = useEnrollOffering();
+  const muteOffering = useUpdateOfferingMute();
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const inFlight = cancel.isPending || del.isPending || enroll.isPending;
+  const inFlight = cancel.isPending || del.isPending || enroll.isPending || muteOffering.isPending;
 
   // Reset mutation + error state whenever the selected event changes.
   // event.id is the only stable signal; mutation refs are recreated each render.
@@ -37,6 +39,7 @@ export function CalendarEventPopover({
     cancel.reset();
     del.reset();
     enroll.reset();
+    muteOffering.reset();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [event?.id]);
 
@@ -60,6 +63,18 @@ export function CalendarEventPopover({
       {
         onSuccess: onClose,
         onError: (err) => setErrorMsg(err.message || 'Failed to enroll'),
+      },
+    );
+  };
+
+  const handleMute = (mutedUntil: string | null) => {
+    if (!event?.offering_id) return;
+    setErrorMsg(null);
+    muteOffering.mutate(
+      { offeringId: event.offering_id, mutedUntil },
+      {
+        onSuccess: onClose,
+        onError: (err) => setErrorMsg(err.message || 'Failed to update mute'),
       },
     );
   };
@@ -117,6 +132,14 @@ export function CalendarEventPopover({
                   <Button onClick={handleEnroll} disabled={inFlight}>
                     Enroll
                   </Button>
+                  {/* mutedUntil hardcoded null: muted matches are filtered out
+                      server-side (5d-1 spec Q4), so the popover never shows a muted
+                      match. The button always renders the duration picker, never Unmute. */}
+                  <MuteButton
+                    mutedUntil={null}
+                    onChange={handleMute}
+                    isPending={muteOffering.isPending}
+                  />
                   {event.registration_url && (
                     <a
                       href={event.registration_url}

--- a/frontend/src/components/common/MuteButton.test.tsx
+++ b/frontend/src/components/common/MuteButton.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MuteButton } from './MuteButton';
+import { FOREVER_SENTINEL } from '@/lib/mute';
+
+describe('MuteButton', () => {
+  it('renders "Mute" when not muted (null)', () => {
+    render(<MuteButton mutedUntil={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /^mute$/i })).toBeInTheDocument();
+  });
+
+  it('renders "Mute" when mute timestamp is in the past', () => {
+    const now = new Date();
+    const past = new Date(now.getTime() - 86_400_000).toISOString();
+    render(<MuteButton mutedUntil={past} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /^mute$/i })).toBeInTheDocument();
+  });
+
+  it('renders "Muted until ..." when mute timestamp is in the future', () => {
+    const now = new Date();
+    const future = new Date(now.getTime() + 7 * 86_400_000).toISOString();
+    render(<MuteButton mutedUntil={future} onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /muted until/i })).toBeInTheDocument();
+  });
+
+  it('clicking a duration option calls onChange with a future ISO timestamp', async () => {
+    const onChange = vi.fn();
+    render(<MuteButton mutedUntil={null} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /^mute$/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /7 days/i }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const arg = onChange.mock.calls[0]![0];
+    expect(typeof arg).toBe('string');
+    expect(new Date(arg).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('clicking "Forever" calls onChange with the sentinel', async () => {
+    const onChange = vi.fn();
+    render(<MuteButton mutedUntil={null} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /^mute$/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /forever/i }));
+    expect(onChange).toHaveBeenCalledWith(FOREVER_SENTINEL);
+  });
+
+  it('clicking "Unmute" calls onChange with null', async () => {
+    const onChange = vi.fn();
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    render(<MuteButton mutedUntil={future} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /muted until/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /unmute/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/src/components/common/MuteButton.tsx
+++ b/frontend/src/components/common/MuteButton.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { Popover } from 'radix-ui';
+import { Button } from '@/components/ui/button';
+import { isMuted, muteUntilFromDuration, type MuteDuration } from '@/lib/mute';
+import { cn } from '@/lib/utils';
+
+interface MuteButtonProps {
+  mutedUntil: string | null;
+  onChange: (mutedUntil: string | null) => void;
+  isPending?: boolean;
+  size?: 'default' | 'sm';
+}
+
+const DURATION_OPTIONS: Array<{ value: MuteDuration; label: string }> = [
+  { value: '7d', label: '7 days' },
+  { value: '30d', label: '30 days' },
+  { value: '90d', label: '90 days' },
+  { value: 'forever', label: 'Forever' },
+];
+
+export function MuteButton({
+  mutedUntil,
+  onChange,
+  isPending,
+  size = 'default',
+}: MuteButtonProps) {
+  const [open, setOpen] = useState(false);
+  const muted = isMuted(mutedUntil);
+  const label = muted
+    ? `Muted until ${format(new Date(mutedUntil!), 'MMM d')}`
+    : 'Mute';
+
+  const handle = (next: string | null) => {
+    setOpen(false);
+    onChange(next);
+  };
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button
+          size={size}
+          variant={muted ? 'outline' : 'ghost'}
+          disabled={isPending}
+        >
+          {label}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        className={cn(
+          'z-50 rounded-md border border-border bg-popover p-1 shadow-md',
+          'min-w-[10rem] text-sm',
+        )}
+        sideOffset={4}
+        align="end"
+      >
+        {muted ? (
+          <button
+            role="menuitem"
+            type="button"
+            className="block w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+            onClick={() => handle(null)}
+          >
+            Unmute
+          </button>
+        ) : (
+          DURATION_OPTIONS.map(({ value, label: dLabel }) => (
+            <button
+              key={value}
+              role="menuitem"
+              type="button"
+              className="block w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+              onClick={() => handle(muteUntilFromDuration(value))}
+            >
+              {dLabel}
+            </button>
+          ))
+        )}
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/frontend/src/components/matches/MatchCard.tsx
+++ b/frontend/src/components/matches/MatchCard.tsx
@@ -2,6 +2,8 @@ import type { Match } from '@/lib/types';
 import { Card } from '@/components/ui/card';
 import { price, relDate } from '@/lib/format';
 import { cn } from '@/lib/utils';
+import { MuteButton } from '@/components/common/MuteButton';
+import { useUpdateOfferingMute } from '@/lib/mutations';
 
 export function MatchCard({
   match,
@@ -13,6 +15,8 @@ export function MatchCard({
   onClick?: () => void;
 }) {
   const o = match.offering;
+  const muteOffering = useUpdateOfferingMute();
+
   return (
     <Card
       className={cn(
@@ -31,7 +35,17 @@ export function MatchCard({
             {o.registration_opens_at && ` · reg ${relDate(o.registration_opens_at)}`}
           </div>
         </div>
-        <div className="text-sm font-semibold">{match.score.toFixed(2)}</div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">{match.score.toFixed(2)}</span>
+          <MuteButton
+            size="sm"
+            mutedUntil={o.muted_until ?? null}
+            onChange={(mutedUntil) =>
+              muteOffering.mutate({ offeringId: o.id, mutedUntil })
+            }
+            isPending={muteOffering.isPending}
+          />
+        </div>
       </div>
     </Card>
   );

--- a/frontend/src/components/matches/MatchCard.tsx
+++ b/frontend/src/components/matches/MatchCard.tsx
@@ -37,14 +37,18 @@ export function MatchCard({
         </div>
         <div className="flex items-center gap-2">
           <span className="text-sm font-semibold">{match.score.toFixed(2)}</span>
-          <MuteButton
-            size="sm"
-            mutedUntil={o.muted_until ?? null}
-            onChange={(mutedUntil) =>
-              muteOffering.mutate({ offeringId: o.id, mutedUntil })
-            }
-            isPending={muteOffering.isPending}
-          />
+          {/* Stop propagation so the Mute popover doesn't also fire the
+              row's onClick (which opens the MatchDetailDrawer). */}
+          <div onClick={(e) => e.stopPropagation()}>
+            <MuteButton
+              size="sm"
+              mutedUntil={o.muted_until ?? null}
+              onChange={(mutedUntil) =>
+                muteOffering.mutate({ offeringId: o.id, mutedUntil })
+              }
+              isPending={muteOffering.isPending}
+            />
+          </div>
         </div>
       </div>
     </Card>

--- a/frontend/src/components/matches/UrgencyGroup.test.tsx
+++ b/frontend/src/components/matches/UrgencyGroup.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { UrgencyGroup } from './UrgencyGroup';
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
 
 const m = {
   kid_id: 1,
@@ -24,16 +30,17 @@ const m = {
     price_cents: null,
     registration_url: null,
     registration_opens_at: null,
+    muted_until: null,
   },
 };
 
 describe('UrgencyGroup', () => {
   it('renders nothing when matches is empty', () => {
-    const { container } = render(<UrgencyGroup title="t" matches={[]} onSelect={() => {}} />);
+    const { container } = wrap(<UrgencyGroup title="t" matches={[]} onSelect={() => {}} />);
     expect(container.firstChild).toBeNull();
   });
   it('renders a card per match', () => {
-    render(<UrgencyGroup title="t" matches={[m as never]} onSelect={() => {}} />);
+    wrap(<UrgencyGroup title="t" matches={[m as never]} onSelect={() => {}} />);
     expect(screen.getByText('T-Ball')).toBeInTheDocument();
   });
 });

--- a/frontend/src/lib/matches.test.ts
+++ b/frontend/src/lib/matches.test.ts
@@ -27,6 +27,7 @@ function makeMatch(overrides: Partial<Match['offering']> = {}): Match {
       price_cents: null,
       registration_url: null,
       registration_opens_at: null,
+      muted_until: null,
       ...overrides,
     },
   };

--- a/frontend/src/lib/mutations.test.tsx
+++ b/frontend/src/lib/mutations.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/server';
-import { useCloseAlert, useReopenAlert, useCancelEnrollment, useDeleteUnavailability, useEnrollOffering } from './mutations';
+import { useCloseAlert, useReopenAlert, useCancelEnrollment, useDeleteUnavailability, useEnrollOffering, useUpdateOfferingMute, useUpdateSiteMute } from './mutations';
 import type { InboxSummary, KidCalendarResponse } from './types';
 
 function makeWrapper(qc: QueryClient) {
@@ -303,6 +303,85 @@ describe('useEnrollOffering', () => {
     ]);
     expect(after?.events).toHaveLength(1);
     expect(after?.events[0]!.kind).toBe('match');
+  });
+});
+
+describe('useUpdateSiteMute', () => {
+  it('PATCHes /api/sites/{id} with the muted_until payload', async () => {
+    const qc = new QueryClient();
+    const { result } = renderHook(() => useUpdateSiteMute(), {
+      wrapper: makeWrapper(qc),
+    });
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    await act(async () => {
+      await result.current.mutateAsync({ siteId: 1, mutedUntil: future });
+    });
+    expect(result.current.isSuccess).toBe(true);
+  });
+});
+
+describe('useUpdateOfferingMute', () => {
+  it('removes match events for the offering optimistically when muting', async () => {
+    const qc = new QueryClient();
+    const matchEvent = {
+      id: 'match:7:2026-04-29',
+      kind: 'match' as const,
+      date: '2026-04-29',
+      time_start: '17:00:00',
+      time_end: '18:00:00',
+      all_day: false,
+      title: 'Soccer',
+      offering_id: 7,
+      score: 0.85,
+    };
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches'],
+      seedCal([matchEvent]),
+    );
+
+    const { result } = renderHook(() => useUpdateOfferingMute(), {
+      wrapper: makeWrapper(qc),
+    });
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    await act(async () => {
+      await result.current.mutateAsync({ offeringId: 7, mutedUntil: future });
+    });
+
+    const after = qc.getQueryData<KidCalendarResponse>([
+      'kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches',
+    ]);
+    expect(after?.events).toEqual([]);
+  });
+
+  it('does not perform optimistic surgery on unmute (mutedUntil=null)', async () => {
+    const qc = new QueryClient();
+    const matchEvent = {
+      id: 'match:7:2026-04-29',
+      kind: 'match' as const,
+      date: '2026-04-29',
+      time_start: '17:00:00',
+      time_end: '18:00:00',
+      all_day: false,
+      title: 'Soccer',
+      offering_id: 7,
+      score: 0.85,
+    };
+    qc.setQueryData<KidCalendarResponse>(
+      ['kids', 1, 'calendar', '2026-04-27', '2026-05-04', 'with-matches'],
+      seedCal([matchEvent]),
+    );
+
+    const { result } = renderHook(() => useUpdateOfferingMute(), {
+      wrapper: makeWrapper(qc),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ offeringId: 7, mutedUntil: null });
+    });
+
+    // The mutation completed successfully; cache state after invalidation
+    // depends on whether refetch resolved before the assertion. The key
+    // assertion is that no crash happened on unmute path.
+    expect(result.current.isSuccess).toBe(true);
   });
 });
 

--- a/frontend/src/lib/mutations.ts
+++ b/frontend/src/lib/mutations.ts
@@ -161,6 +161,81 @@ export function useEnrollOffering() {
   });
 }
 
+interface UpdateSiteMuteInput {
+  siteId: number;
+  mutedUntil: string | null;
+}
+
+export function useUpdateSiteMute() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, UpdateSiteMuteInput>({
+    mutationFn: ({ siteId, mutedUntil }) =>
+      api.patch(`/api/sites/${siteId}`, { muted_until: mutedUntil }),
+
+    onMutate: async () => {
+      await qc.cancelQueries({ queryKey: ['sites'] });
+    },
+
+    onSettled: async (_d, _e, { siteId }) => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['sites'] }),
+        qc.invalidateQueries({ queryKey: ['sites', siteId] }),
+        qc.invalidateQueries({ queryKey: ['kids'] }),
+      ]);
+    },
+  });
+}
+
+interface UpdateOfferingMuteInput {
+  offeringId: number;
+  mutedUntil: string | null;
+}
+
+export function useUpdateOfferingMute() {
+  const qc = useQueryClient();
+  type Ctx = {
+    snapshots: ReadonlyArray<readonly [QueryKey, KidCalendarResponse | undefined]>;
+  };
+  return useMutation<unknown, Error, UpdateOfferingMuteInput, Ctx>({
+    mutationFn: ({ offeringId, mutedUntil }) =>
+      api.patch(`/api/offerings/${offeringId}`, { muted_until: mutedUntil }),
+
+    onMutate: async ({ offeringId, mutedUntil }) => {
+      // Always cancel to flush state; optimistic surgery only when muting.
+      await qc.cancelQueries({ queryKey: ['kids'] });
+      if (mutedUntil == null) return { snapshots: [] };
+
+      await qc.cancelQueries({ queryKey: ['kids'] });
+      const allKidsQueries = qc.getQueriesData<KidCalendarResponse>({
+        queryKey: ['kids'],
+      });
+      const calendarSnapshots = allKidsQueries.filter(
+        ([key]) => key.length >= 3 && key[2] === 'calendar',
+      );
+
+      for (const [key, data] of calendarSnapshots) {
+        if (!data) continue;
+        const filtered = data.events.filter(
+          (e) => !(e.kind === 'match' && e.offering_id === offeringId),
+        );
+        qc.setQueryData<KidCalendarResponse>(key, { ...data, events: filtered });
+      }
+      return { snapshots: calendarSnapshots };
+    },
+
+    onError: (_err, _vars, ctx) => {
+      ctx?.snapshots.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+
+    onSettled: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['matches'] }),
+        qc.invalidateQueries({ queryKey: ['kids'] }),
+      ]);
+    },
+  });
+}
+
 interface DeleteUnavailabilityInput {
   kidId: number;
   blockId: number;

--- a/frontend/src/lib/mute.test.ts
+++ b/frontend/src/lib/mute.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { FOREVER_SENTINEL, isMuted, muteUntilFromDuration } from './mute';
+
+describe('muteUntilFromDuration', () => {
+  it('returns the forever sentinel for "forever"', () => {
+    expect(muteUntilFromDuration('forever')).toBe(FOREVER_SENTINEL);
+  });
+
+  it('returns now + 7 days for "7d"', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(muteUntilFromDuration('7d', now)).toBe('2026-05-06T12:00:00.000Z');
+  });
+
+  it('returns now + 30 days for "30d"', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(muteUntilFromDuration('30d', now)).toBe('2026-05-29T12:00:00.000Z');
+  });
+
+  it('returns now + 90 days for "90d"', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(muteUntilFromDuration('90d', now)).toBe('2026-07-28T12:00:00.000Z');
+  });
+});
+
+describe('isMuted', () => {
+  it('returns false for null', () => {
+    expect(isMuted(null)).toBe(false);
+  });
+
+  it('returns false for past timestamps', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(isMuted('2026-04-28T12:00:00Z', now)).toBe(false);
+  });
+
+  it('returns true for future timestamps', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(isMuted('2026-05-01T12:00:00Z', now)).toBe(true);
+  });
+
+  it('returns true for the forever sentinel', () => {
+    const now = new Date('2026-04-29T12:00:00Z');
+    expect(isMuted(FOREVER_SENTINEL, now)).toBe(true);
+  });
+});

--- a/frontend/src/lib/mute.ts
+++ b/frontend/src/lib/mute.ts
@@ -1,0 +1,27 @@
+export const FOREVER_SENTINEL = '3000-01-01T00:00:00.000Z';
+
+export type MuteDuration = '7d' | '30d' | '90d' | 'forever';
+
+const DAYS: Record<Exclude<MuteDuration, 'forever'>, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
+
+export function muteUntilFromDuration(
+  duration: MuteDuration,
+  now: Date = new Date(),
+): string {
+  if (duration === 'forever') return FOREVER_SENTINEL;
+  const out = new Date(now);
+  out.setDate(out.getDate() + DAYS[duration]);
+  return out.toISOString();
+}
+
+export function isMuted(
+  mutedUntil: string | null,
+  now: Date = new Date(),
+): boolean {
+  if (mutedUntil == null) return false;
+  return new Date(mutedUntil) > now;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface OfferingSummary {
   // Added in Task 1:
   site_name: string;
   registration_opens_at: string | null;
+  muted_until: string | null;
 }
 
 export interface Match {

--- a/frontend/src/routes/sites.$id.tsx
+++ b/frontend/src/routes/sites.$id.tsx
@@ -4,6 +4,8 @@ import { ErrorBanner } from '@/components/common/ErrorBanner';
 import { useSite, useSiteCrawls } from '@/lib/queries';
 import { CrawlHistoryList } from '@/components/sites/CrawlHistoryList';
 import { fmt } from '@/lib/format';
+import { MuteButton } from '@/components/common/MuteButton';
+import { useUpdateSiteMute } from '@/lib/mutations';
 
 export const Route = createFileRoute('/sites/$id')({ component: SiteDetailPage });
 
@@ -12,6 +14,7 @@ function SiteDetailPage() {
   const siteId = Number(id);
   const site = useSite(siteId);
   const crawls = useSiteCrawls(siteId);
+  const muteSite = useUpdateSiteMute();
 
   if (site.isLoading) return <Skeleton className="h-32 w-full" />;
   if (site.isError || !site.data) return <ErrorBanner message="Failed to load site" onRetry={() => site.refetch()} />;
@@ -19,9 +22,18 @@ function SiteDetailPage() {
   const s = site.data;
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold">{s.name}</h1>
-        <p className="text-sm text-muted-foreground">{s.base_url} · adapter: {s.adapter}</p>
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{s.name}</h1>
+          <p className="text-sm text-muted-foreground">{s.base_url} · adapter: {s.adapter}</p>
+        </div>
+        <MuteButton
+          mutedUntil={s.muted_until ?? null}
+          onChange={(mutedUntil) =>
+            muteSite.mutate({ siteId, mutedUntil })
+          }
+          isPending={muteSite.isPending}
+        />
       </header>
 
       <section>

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -112,4 +112,27 @@ export const handlers = [
       created_at: '2026-04-29T12:00:00Z',
     }, { status: 201 });
   }),
+  http.patch('/api/sites/:id', async ({ params, request }) => {
+    const body = (await request.json()) as { muted_until?: string | null };
+    return HttpResponse.json({
+      id: Number(params.id),
+      name: 'X',
+      base_url: 'https://x',
+      adapter: 'llm',
+      needs_browser: false,
+      active: true,
+      default_cadence_s: 86400,
+      muted_until: body.muted_until ?? null,
+      pages: [],
+    });
+  }),
+  http.patch('/api/offerings/:id', async ({ params, request }) => {
+    const body = (await request.json()) as { muted_until?: string | null };
+    return HttpResponse.json({
+      id: Number(params.id),
+      name: 'T-Ball',
+      site_id: 1,
+      muted_until: body.muted_until ?? null,
+    });
+  }),
 ];

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom/vitest';
 import { afterAll, afterEach, beforeAll } from 'vitest';
+import { notifyManager } from '@tanstack/query-core';
 import { server } from './server';
+
+// React Query uses setTimeout(fn, 0) by default, which `act()` may not fully
+// drain in JSDOM. Switch to queueMicrotask so state updates flush synchronously
+// within act() wrappers in tests.
+notifyManager.setScheduler(queueMicrotask);
 
 // Node 22+ ships a built-in localStorage backed by --localstorage-file.
 // When no file path is configured the global is present but broken

--- a/src/yas/alerts/enqueuer.py
+++ b/src/yas/alerts/enqueuer.py
@@ -104,6 +104,46 @@ def _kid_alert_on(kid: Kid, key: str, default: bool = True) -> bool:
     return bool(val)
 
 
+async def _is_muted(session: AsyncSession, *, offering_id: int) -> bool:
+    """True if the offering or its parent site is currently muted.
+
+    Used by offering-targeted enqueue functions (new_match, watchlist_hit,
+    reg-opens variants).
+    """
+    now = datetime.now(UTC)
+    row = (
+        await session.execute(
+            select(Offering.muted_until, Site.muted_until)
+            .join(Site, Site.id == Offering.site_id)
+            .where(Offering.id == offering_id)
+        )
+    ).one_or_none()
+    if row is None:
+        return False
+    o_muted, s_muted = row
+    # SQLite returns naive datetimes; treat them as UTC for comparison.
+    if o_muted is not None and o_muted.tzinfo is None:
+        o_muted = o_muted.replace(tzinfo=UTC)
+    if s_muted is not None and s_muted.tzinfo is None:
+        s_muted = s_muted.replace(tzinfo=UTC)
+    return (o_muted is not None and o_muted > now) or (s_muted is not None and s_muted > now)
+
+
+async def _is_site_muted(session: AsyncSession, *, site_id: int) -> bool:
+    """True if the site is currently muted.
+
+    Used by site-targeted enqueue functions (schedule_posted, crawl_failed,
+    site_stagnant).
+    """
+    now = datetime.now(UTC)
+    s_muted = (
+        await session.execute(select(Site.muted_until).where(Site.id == site_id))
+    ).scalar_one_or_none()
+    if s_muted is not None and s_muted.tzinfo is None:
+        s_muted = s_muted.replace(tzinfo=UTC)
+    return s_muted is not None and s_muted > now
+
+
 async def enqueue_new_match(
     session: AsyncSession,
     *,
@@ -115,6 +155,8 @@ async def enqueue_new_match(
     """Insert or update a new_match alert. Respects kid.alert_on.new_match."""
     kid = (await session.execute(select(Kid).where(Kid.id == kid_id))).scalar_one()
     if not _kid_alert_on(kid, "new_match", default=True):
+        return None
+    if await _is_muted(session, offering_id=offering_id):
         return None
     dk = dedup_key_for(AlertType.new_match, kid_id=kid_id, offering_id=offering_id)
     return await _upsert_alert(
@@ -136,9 +178,12 @@ async def enqueue_watchlist_hit(
     offering_id: int,
     watchlist_entry_id: int,
     reasons: dict[str, Any],
-) -> int:
-    """Insert or update a watchlist_hit alert. Bypasses kid.alert_on — the user
-    added the watchlist entry explicitly."""
+) -> int | None:
+    """Insert or update a watchlist_hit alert. Bypasses kid.alert_on (the user
+    added the watchlist entry explicitly) but is suppressed by Site/Offering
+    mute (the user has since changed their mind)."""
+    if await _is_muted(session, offering_id=offering_id):
+        return None
     dk = dedup_key_for(AlertType.watchlist_hit, kid_id=kid_id, offering_id=offering_id)
     return await _upsert_alert(
         session,
@@ -161,7 +206,9 @@ async def enqueue_schedule_posted(
     page_id: int,
     site_id: int,
     summary: str | None,
-) -> int:
+) -> int | None:
+    if await _is_site_muted(session, site_id=site_id):
+        return None
     dk = dedup_key_for(AlertType.schedule_posted, site_id=site_id, page_id=page_id)
     return await _upsert_alert(
         session,
@@ -181,7 +228,9 @@ async def enqueue_crawl_failed(
     site_id: int,
     consecutive_failures: int,
     last_error: str,
-) -> int:
+) -> int | None:
+    if await _is_site_muted(session, site_id=site_id):
+        return None
     dk = dedup_key_for(AlertType.crawl_failed, site_id=site_id)
     return await _upsert_alert(
         session,
@@ -203,14 +252,22 @@ async def enqueue_registration_countdowns(
     *,
     offering_id: int,
     kid_id: int,
-    opens_at: datetime,
+    opens_at: datetime | None = None,
 ) -> list[int]:
     """Delete any existing unsent reg_opens_* rows for this (kid, offering) and
     insert up to three fresh ones at T-24h, T-1h, T. Skips past-due schedules."""
+    if await _is_muted(session, offering_id=offering_id):
+        return []
     # Load the offering to get its name and registration_url for the payload.
     offering = (
         await session.execute(select(Offering).where(Offering.id == offering_id))
     ).scalar_one()
+    if opens_at is None:
+        opens_at = offering.registration_opens_at
+        if opens_at is None:
+            return []
+        if opens_at.tzinfo is None:
+            opens_at = opens_at.replace(tzinfo=UTC)
 
     # Delete prior unsent countdowns for this pair.
     await session.execute(
@@ -270,7 +327,9 @@ async def enqueue_site_stagnant(
     *,
     site_id: int,
     days_silent: int,
-) -> int:
+) -> int | None:
+    if await _is_site_muted(session, site_id=site_id):
+        return None
     site = (await session.execute(select(Site).where(Site.id == site_id))).scalar_one()
     dk = dedup_key_for(AlertType.site_stagnant, site_id=site_id)
     return await _upsert_alert(

--- a/src/yas/web/app.py
+++ b/src/yas/web/app.py
@@ -58,6 +58,7 @@ def create_app(
         watchlist_router,
     )
     from yas.web.routes.kid_calendar import router as kid_calendar_router
+    from yas.web.routes.offerings import router as offerings_router
 
     app.include_router(alert_routing_router)
     app.include_router(alerts_router)
@@ -71,6 +72,7 @@ def create_app(
     app.include_router(watchlist_router)
     app.include_router(unavailability_router)
     app.include_router(enrollments_router)
+    app.include_router(offerings_router)
     app.include_router(matches_router)
 
     @app.on_event("shutdown")

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import date, time
+from datetime import UTC, date, datetime, time
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from yas.calendar.occurrences import expand_recurring
-from yas.db.models import Enrollment, Kid, Match, Offering, UnavailabilityBlock
+from yas.db.models import Enrollment, Kid, Match, Offering, Site, UnavailabilityBlock
 from yas.db.models._types import EnrollmentStatus
 from yas.db.session import session_scope
 from yas.web.routes.kid_calendar_schemas import CalendarEventOut, KidCalendarOut
@@ -41,6 +41,8 @@ async def get_kid_calendar(
             status_code=422,
             detail=f"range exceeds {_MAX_RANGE_DAYS}-day cap",
         )
+
+    now = datetime.now(UTC)
 
     async with session_scope(_engine(request)) as s:
         kid = (await s.execute(select(Kid).where(Kid.id == kid_id))).scalar_one_or_none()
@@ -130,9 +132,12 @@ async def get_kid_calendar(
                 await s.execute(
                     select(Match, Offering)
                     .join(Offering, Offering.id == Match.offering_id)
+                    .join(Site, Site.id == Offering.site_id)
                     .where(Match.kid_id == kid_id)
                     .where(Match.score >= _MATCH_THRESHOLD)
                     .where(~Match.offering_id.in_(committed_offering_ids))
+                    .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= now))
+                    .where(or_(Site.muted_until.is_(None), Site.muted_until <= now))
                 )
             ).all()
             for match, offering in match_rows:

--- a/src/yas/web/routes/matches_schemas.py
+++ b/src/yas/web/routes/matches_schemas.py
@@ -25,6 +25,7 @@ class OfferingSummary(BaseModel):
     site_id: int
     registration_opens_at: datetime | None = None
     site_name: str
+    muted_until: datetime | None = None
 
 
 class MatchOut(BaseModel):

--- a/src/yas/web/routes/offerings.py
+++ b/src/yas/web/routes/offerings.py
@@ -1,0 +1,52 @@
+"""CRUD for /api/offerings — initial scope: mute toggle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from yas.db.models import Offering
+from yas.db.session import session_scope
+
+router = APIRouter(prefix="/api/offerings", tags=["offerings"])
+
+
+def _engine(req: Request) -> AsyncEngine:
+    engine: AsyncEngine = req.app.state.yas.engine
+    return engine
+
+
+class OfferingPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    muted_until: datetime | None = None
+
+
+class OfferingMuteOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    name: str
+    site_id: int
+    muted_until: datetime | None
+
+
+@router.patch("/{offering_id}", response_model=OfferingMuteOut)
+async def update_offering(
+    request: Request,
+    offering_id: int,
+    payload: OfferingPatch,
+) -> OfferingMuteOut:
+    async with session_scope(_engine(request)) as s:
+        offering = (
+            await s.execute(select(Offering).where(Offering.id == offering_id))
+        ).scalar_one_or_none()
+        if offering is None:
+            raise HTTPException(status_code=404, detail=f"offering {offering_id} not found")
+        if "muted_until" in payload.model_fields_set:
+            offering.muted_until = payload.muted_until
+        await s.flush()
+        await s.refresh(offering)
+        return OfferingMuteOut.model_validate(offering)

--- a/tests/integration/test_alerts_enqueuer_mute.py
+++ b/tests/integration/test_alerts_enqueuer_mute.py
@@ -1,0 +1,187 @@
+"""Mute gate tests for src/yas/alerts/enqueuer.py."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from yas.alerts.enqueuer import (
+    enqueue_crawl_failed,
+    enqueue_new_match,
+    enqueue_registration_countdowns,
+    enqueue_schedule_posted,
+    enqueue_site_stagnant,
+    enqueue_watchlist_hit,
+)
+from yas.db.base import Base
+from yas.db.models import Alert, Kid, Offering, Page, Site, WatchlistEntry
+from yas.db.models._types import AlertType, OfferingStatus
+from yas.db.session import session_scope
+
+
+async def _make_engine(tmp_path: Any) -> Any:
+    url = f"sqlite+aiosqlite:///{tmp_path}/m.db"
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine
+
+
+async def _seed(
+    engine: Any,
+    *,
+    site_muted_until: datetime | None = None,
+    offering_muted_until: datetime | None = None,
+) -> None:
+    async with session_scope(engine) as s:
+        s.add(Kid(id=1, name="Sam", dob=date(2019, 5, 1)))
+        s.add(Site(id=1, name="X", base_url="https://x", muted_until=site_muted_until))
+        await s.flush()
+        s.add(Page(id=1, site_id=1, url="https://x/p"))
+        await s.flush()
+        s.add(
+            Offering(
+                id=1,
+                site_id=1,
+                page_id=1,
+                name="T-Ball",
+                normalized_name="t-ball",
+                days_of_week=["tue"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+                muted_until=offering_muted_until,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_new_match_skipped_when_offering_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, offering_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(s, kid_id=1, offering_id=1, score=0.9, reasons={})
+    assert result is None
+    async with session_scope(engine) as s:
+        alerts = (await s.execute(select(Alert))).scalars().all()
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_new_match_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(s, kid_id=1, offering_id=1, score=0.9, reasons={})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_new_match_enqueues_when_both_unmuted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    await _seed(engine)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(s, kid_id=1, offering_id=1, score=0.9, reasons={})
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_new_match_enqueues_when_mute_in_past(tmp_path):
+    engine = await _make_engine(tmp_path)
+    past = datetime.now(UTC) - timedelta(days=1)
+    await _seed(engine, offering_muted_until=past)
+    async with session_scope(engine) as s:
+        result = await enqueue_new_match(s, kid_id=1, offering_id=1, score=0.9, reasons={})
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_watchlist_hit_skipped_when_offering_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, offering_muted_until=future)
+    async with session_scope(engine) as s:
+        s.add(WatchlistEntry(id=99, kid_id=1, pattern="t-ball", active=True))
+    async with session_scope(engine) as s:
+        result = await enqueue_watchlist_hit(
+            s, kid_id=1, offering_id=1, watchlist_entry_id=99, reasons={}
+        )
+    assert result is None
+    async with session_scope(engine) as s:
+        alerts = (
+            (await s.execute(select(Alert).where(Alert.type == AlertType.watchlist_hit.value)))
+            .scalars()
+            .all()
+        )
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_watchlist_hit_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        s.add(WatchlistEntry(id=99, kid_id=1, pattern="t-ball", active=True))
+    async with session_scope(engine) as s:
+        result = await enqueue_watchlist_hit(
+            s, kid_id=1, offering_id=1, watchlist_entry_id=99, reasons={}
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_posted_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_schedule_posted(s, page_id=1, site_id=1, summary="3 new offerings")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_crawl_failed_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_crawl_failed(
+            s, site_id=1, consecutive_failures=3, last_error="timeout"
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_site_stagnant_skipped_when_site_muted(tmp_path):
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, site_muted_until=future)
+    async with session_scope(engine) as s:
+        result = await enqueue_site_stagnant(s, site_id=1, days_silent=15)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reg_opens_countdowns_skipped_when_offering_muted(tmp_path):
+    """All three reg-opens variants are gated by a single mute check."""
+    engine = await _make_engine(tmp_path)
+    future = datetime.now(UTC) + timedelta(days=30)
+    await _seed(engine, offering_muted_until=future)
+    async with session_scope(engine) as s:
+        offering = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+        offering.registration_opens_at = datetime.now(UTC) + timedelta(hours=2)
+    async with session_scope(engine) as s:
+        result = await enqueue_registration_countdowns(s, kid_id=1, offering_id=1)
+    assert result == []
+    async with session_scope(engine) as s:
+        alerts = (await s.execute(select(Alert))).scalars().all()
+    assert alerts == []

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -462,3 +462,93 @@ async def test_match_overlay_includes_offerings_with_only_cancelled_enrollment(c
     matches = [e for e in body["events"] if e["kind"] == "match"]
     assert len(matches) == 1
     assert matches[0]["offering_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_match_overlay_excludes_muted_offerings(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    future = datetime.now(UTC) + timedelta(days=30)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+                muted_until=future,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    assert all(e["kind"] != "match" for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_match_overlay_excludes_offering_whose_site_is_muted(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    future = datetime.now(UTC) + timedelta(days=30)
+    async with session_scope(engine) as s:
+        site = (await s.execute(select(Site).where(Site.id == 1))).scalar_one()
+        site.muted_until = future
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    assert all(e["kind"] != "match" for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_match_overlay_includes_offering_whose_mute_expired(client):
+    """A muted_until in the past doesn't suppress the match."""
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    past = datetime.now(UTC) - timedelta(days=1)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+                muted_until=past,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    matches = [e for e in body["events"] if e["kind"] == "match"]
+    assert len(matches) == 1

--- a/tests/integration/test_api_offerings.py
+++ b/tests/integration/test_api_offerings.py
@@ -1,0 +1,103 @@
+"""Integration tests for PATCH /api/offerings/{id}."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from yas.db.base import Base
+from yas.db.models import Offering, Page, Site
+from yas.db.models._types import OfferingStatus
+from yas.db.session import create_engine_for, session_scope
+from yas.web.app import create_app
+
+
+@pytest.fixture
+async def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("YAS_ANTHROPIC_API_KEY", "sk-test")
+    url = f"sqlite+aiosqlite:///{tmp_path}/o.db"
+    monkeypatch.setenv("YAS_DATABASE_URL", url)
+    engine = create_engine_for(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with session_scope(engine) as s:
+        s.add(Site(id=1, name="X", base_url="https://x"))
+        await s.flush()
+        s.add(Page(id=1, site_id=1, url="https://x/p"))
+        await s.flush()
+        s.add(
+            Offering(
+                id=1,
+                site_id=1,
+                page_id=1,
+                name="T-Ball",
+                normalized_name="t-ball",
+                days_of_week=["tue"],
+                time_start=time(16, 0),
+                time_end=time(17, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    app = create_app(engine=engine, fetcher=None, llm=None, geocoder=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c, engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_404_for_unknown_id(client):
+    c, _ = client
+    r = await c.patch("/api/offerings/9999", json={"muted_until": None})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_422_for_unknown_field(client):
+    c, _ = client
+    r = await c.patch("/api/offerings/1", json={"unknown_field": "value"})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_sets_muted_until(client):
+    c, engine = client
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    r = await c.patch("/api/offerings/1", json={"muted_until": future})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["muted_until"] is not None
+    async with session_scope(engine) as s:
+        o = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+    assert o.muted_until is not None
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_clears_muted_until(client):
+    c, engine = client
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    await c.patch("/api/offerings/1", json={"muted_until": future})
+    r = await c.patch("/api/offerings/1", json={"muted_until": None})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["muted_until"] is None
+    async with session_scope(engine) as s:
+        o = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+    assert o.muted_until is None
+
+
+@pytest.mark.asyncio
+async def test_patch_offering_empty_body_does_not_clear_muted_until(client):
+    """An empty PATCH body must not null out the muted_until field."""
+    c, engine = client
+    future = (datetime.now(UTC) + timedelta(days=7)).isoformat()
+    await c.patch("/api/offerings/1", json={"muted_until": future})
+    r = await c.patch("/api/offerings/1", json={})
+    assert r.status_code == 200
+    async with session_scope(engine) as s:
+        o = (await s.execute(select(Offering).where(Offering.id == 1))).scalar_one()
+    assert o.muted_until is not None


### PR DESCRIPTION
## Summary

- **Backend:** wired \`Site.muted_until\` and \`Offering.muted_until\` into the alert pipeline (6 enqueue functions gated). New \`PATCH /api/offerings/{id}\` route. Calendar match overlay now excludes muted offerings + offerings whose site is muted. \`OfferingSummary\` exposes \`muted_until\`.
- **Frontend:** new \`<MuteButton>\` primitive (popover with 4-option duration picker + Unmute action). Two new mutation hooks following the canonical pattern. Wired in three placements: site detail, matches list (per-row in MatchCard), calendar event popover (match branch).

**Closes the v1 terminal-state criterion:** *"User can disable alerts from a specific site or offering with one click."* — v1 functional scope is now complete.

## Test plan

- [x] uv run pytest -q (585 passed; +18 backend tests: 10 enqueuer mute, 5 PATCH offerings, 3 calendar overlay)
- [x] uv run ruff check . && uv run ruff format --check . clean
- [x] uv run mypy src clean
- [x] cd frontend && npm run typecheck clean
- [x] cd frontend && npm run lint clean
- [x] cd frontend && npm run test (67 passed; +18 frontend tests: 8 mute helpers + 6 MuteButton + 3 hooks + 1 popover)
- [ ] CI passes
- [ ] Manual smoke: mute a site → no new alerts; mute an offering on calendar → vanishes; unmute → returns

## Decisions captured in spec

- Mute suppresses ALL alerts touching site/offering (Q1)
- 4-option duration picker: 7d/30d/90d/forever (Q2; "forever" is year-3000 sentinel)
- Three placements: site detail + matches list + calendar popover (Q3)
- Muted offerings hidden from calendar match overlay (Q4)
- Worker does NOT re-check mute at delivery time (filters at enqueue time only)

## Spec / plan

- Spec: \`docs/superpowers/specs/2026-04-29-phase-5d-1-site-offering-mute-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-29-phase-5d-1-site-offering-mute.md\`

## Out of scope (deferred)

- Mute reasons / notes
- Per-channel mute (no email but yes push)
- Bulk mute / multi-select
- Auto-unmute notifications
- Mute history audit log