### PR TITLE
docs: drop GitHub auto-close keyword pattern

### DIFF
--- a/docs/superpowers/plans/2026-04-30-phase-6-1-3-4-setup-mutation-uis.md
+++ b/docs/superpowers/plans/2026-04-30-phase-6-1-3-4-setup-mutation-uis.md
@@ -1588,8 +1588,8 @@ Closes master §10 criterion #6 (UI for setting kid school hours that produce ma
 
 ## Master §10 terminal-criteria delta
 
-- Closes #6 (school-hours UI). Backend already shipped; this UI provides the criterion's "user can set" affordance.
-- Does NOT close #1 (Add Site wizard) — that's Phase 6-2.
+- Closes criterion #6 (school-hours UI). Backend already shipped; this UI provides the criterion's "user can set" affordance.
+- Does NOT close criterion #1 (Add Site wizard) — that's Phase 6-2.
 
 After this lands: 7 of 8 v1 terminal criteria met. Criterion #4 (30-day observation) becomes runnable as soon as #1 lands.
 EOF

--- a/docs/superpowers/plans/2026-04-30-phase-6-2-add-site-wizard.md
+++ b/docs/superpowers/plans/2026-04-30-phase-6-2-add-site-wizard.md
@@ -1532,7 +1532,7 @@ Closes master §10 terminal criterion #1 ("User can add a site via the UI in <2 
 
 ## Master §10 terminal-criteria delta
 
-- **Closes #1** (Add Site UI in <2 min). After this PR: 8 of 8 v1 terminal criteria met.
+- **Closes criterion #1** (Add Site UI in <2 min). After this PR: 8 of 8 v1 terminal criteria met.
 - Criterion #4 (30-day observation) is now runnable end-to-end — kicks off Phase 9.
 EOF
 )"


### PR DESCRIPTION
Two plan docs in main contained the phrases "Closes #1" and "Closes #6", which were meant to reference master design terminal criteria — but GitHub parses these literally as auto-close directives for the corresponding issue numbers.

Issue #1 in this repo is the Renovate Dependency Dashboard, which must stay permanently open. PR #24's body inherited the same pattern; that's been edited on GitHub directly to remove the keyword.

This PR replaces the in-doc patterns with `Closes criterion #N` / `Does NOT close criterion #N` so the cross-reference stays legible without triggering GitHub's linker on any future re-merge or copy/paste.

## Test plan

- [x] grep -E 'Closes #|Fixes #|Resolves #' docs/ — empty
- [ ] CI passes

## Summary by Sourcery

Documentation:
- Replace ambiguous "Closes #N" references in plan docs with explicit "Closes criterion #N" / "Does NOT close criterion #N" wording to prevent unintended GitHub issue closure.