### PR TITLE
fix(compose): disable inherited Dockerfile HEALTHCHECK on migrate + worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@ services:
     volumes:
       - ./data:/data
     restart: "no"
+    # The Dockerfile's baked HEALTHCHECK probes localhost:8080/healthz, which
+    # only makes sense for the API service. This container is a one-shot
+    # alembic runner — disable the inherited check so it doesn't report
+    # "unhealthy" before exiting.
+    healthcheck:
+      disable: true
 
   yas-worker:
     <<: *yas-image
@@ -20,6 +26,11 @@ services:
       yas-migrate:
         condition: service_completed_successfully
     restart: unless-stopped
+    # Same reason as yas-migrate: the worker doesn't run an HTTP server, so
+    # the inherited Dockerfile HEALTHCHECK fails forever and breaks
+    # `depends_on: service_healthy` chains in deploy scripts.
+    healthcheck:
+      disable: true
 
   yas-api:
     <<: *yas-image


### PR DESCRIPTION
## Summary

First production deploy of the GHCR image surfaced a real bug: the Dockerfile bakes a \`curl http://localhost:8080/healthz\` HEALTHCHECK that the worker and migrate containers inherit. The worker doesn't run an HTTP server, so the inherited check fails forever — Docker reports the worker as **unhealthy** and any \`depends_on: service_healthy\` chain in a deploy script (Watchtower, Portainer, custom scripts) gets stuck.

## Root cause

The Dockerfile's HEALTHCHECK was correct when the image's default CMD was \`python -m yas all\` (one container running everything). Compose splits services across distinct containers, where:

- \`yas-api\` → runs API server, healthcheck is correct (compose-overridden anyway)
- \`yas-worker\` → runs background loops, no HTTP. Inherits broken check.
- \`yas-migrate\` → one-shot alembic, exits in seconds. Inherits the check, reports unhealthy until it exits.

## Fix

\`\`\`yaml
yas-migrate:
  healthcheck:
    disable: true   # one-shot, exits before any meaningful check

yas-worker:
  healthcheck:
    disable: true   # no HTTP server
\`\`\`

The image contract is unchanged. Anyone running the image standalone with the default \`python -m yas all\` CMD still gets the baked HEALTHCHECK as a sensible default.

## Production deploy log (before fix)

\`\`\`
Container yas-migrate Exited
Container yas-worker Started
Container yas-api Healthy
container yas-worker is unhealthy
❌ Failed to deploy yas during deploy (timeout or error)
\`\`\`

The worker is *actually fine* — its logs show all loops starting cleanly:
\`\`\`
{"event": "worker.start", "level": "info"}
{"interval_s": 10, "event": "heartbeat.start"}
{"tick_s": 30, "event": "scheduler.start"}
{"tick_s": 60, "event": "delivery.start"}
{"event": "sweep.ran", "kids": 0}
{"event": "detector.ran", "stagnant_sites": 0}
{"event": "digest.ran", "kids": 0}
\`\`\`

It's just running with a misconfigured healthcheck.

## Test plan

- [x] \`docker compose config\` validates with both services showing \`healthcheck: disable: true\`
- [x] api keeps its explicit healthcheck (rendered output confirmed)
- [ ] CI passes
- [ ] Deploy host re-pulls and starts cleanly: \`docker compose pull && docker compose up -d\` no longer times out on worker

## Out of scope

- Removing HEALTHCHECK from the Dockerfile entirely. The current arrangement (sensible default + per-service overrides in compose) is the better split — anyone running the image with the default CMD still gets a working check.

## Summary by Sourcery

Disable inappropriate Dockerfile health checks for non-HTTP compose services to prevent false unhealthy states and deployment timeouts.

Bug Fixes:
- Disable the inherited Dockerfile HEALTHCHECK on the yas-migrate service so the one-shot migration container does not report as unhealthy before exiting.
- Disable the inherited Dockerfile HEALTHCHECK on the yas-worker service so the background worker is not permanently marked unhealthy and blocking depends_on health chains.