### PR TITLE
fix(ci): strip manifest: prefix on imagetools annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,12 +274,23 @@ jobs:
           ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
         run: |
           short_sha="${SHA:0:7}"
-          # Convert metadata-action's newline-separated annotations to
-          # repeated --annotation flags for imagetools create.
+          # Convert metadata-action's annotations to --annotation flags.
+          # metadata-action emits "manifest:<key>=<value>" which buildx
+          # imagetools create rejects ("manifest annotations not supported
+          # yet"). Strip the manifest: prefix and replace with index:
+          # since the multi-arch manifest IS an OCI image index — that's
+          # what GHCR's package page surfaces.
+          # Skip lines whose value is empty (metadata-action emits blank
+          # entries for fields like description/licenses where it didn't
+          # auto-resolve a value; the explicit `labels:` above handle them
+          # at the per-arch image level instead).
           ann_args=()
           while IFS= read -r line; do
             [ -z "$line" ] && continue
-            ann_args+=("--annotation" "$line")
+            stripped="${line#manifest:}"
+            value="${stripped#*=}"
+            [ -z "$value" ] && continue
+            ann_args+=("--annotation" "index:${stripped}")
           done <<< "$ANNOTATIONS"
           # shellcheck disable=SC2046
           docker buildx imagetools create \


### PR DESCRIPTION
## Summary

Post-merge run of #34 failed in `docker-publish`:

```
ERROR: "manifest" annotations are not supported yet
```

`docker/metadata-action` emits annotations prefixed with `manifest:` (e.g. `manifest:org.opencontainers.image.created=...`). The buildx version on the GitHub runner only supports `index:` / no-prefix / `manifest-descriptor:` — not `manifest:`.

For a multi-arch image, the multi-arch manifest IS an OCI image **index**, so `index:` is the correct target — and that's also what GHCR's package page surfaces, which was the original goal.

Also: skip lines with empty values. `metadata-action` emits blank entries for fields like `description`/`licenses` where it didn't auto-resolve a value; the explicit per-arch `labels:` set in the build-push-action step handle those at the image level instead.

## Test plan

- [x] YAML syntax-valid
- [ ] CI: `docker-publish` job succeeds on push to main
- [ ] After merge: `docker buildx imagetools inspect ghcr.io/owine/youth-activity-scheduler:latest` shows the index-level annotations