### PR TITLE
chore(deps): bump GitHub Actions to next major (login v4, artifact v7/v8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: digests-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -118,7 +118,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/download-artifact@v4.3.0
+      - uses: actions/download-artifact@v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -127,7 +127,7 @@ jobs:
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

Three next-major action bumps. Audited each against our actual call sites; none affect us.

**Branched off \`chore/safe-dep-bumps\` (PR #20)** — diffs show the v3.7.0 → v4.1.0 step rather than v3.4.0 → v4.1.0. After #20 merges, this branch rebases trivially.

## Bumps

- \`docker/login-action\` v3.7.0 → **v4.1.0** (Node 24 runtime; ESM)
- \`actions/upload-artifact\` v4.6.2 → **v7.0.1** (Node 24; ESM; opt-in direct uploads)
- \`actions/download-artifact\` v4.3.0 → **v8.0.1** (Node 24; ESM; **hash-mismatch errors on by default — security win**)

## Breaking-change audit

### upload-artifact v4 → v7

| Version | Breaking change | Affects us? |
|---|---|---|
| v5 | Artifact immutability (no overwrite-by-name within same run) | **No** — each matrix arm uses unique name (\`digests-amd64\`, \`digests-arm64\`), no name collisions |
| v6 | Default Node 24 runtime; requires runner v2.327.1+ | **No** — GitHub-hosted runners are above this |
| v7 | ESM module; opt-in direct file uploads via \`archive: false\` | **No** — we don't use \`archive: false\` |

### download-artifact v4 → v8

| Version | Breaking change | Affects us? |
|---|---|---|
| v5 | Path semantics changed for single-artifact-by-ID downloads | **No** — we use \`pattern: digests-*\` + \`merge-multiple: true\`, not ID lookup |
| v6 | Node 24 prelim | **No** |
| v7 | Default Node 24 runtime | **No** — runner version covered |
| v8 | ESM; hash-mismatch errors by default (was warn) | **No, and a win** — we have zero reason to silently accept corrupted artifact downloads |

### login-action v3 → v4

Just a Node 24 default runtime + ESM. GitHub-hosted runners satisfy the runner version requirement.

## Test plan

- [x] actionlint clean on the bumped workflow
- [ ] CI passes (the real test for action major bumps is runtime, not lint)
- [ ] Renovate pins the new tag refs to SHAs in a follow-up
- [ ] After merge: post-main publish run still produces a working multi-arch manifest at \`ghcr.io/owine/youth-activity-scheduler:latest\`

## Merge order

1. **PR #20** (safe bumps) merges first
2. Rebase this branch onto main
3. This PR merges second

## Summary by Sourcery

Update CI workflows and development tooling dependencies to newer major and patch versions.

Build:
- Bump docker/login-action to v4.1.0 in CI workflows.
- Bump actions/upload-artifact to v7.0.1 and actions/download-artifact to v8.0.1 in CI workflows.

Chores:
- Update various frontend dependencies (TanStack React Router, router Vite plugin, msw) to the latest patch releases.
- Bump ggshield pre-commit hook to v1.50.3.
- Refresh Python and frontend lockfile version metadata.