### PR TITLE
chore(ci): add OCI labels + git_sha to image and /healthz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,16 @@ jobs:
         run: |
           echo "name=ghcr.io/${REPO,,}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute OCI metadata
+        id: meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893  # v5.9.0
+        with:
+          images: ${{ steps.image.outputs.name }}
+          labels: |
+            org.opencontainers.image.title=Youth Activity Scheduler
+            org.opencontainers.image.description=Self-hosted youth-activity scheduler with crawl, matching, and alerting.
+            org.opencontainers.image.licenses=MIT
+
       - name: Build (push by digest on main)
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
@@ -177,6 +187,16 @@ jobs:
           # manifest. On PRs: just build to verify the Dockerfile.
           outputs: |
             type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          # OCI labels (manifest-level, zero Dockerfile cache impact). The
+          # metadata-action auto-fills source/revision/created/url/version
+          # from the workflow context.
+          labels: ${{ steps.meta.outputs.labels }}
+          # GIT_SHA is consumed by the trailing ARG/ENV in the Dockerfile so
+          # the running container can report its commit at /healthz. Placed
+          # last in the Dockerfile so this only invalidates the trailing
+          # layer (which busts every commit anyway via the source COPY).
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 
@@ -236,18 +256,37 @@ jobs:
         run: |
           echo "name=ghcr.io/${REPO,,}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute OCI annotations for manifest
+        id: meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893  # v5.9.0
+        with:
+          images: ${{ steps.image.outputs.name }}
+          labels: |
+            org.opencontainers.image.title=Youth Activity Scheduler
+            org.opencontainers.image.description=Self-hosted youth-activity scheduler with crawl, matching, and alerting.
+            org.opencontainers.image.licenses=MIT
+
       - name: Create multi-arch manifest + push
         working-directory: /tmp/digests
         env:
           IMAGE: ${{ steps.image.outputs.name }}
           SHA: ${{ github.sha }}
+          ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
         run: |
           short_sha="${SHA:0:7}"
+          # Convert metadata-action's newline-separated annotations to
+          # repeated --annotation flags for imagetools create.
+          ann_args=()
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            ann_args+=("--annotation" "$line")
+          done <<< "$ANNOTATIONS"
           # shellcheck disable=SC2046
           docker buildx imagetools create \
             --tag "${IMAGE}:latest" \
             --tag "${IMAGE}:main" \
             --tag "${IMAGE}:sha-${short_sha}" \
+            "${ann_args[@]}" \
             $(printf "${IMAGE}@sha256:%s " *)
 
       - name: Inspect manifest

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,13 @@ ENV YAS_DATABASE_URL=sqlite+aiosqlite:////data/activities.db \
 # Copy the SPA bundle into the static dir consumed by yas.web.spa_fallback
 COPY --from=frontend-build /build/dist /app/static
 
+# Bake the git commit SHA into the image so /healthz can report it.
+# Placed at the very end so cache invalidation per-commit only rebuilds
+# this trivial layer, not the heavy frontend/backend/playwright layers
+# above. Default is "unknown" so non-CI builds still succeed.
+ARG GIT_SHA=unknown
+ENV YAS_GIT_SHA=$GIT_SHA
+
 HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
   CMD curl -fsS http://localhost:8080/healthz || exit 1
 

--- a/src/yas/web/app.py
+++ b/src/yas/web/app.py
@@ -31,7 +31,9 @@ def create_app(
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:
-        return {"status": "ok"}
+        import os
+
+        return {"status": "ok", "git_sha": os.environ.get("YAS_GIT_SHA", "unknown")}
 
     @app.get("/readyz")
     async def readyz(response: Response) -> dict[str, object]:

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -28,7 +28,18 @@ async def test_healthz_returns_ok(app_with_db):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get("/healthz")
     assert r.status_code == 200
-    assert r.json() == {"status": "ok"}
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "git_sha" in body  # default "unknown" outside CI; SHA in CI builds
+
+
+@pytest.mark.asyncio
+async def test_healthz_reports_git_sha_when_set(app_with_db, monkeypatch):
+    monkeypatch.setenv("YAS_GIT_SHA", "abc1234")
+    app, _ = app_with_db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/healthz")
+    assert r.json()["git_sha"] == "abc1234"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two related improvements that make built images self-describing:

### 1. OCI labels via docker/metadata-action

\`docker/metadata-action\` auto-fills \`org.opencontainers.image.{source,revision,created,url,version}\` from the workflow context. The \`revision\` label carries the full 40-char commit SHA, so \`docker inspect ghcr.io/owine/youth-activity-scheduler:latest\` will reveal exactly which commit produced the image.

Adds explicit \`title\`, \`description\`, and \`licenses\` labels.

Applied to **both** per-arch builds (\`build-push-action\` \`labels:\` input) and the stitched multi-arch manifest (\`docker buildx imagetools create --annotation\` flags). The GHCR web UI uses the \`source\` label to render a linked-to-repo card on the package page.

**Zero Dockerfile cache impact**: these are manifest-level labels, not Dockerfile \`LABEL\` instructions, so they don't invalidate any layers.

### 2. Git SHA exposed at /healthz

Trailing \`ARG GIT_SHA=unknown\` + \`ENV YAS_GIT_SHA=\$GIT_SHA\` in the Dockerfile, placed **after** the heavy COPY/RUN/playwright-install layers. Cache impact is exactly one layer — the trailing ENV — which would bust on every commit anyway via the source \`COPY\` further up. Net cost ≈ 0.

CI passes \`build-args: GIT_SHA=\${{ github.sha }}\`. The running container reads it from \`os.environ\` and exposes it at \`/healthz\`:

\`\`\`json
{"status": "ok", "git_sha": "1da6bc6f8e..."}
\`\`\`

Default \`\"unknown\"\` outside CI builds.

## Why both

- **Labels** are great for registry-side introspection (GHCR, \`crane manifest\`, \`docker inspect\` after pull).
- **\`/healthz\` SHA** is great for "which commit is this *running* container serving?" without a registry round-trip — useful when debugging staged rollouts or verifying a deploy actually picked up.

Together: the image is fully self-describing whether you're looking at it from outside (registry) or inside (running container).

## Master §10 terminal criteria delta

None — pure infrastructure improvement.

## Test plan

- [x] uv run pytest -q (595 passing, +1 new test for git_sha env-var path)
- [x] uv run ruff check / format / mypy clean
- [x] YAML syntax-valid (\`python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\`)
- [x] Existing \`test_healthz_unaffected\` (spa_fallback) still passes (only checked status code + content-type, unaffected by new fields)
- [ ] CI passes (new \`metadata\` step appears in docker-build job)
- [ ] After merge: \`docker pull ghcr.io/owine/youth-activity-scheduler:latest && docker inspect <id> | jq .[0].Config.Labels\` shows revision/source/created
- [ ] After merge: container's \`/healthz\` returns \`git_sha\` matching the source commit

## Cache impact summary

| Layer | Cache impact |
|---|---|
| Frontend deps install | none (independent of these changes) |
| Frontend build | none |
| Backend deps install | none |
| Backend source COPY | already busts every commit (unchanged) |
| Playwright install | none |
| Frontend dist COPY | none |
| **NEW: ARG GIT_SHA + ENV** | rebuilds per-commit, but trivially small (just env-var metadata) |
| OCI labels | none — manifest-level, not Dockerfile layer |