### PR TITLE
fix(ui): add Kids link to TopBar nav

### DIFF
--- a/frontend/src/components/layout/TopBar.test.tsx
+++ b/frontend/src/components/layout/TopBar.test.tsx
@@ -62,5 +62,6 @@ describe('TopBar', () => {
 
     expect(await screen.findByText('Sam')).toBeInTheDocument();
     expect(await screen.findByText('1')).toBeInTheDocument(); // alert badge
+    expect(screen.getByRole('link', { name: /Kids/ })).toHaveAttribute('href', '/kids');
   });
 });

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { Bell, Globe, LayoutGrid, Mail, Settings } from 'lucide-react';
+import { Bell, Globe, LayoutGrid, Mail, Settings, Users } from 'lucide-react';
 import { KidSwitcher } from './KidSwitcher';
 import { ThemeToggle } from './ThemeToggle';
 import { useInboxSummary } from '@/lib/queries';
@@ -27,6 +27,12 @@ export function TopBar() {
             {alertCount}
           </Badge>
         )}
+      </Link>
+      <Link
+        to="/kids"
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <Users className="h-4 w-4" /> Kids
       </Link>
       <Link
         to="/offerings"


### PR DESCRIPTION
## Summary

Phase 6-1 shipped the \`/kids\` list, \`/kids/new\` Add Kid form, and \`/kids/\$id/edit\` editor — but the TopBar nav was never updated, so users had no way to reach the Add Kid flow without typing the URL directly. This adds a Users-icon link between Inbox and Offerings.

Audit of remaining nav: per-kid views (Matches / Watchlist / Enrollments / Calendar) are still reachable via KidSwitcher → KidTabs, and Sites detail/new are sub-flows of \`/sites\`. The only missing top-level entry was Kids.

## Test plan

- [x] frontend TopBar.test.tsx passing (added assertion for \`/kids\` link)
- [x] npm run typecheck clean
- [x] npm run lint clean
- [ ] CI passes

## Summary by Sourcery

Add navigation access to the Kids section from the top bar.

New Features:
- Add a Kids link with icon to the TopBar navigation between Inbox and Offerings.

Tests:
- Extend TopBar tests to assert the presence and URL of the Kids navigation link.