### PR TITLE
infra: publish multi-arch Docker image to GHCR; compose pulls instead of builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,24 +34,128 @@ jobs:
   docker-build:
     # Verify the Dockerfile builds on both supported runtime architectures.
     # Native runners (no QEMU emulation) per arch via matrix.
+    #
+    # On push-to-main, also pushes each arch by-digest to GHCR. The
+    # docker-publish job then assembles a multi-arch manifest. PRs only
+    # build (no push), preserving the security boundary.
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: linux/amd64
             runner: ubuntu-24.04
+            arch: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            arch: arm64
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
-      - name: Build (no push)
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name (lowercase)
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          echo "name=ghcr.io/${REPO,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Build (push by digest on main)
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: false
-          load: false
+          # On main: push by-digest so the publish job can stitch a multi-arch
+          # manifest. On PRs: just build to verify the Dockerfile.
+          outputs: |
+            type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - name: Export digest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-publish:
+    # Stitch the per-arch digests pushed by docker-build into a single
+    # multi-arch manifest, tagged `latest`, `main`, and `sha-<short>`.
+    #
+    # Future (semver releases): when cutting `git tag v1.0.0 && git push --tags`,
+    # add a parallel job triggered on `push: tags: ['v*']` that uses
+    # docker/metadata-action to compute v1.0.0 / v1.0 / v1 / latest tags from
+    # the git ref. At that point, the `latest` tag below should drop in favor
+    # of the tag-driven version so `latest` always tracks releases, not main
+    # HEAD. See PR #16 description (or the docs/) for the full sketch.
+    needs: docker-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image name (lowercase)
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          echo "name=ghcr.io/${REPO,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Create multi-arch manifest + push
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          SHA: ${{ github.sha }}
+        run: |
+          short_sha="${SHA:0:7}"
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            --tag "${IMAGE}:main" \
+            --tag "${IMAGE}:sha-${short_sha}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:latest"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,34 @@
 Self-hosted crawler + alerter for youth activity / sports / enrichment websites.
 See `docs/superpowers/specs/` for the design spec.
 
-## Quickstart (Docker)
+## Quickstart (Docker, prod)
+
+The base compose pulls a pre-built multi-arch image from GHCR
+(`ghcr.io/owine/youth-activity-scheduler:latest`, published from `main`).
+No local build — just pull and run:
 
 ```bash
 cp .env.example .env
 echo "YAS_ANTHROPIC_API_KEY=sk-ant-…" >> .env
+docker compose pull
 docker compose up -d
 curl http://localhost:8080/healthz
+```
+
+To upgrade later: `docker compose pull && docker compose up -d`.
+
+Available image tags:
+- `:latest` — main HEAD (default; bleeding edge)
+- `:main` — alias of latest
+- `:sha-<short>` — pin to a specific commit (recommended for production)
+
+### Local dev (build from source)
+
+For iterating on uncommitted source, layer in `docker-compose.dev.yml` to
+swap the `image:` for a local `build: .`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
 ### Local dev on macOS
@@ -20,7 +41,15 @@ access. Real Linux deployments are unaffected. For local dev on macOS, use the
 overlay that switches `./data` to a Docker-managed named volume:
 
 ```bash
+# pulls from GHCR
 docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d
+
+# or build locally + macOS volume override
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.macos.yml \
+  -f docker-compose.dev.yml \
+  up --build
 
 # inspect the db (it's inside the named volume, not on the host)
 docker compose -f docker-compose.yml -f docker-compose.macos.yml \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,25 @@
+# Override that swaps the GHCR `image:` for a local `build: .` so devs can
+# iterate on uncommitted source. The base compose targets prod (pulls from
+# GHCR); this override is opt-in.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+#
+# Stack with macOS volume override:
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.macos.yml \
+#     -f docker-compose.dev.yml \
+#     up --build
+
+x-build: &yas-build
+  build: .
+  image: yas-local:dev   # local-only tag; not pushed
+
+services:
+  yas-migrate:
+    <<: *yas-build
+  yas-worker:
+    <<: *yas-build
+  yas-api:
+    <<: *yas-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
+x-image: &yas-image
+  image: ghcr.io/owine/youth-activity-scheduler:latest
+
 services:
   yas-migrate:
-    build: .
+    <<: *yas-image
     command: ["uv", "run", "alembic", "upgrade", "head"]
     env_file: .env
     volumes:
@@ -8,7 +11,7 @@ services:
     restart: "no"
 
   yas-worker:
-    build: .
+    <<: *yas-image
     command: ["python", "-m", "yas", "worker"]
     env_file: .env
     volumes:
@@ -19,7 +22,7 @@ services:
     restart: unless-stopped
 
   yas-api:
-    build: .
+    <<: *yas-image
     command: ["python", "-m", "yas", "api"]
     env_file: .env
     ports:


### PR DESCRIPTION
## Summary

CI now publishes a multi-arch Docker image to GHCR on every push to \`main\`; \`docker-compose.yml\` pulls instead of building. Local-source iteration moves to a new \`docker-compose.dev.yml\` override.

## What ships

**CI (\`.github/workflows/ci.yml\`):**
- Existing \`docker-build\` matrix (amd64 + arm64 on native runners — no QEMU) now pushes each arch by-digest to \`ghcr.io/owine/youth-activity-scheduler\` on \`main\` push events. PRs still build but don't push.
- New \`docker-publish\` job assembles the multi-arch manifest via \`docker buildx imagetools create\`, tagged \`latest\` / \`main\` / \`sha-<short>\`.
- All \`run:\` blocks bind \`\${{ }}\` interpolations to \`env:\` vars first — defense-in-depth against the workflow command-injection pattern, even though current inputs are project-controlled.

**Compose:**
- \`docker-compose.yml\`: \`build: .\` → \`image: ghcr.io/...:latest\` (deduped via \`x-image\` YAML anchor).
- \`docker-compose.dev.yml\` (new): re-adds \`build: .\` for local iteration.
- \`docker-compose.macos.yml\`: untouched; composes with both base and dev override.

**README:** quickstart now distinguishes prod (\`pull && up -d\`) from dev (\`-f docker-compose.dev.yml up --build\`).

## Test plan

- [x] \`actionlint\` clean on the new workflow
- [x] \`docker compose config\` validates the base, dev override, macOS override, and the triple-stack
- [ ] Once merged: first push to main creates the GHCR package as **private**. Manual one-time step: visit the [package settings](https://github.com/owine/youth-activity-scheduler/pkgs/container/youth-activity-scheduler) and switch to **Public** (or keep private + use a PAT on the host).
- [ ] CI passes
- [ ] After publish, smoke: a fresh host runs \`docker compose pull && docker compose up -d\` against this branch's \`docker-compose.yml\` and the API responds at \`/healthz\`.

## Tag strategy (current)

| Tag | What it points to | When to use |
|---|---|---|
| \`latest\` | Main HEAD (whatever was just merged) | Bleeding edge; ok for a single-household app where you trust your own CI |
| \`main\` | Alias of \`latest\` | Explicit "I want main" semantics |
| \`sha-<short>\` | A specific commit | **Recommended for production**: pin in compose, upgrade deliberately |

## Semver tag promotion (sketch — when cutting v1.0.0)

Right now \`latest\` tracks main HEAD. That's fine for solo / household use, but the moment you want to share the image (or roll back without remembering shas), semver tags pay off.

The promotion path is:

**Step 1 — Cut a tag locally:**
\`\`\`bash
git tag -a v1.0.0 -m "v1.0.0"
git push origin v1.0.0
\`\`\`

**Step 2 — Add a tag-driven publish workflow.** A small extension to \`ci.yml\` (or a sibling workflow):

\`\`\`yaml
on:
  push:
    branches: [main]
    tags: ['v*.*.*']        # NEW
  pull_request:
\`\`\`

In the new \`docker-publish\` job, swap the hardcoded tags for \`docker/metadata-action\`:

\`\`\`yaml
- uses: docker/metadata-action@<sha>  # v5
  id: meta
  with:
    images: ghcr.io/owine/youth-activity-scheduler
    tags: |
      # branch push: tag as 'main' + sha-short
      type=ref,event=branch
      type=sha,prefix=sha-,format=short
      # tag push: tag as v1.0.0, v1.0, v1
      type=semver,pattern={{version}}
      type=semver,pattern={{major}}.{{minor}}
      type=semver,pattern={{major}}
      # 'latest' moves from "main HEAD" to "latest stable release"
      type=raw,value=latest,enable=\${{ startsWith(github.ref, 'refs/tags/v') }}
\`\`\`

Then \`docker buildx imagetools create\` consumes \`steps.meta.outputs.tags\` instead of the hardcoded list.

**Step 3 — Tag effects after Step 2 lands:**

| Event | Tags pushed |
|---|---|
| \`git push origin main\` | \`main\`, \`sha-abc1234\` |
| \`git push origin v1.0.0\` | \`v1.0.0\`, \`v1.0\`, \`v1\`, \`latest\`, \`sha-abc1234\` |
| \`git push origin v1.0.1\` | \`v1.0.1\`, \`v1.0\` (moves), \`v1\` (moves), \`latest\` (moves), \`sha-...\` |
| \`git push origin v2.0.0\` | \`v2.0.0\`, \`v2.0\`, \`v2\`, \`latest\` (moves), \`sha-...\` |

**The semantics:**
- \`v1.0.0\` is **immutable** — never moves. Pinning to it is a forever pin.
- \`v1.0\` moves forward as patches land in the 1.0 line.
- \`v1\` moves forward as minors land in v1.x.
- \`latest\` moves forward only on **stable** tags, never on main pushes (this is the breaking change from current behavior — and the whole point: \`latest\` becomes safe for production).
- \`main\` keeps tracking HEAD for the \`docker compose pull && up -d\` upgrade-on-merge crowd.
- \`sha-<short>\` is always available for any commit; useful for rollback ("the v1.0.5 image worked but v1.0.6 broke me — pin to the sha that was \`v1.0.5\`'s HEAD").

**Step 4 — Recommend pinning compose to a stable tag** in the README at that point:
\`\`\`yaml
image: ghcr.io/owine/youth-activity-scheduler:v1
# or for stricter pinning:
# image: ghcr.io/owine/youth-activity-scheduler:v1.0.5
\`\`\`

## Out of scope

- **GHCR package public-vs-private.** This PR doesn't touch package visibility. After the first publish, flip it manually if you want unauthenticated pulls.
- **Image signing (cosign).** Worth doing later; not v1-blocking for a self-hosted single-household app.
- **SBOM / provenance attestation.** \`docker/build-push-action\` supports both via \`provenance:\` / \`sbom:\` flags; can layer in later if useful.
- **Watchtower / autoupdate.** This PR makes \`docker compose pull && up -d\` work; a host-level autoupdater is a separate decision.

## Summary by Sourcery

Publish a multi-architecture Docker image to GHCR from CI and switch the default Docker Compose setup to pull that image, with a separate override for local source builds.

New Features:
- Add CI support to push per-architecture images to GHCR and assemble a multi-arch manifest tagged for main and specific commits.
- Introduce a production-oriented docker-compose configuration that pulls a prebuilt image from GHCR instead of building locally.
- Provide a docker-compose.dev override file to enable local development builds from source while keeping the base stack image-based.

Enhancements:
- Document new image usage, tag strategy, and development workflows in the README, including macOS-specific compose guidance.

CI:
- Extend the CI workflow to authenticate to GHCR, push per-arch images on main pushes, and create a tagged multi-arch manifest from uploaded digests.