### PR TITLE
test(topbar): tighten Kids link matcher to exact name

### DIFF
--- a/frontend/src/components/layout/TopBar.test.tsx
+++ b/frontend/src/components/layout/TopBar.test.tsx
@@ -62,6 +62,6 @@ describe('TopBar', () => {
 
     expect(await screen.findByText('Sam')).toBeInTheDocument();
     expect(await screen.findByText('1')).toBeInTheDocument(); // alert badge
-    expect(screen.getByRole('link', { name: /Kids/ })).toHaveAttribute('href', '/kids');
+    expect(screen.getByRole('link', { name: 'Kids' })).toHaveAttribute('href', '/kids');
   });
 });


### PR DESCRIPTION
Follow-up to #30 addressing the Sourcery review comment on the Kids-link assertion. Replaces the bare `/Kids/` regex with an exact `name: 'Kids'` match so the test stays robust if surrounding nav labels ever start with the word 'Kids'.

## Test plan
- [x] TopBar.test.tsx passes
- [ ] CI passes

## Summary by Sourcery

Tests:
- Update the TopBar Kids-link assertion to match the link by exact name instead of a regex to make the test more robust.