### PR TITLE
phase 8-2: holiday/school-year calendar integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           enable-cache: true
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.14
       - name: Install deps
         run: uv sync --all-extras --dev
       - name: Lint
@@ -70,7 +70,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.14
       - name: Install backend deps
         run: uv sync --all-extras --dev
       - name: Install frontend deps

--- a/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
@@ -100,7 +100,7 @@ Estimated size: 4 PRs.
 **Why third:** quality-of-life. None block v1 terminal state.
 
 - Phase 8-1: Multi-kid combined calendar (deferred from 5c-1)
-- Phase 8-2: Holiday calendar / school-year integration (school blocks render every weekday in date range today; spring break is a separate manual block)
+- Phase 8-2: ✅ shipped 2026-05-02. Calendar respects `kid.school_holidays` (school blocks skip holiday dates) and emits explicit `holiday` events for in-range, in-school-year holidays.
 - Phase 8-3: Watchlist on calendar (visually distinct from matches)
 - Phase 8-4: Bulk operations (close-many alerts, mute-many offerings, enroll-many)
 - Phase 8-5: E2E test automation in CI (`scripts/e2e_phase5a.sh` is a manual gate today)

--- a/docs/superpowers/specs/2026-05-02-phase-8-2-holiday-school-year-design.md
+++ b/docs/superpowers/specs/2026-05-02-phase-8-2-holiday-school-year-design.md
@@ -1,0 +1,95 @@
+# Phase 8-2: Holiday / School-Year Calendar Integration — Design
+
+**Date:** 2026-05-02
+**Status:** Approved
+**Roadmap:** `docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md` §6 Phase 8-2
+
+## 1. Problem
+
+`Kid.school_holidays` is a list of ISO-date strings the user already maintains via the Kid edit form (Phase 6-1). The matcher correctly skips conflict checks on those dates (`yas.matching.matcher._school_holidays`). But `GET /api/kids/{id}/calendar` ignores them — the calendar happily renders a "School" recurring block on every weekday in `school_year_ranges`, including holidays. The roadmap entry called this out: today users have to also create a separate manual `UnavailabilityBlock` for spring break to make the calendar match reality. That's a workaround for a bug.
+
+Two gaps:
+- **Bug:** the calendar renders school on holiday dates.
+- **UX gap:** even after the bug fix, holidays render as "nothing." Users see a weekday with no school and no obvious reason. An explicit marker makes the calendar self-explanatory.
+
+## 2. Approach
+
+Two coordinated changes:
+
+**(1) Backend bug fix.** When expanding `UnavailabilityBlock`s in `kid_calendar.py`, skip occurrences whose date is in `kid.school_holidays` AND whose `block.source == 'school'`. Non-school blocks (manual unavailability, enrollment-derived blocks) are unaffected — those still render even on holidays, since they represent the kid being unavailable for non-school reasons.
+
+**(2) Add `holiday` event kind.** The endpoint emits one `holiday` event per date in `kid.school_holidays` that falls within the request range AND inside at least one `school_year_range`. Frontend gets a matching CSS class and the combined calendar's type-filter list grows by one.
+
+**Why filter holidays to the school-year range?** A date in `school_holidays` outside the school year (e.g., July 4) doesn't represent a school holiday — it represents a free day that's already free. Rendering it as "Holiday" would imply school is being cancelled, which is misleading.
+
+## 3. Components and files
+
+### Backend
+
+| File | Change |
+|---|---|
+| `src/yas/web/routes/kid_calendar_schemas.py` | Extend the `kind` `Literal` to include `"holiday"`. |
+| `src/yas/web/routes/kid_calendar.py` | (a) Build a `school_holiday_dates: set[date]` from `kid.school_holidays`; (b) when expanding `UnavailabilityBlock` with `source=school`, skip occurrences whose date is in that set; (c) after expanding blocks, emit one `holiday` event per holiday date that falls in range AND inside `school_year_ranges`. |
+| `tests/integration/test_api_kid_calendar.py` | Add tests: school block skipped on holiday; holiday event emitted; holiday outside school year not emitted; non-school blocks not affected by holidays. |
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `frontend/src/lib/types.ts` | Add `'holiday'` to `CalendarEventKind` union. |
+| `frontend/src/components/calendar/CalendarView.tsx` | Extend the kind→className mapping to include `'holiday' → 'rbc-event-holiday'`. |
+| `frontend/src/components/calendar/calendar-overrides.css` | Add `.rbc-event-holiday` rule with a soft amber/yellow palette (festive, non-alarming, distinct from the muted unavailability gray). |
+| `frontend/src/components/calendar/CombinedCalendarFilters.tsx` | Add `{ kind: 'holiday', label: 'Holiday' }` to `ALL_TYPES`. Default on (matches other types). |
+| `frontend/src/components/calendar/CombinedCalendarFilters.test.tsx` | Update test that asserts the type-checkbox set; add coverage for toggling Holiday. |
+| `frontend/src/lib/combinedCalendar.test.ts` | Confirm holiday events flow through merge (filtered by `types` correctly). |
+
+### No change needed
+
+- `frontend/src/components/kids/KidForm.tsx` — already manages `school_holidays`.
+- `src/yas/matching/matcher.py` — already respects `school_holidays`.
+- `src/yas/unavailability/school_materializer.py` — still emits one school block per `school_year_range`; the calendar layer is now responsible for excluding holidays during render. (We deliberately don't materialize holiday-cuts as block boundaries; that would explode block count and conflate "schedule reality" with "calendar rendering.")
+
+## 4. Decisions
+
+**D1. Skip school occurrences on holiday dates, but emit a separate `holiday` event.** Two layers of change rather than one. Rationale: skipping alone leaves a confusing gap; emitting alone leaves school still rendered (worse). Both together produce the right UX.
+
+**D2. `holiday` is a new event kind, not a sub-type of `unavailability`.** A holiday is *not* the kid being unavailable — it's a day they're explicitly free. Conflating with unavailability would distort the type filter ("uncheck Unavailability hides holidays"). New kind is two-line additions in the type system; cheap.
+
+**D3. Holiday events are all-day with title `"Holiday"`.** No name field on `school_holidays` (it's a flat list of date strings). Adding labels would require a DB migration to change the column shape — out of scope. Title `"Holiday"` plus the date being on the calendar is enough context.
+
+**D4. Holidays render only inside `school_year_ranges`.** A holiday date outside the school year is meaningless ("today is a school holiday" doesn't apply when it's summer). Filter in the endpoint, not the frontend.
+
+**D5. Holiday filter defaults ON.** Matches enrollment/unavailability/match defaults. User can hide via the type filter.
+
+**D6. CSS color: soft amber.** `.rbc-event-holiday` uses an amber-100/amber-700 pair (light amber bg, dark amber text). Distinct from the gray of unavailability and the primary blue of enrollment. Color-blind safe.
+
+**D7. Per-kid calendar: no UI change needed beyond CSS + kind mapping.** No type-filter UI on per-kid view. Holidays just appear with their CSS class.
+
+**D8. Combined calendar `eventStyle` for kid-color overlay still applies to `holiday` events.** Each holiday is per-kid (school holidays are kid-specific), so coloring by kid is consistent. The CSS class provides the holiday-shape baseline; the inline kid-color overlays it via `eventStyle`'s `style` prop.
+
+## 5. Test plan
+
+### Backend (`tests/integration/test_api_kid_calendar.py`)
+
+- Holiday on a school weekday → school occurrence skipped, holiday event emitted.
+- Holiday on a non-school weekday → no school to skip, holiday event still emitted.
+- Holiday outside any `school_year_range` → no holiday event emitted.
+- Manual (`source=manual`) unavailability block on a holiday date → still emits unavailability event (only school blocks honor holidays).
+- Holiday outside the request `from`/`to` range → not in response.
+
+### Frontend
+
+- Combined calendar filter: Holiday checkbox renders, defaults on, toggles off filters out events.
+- Merge function: holiday events flow through, respect `types` filter.
+
+## 6. Master §10 terminal criteria delta
+
+None — Phase 8 is polish. Closes roadmap §6 Phase 8-2.
+
+## 7. Out of scope
+
+- Holiday names/labels (would require DB schema change to `school_holidays`).
+- Auto-importing public-holiday calendars (Google Calendar / iCal).
+- Holiday rendering as recurring across multiple school-year ranges (each entry in `school_holidays` is a single date).
+- Materializing holidays as block boundaries in the materializer (kept as render-time exclusion; matcher already handles its own logic).
+- Per-kid color tweaking for holidays (uses the same kid color as other events; holiday-vs-other-event differentiation comes from the CSS class baseline).

--- a/docs/superpowers/specs/2026-05-02-phase-8-2-holiday-school-year-design.md
+++ b/docs/superpowers/specs/2026-05-02-phase-8-2-holiday-school-year-design.md
@@ -30,14 +30,14 @@ Two coordinated changes:
 |---|---|
 | `src/yas/web/routes/kid_calendar_schemas.py` | Extend the `kind` `Literal` to include `"holiday"`. |
 | `src/yas/web/routes/kid_calendar.py` | (a) Build a `school_holiday_dates: set[date]` from `kid.school_holidays`; (b) when expanding `UnavailabilityBlock` with `source=school`, skip occurrences whose date is in that set; (c) after expanding blocks, emit one `holiday` event per holiday date that falls in range AND inside `school_year_ranges`. |
-| `tests/integration/test_api_kid_calendar.py` | Add tests: school block skipped on holiday; holiday event emitted; holiday outside school year not emitted; non-school blocks not affected by holidays. |
+| `tests/integration/test_api_kids_calendar.py` | Add tests: school block skipped on holiday; holiday event emitted; holiday outside school year not emitted; non-school blocks not affected by holidays. |
 
 ### Frontend
 
 | File | Change |
 |---|---|
 | `frontend/src/lib/types.ts` | Add `'holiday'` to `CalendarEventKind` union. |
-| `frontend/src/components/calendar/CalendarView.tsx` | Extend the kind→className mapping to include `'holiday' → 'rbc-event-holiday'`. |
+| `frontend/src/components/calendar/CalendarView.tsx` | Replace the chained-ternary kind→className mapping with an exhaustive `Record<CalendarEventKind, string>` lookup. The current chain falls through to `'rbc-event-unavailability'` for unknown kinds, so adding a member to the union doesn't TS-error — switching to a `Record` ensures the compiler flags any future kind addition that forgets a class. |
 | `frontend/src/components/calendar/calendar-overrides.css` | Add `.rbc-event-holiday` rule with a soft amber/yellow palette (festive, non-alarming, distinct from the muted unavailability gray). |
 | `frontend/src/components/calendar/CombinedCalendarFilters.tsx` | Add `{ kind: 'holiday', label: 'Holiday' }` to `ALL_TYPES`. Default on (matches other types). |
 | `frontend/src/components/calendar/CombinedCalendarFilters.test.tsx` | Update test that asserts the type-checkbox set; add coverage for toggling Holiday. |
@@ -57,7 +57,7 @@ Two coordinated changes:
 
 **D3. Holiday events are all-day with title `"Holiday"`.** No name field on `school_holidays` (it's a flat list of date strings). Adding labels would require a DB migration to change the column shape — out of scope. Title `"Holiday"` plus the date being on the calendar is enough context.
 
-**D4. Holidays render only inside `school_year_ranges`.** A holiday date outside the school year is meaningless ("today is a school holiday" doesn't apply when it's summer). Filter in the endpoint, not the frontend.
+**D4. Holidays render only inside `school_year_ranges`.** A holiday date outside the school year is meaningless ("today is a school holiday" doesn't apply when it's summer). Filter in the endpoint, not the frontend. **Boundary semantics: closed interval on both ends** — `start <= holiday_date <= end`. Matches how `school_materializer.py` materializes school blocks (inclusive `date_start`/`date_end`).
 
 **D5. Holiday filter defaults ON.** Matches enrollment/unavailability/match defaults. User can hide via the type filter.
 
@@ -69,7 +69,7 @@ Two coordinated changes:
 
 ## 5. Test plan
 
-### Backend (`tests/integration/test_api_kid_calendar.py`)
+### Backend (`tests/integration/test_api_kids_calendar.py`)
 
 - Holiday on a school weekday → school occurrence skipped, holiday event emitted.
 - Holiday on a non-school weekday → no school to skip, holiday event still emitted.

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -1,7 +1,7 @@
 import { Calendar, dateFnsLocalizer, Views, type View } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay } from 'date-fns';
 import { enUS } from 'date-fns/locale';
-import type { CalendarEvent } from '@/lib/types';
+import type { CalendarEvent, CalendarEventKind } from '@/lib/types';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import './calendar-overrides.css';
 
@@ -25,6 +25,15 @@ function parseTimeParts(timeStr: string): [number, number] {
   const parts = timeStr.split(':').map(Number);
   return [parts[0] ?? 0, parts[1] ?? 0];
 }
+
+// Exhaustive map: TypeScript will flag any future CalendarEventKind member
+// that's missing here. Avoids the silent fall-through a chained ternary had.
+const KIND_CLASS: Record<CalendarEventKind, string> = {
+  enrollment: 'rbc-event-enrollment',
+  unavailability: 'rbc-event-unavailability',
+  match: 'rbc-event-match',
+  holiday: 'rbc-event-holiday',
+};
 
 function toRbc(e: CalendarEvent): RbcEvent {
   const [y, m, d] = parseDateParts(e.date);
@@ -79,12 +88,7 @@ export function CalendarView({
         onSelectEvent={(rbc) => onSelectEvent((rbc as RbcEvent).resource)}
         eventPropGetter={(rbc) => {
           const ev = (rbc as RbcEvent).resource;
-          const kindClass =
-            ev.kind === 'enrollment'
-              ? 'rbc-event-enrollment'
-              : ev.kind === 'match'
-                ? 'rbc-event-match'
-                : 'rbc-event-unavailability';
+          const kindClass = KIND_CLASS[ev.kind];
           const override = eventStyle?.(ev);
           return {
             className: [kindClass, override?.className].filter(Boolean).join(' '),

--- a/frontend/src/components/calendar/CombinedCalendarFilters.test.tsx
+++ b/frontend/src/components/calendar/CombinedCalendarFilters.test.tsx
@@ -50,6 +50,7 @@ describe('CombinedCalendarFilters', () => {
     expect(screen.getByLabelText(/Enrollment/i)).toBeChecked();
     expect(screen.getByLabelText(/Unavailability/i)).toBeChecked();
     expect(screen.getByLabelText(/^Match$/i)).toBeChecked();
+    expect(screen.getByLabelText(/Holiday/i)).toBeChecked();
   });
 
   it('toggling a kid checkbox invokes onChange with that kid removed', async () => {

--- a/frontend/src/components/calendar/CombinedCalendarFilters.tsx
+++ b/frontend/src/components/calendar/CombinedCalendarFilters.tsx
@@ -5,6 +5,7 @@ const ALL_TYPES: { kind: CalendarEventKind; label: string }[] = [
   { kind: 'enrollment', label: 'Enrollment' },
   { kind: 'unavailability', label: 'Unavailability' },
   { kind: 'match', label: 'Match' },
+  { kind: 'holiday', label: 'Holiday' },
 ];
 
 function isAtDefaults(f: CombinedCalendarFilterState): boolean {

--- a/frontend/src/components/calendar/calendar-overrides.css
+++ b/frontend/src/components/calendar/calendar-overrides.css
@@ -18,6 +18,12 @@
   border: 1px dashed hsl(var(--primary));
 }
 
+.rbc-event-holiday {
+  background-color: rgb(254 243 199); /* amber-100 */
+  color: rgb(180 83 9); /* amber-700 */
+  border: 1px solid rgb(252 211 77); /* amber-300 */
+}
+
 .rbc-today {
   background-color: hsl(var(--accent));
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -285,7 +285,7 @@ export interface TestSendResult {
   detail: string;
 }
 
-export type CalendarEventKind = 'enrollment' | 'unavailability' | 'match';
+export type CalendarEventKind = 'enrollment' | 'unavailability' | 'match' | 'holiday';
 
 export interface CalendarEvent {
   id: string; // composite "kind:source-id:date"

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -51,6 +51,25 @@ async def get_kid_calendar(
 
         events: list[CalendarEventOut] = []
 
+        # School holidays: dates the matcher already skips for conflict checks.
+        # Used here to (a) hide school recurring blocks on those dates, and
+        # (b) emit explicit "Holiday" events for the same dates within the
+        # school-year ranges so the calendar isn't silently empty.
+        school_holiday_dates: set[date] = set()
+        for s_iso in kid.school_holidays or []:
+            try:
+                school_holiday_dates.add(date.fromisoformat(s_iso))
+            except ValueError:
+                continue
+        school_year_ranges_parsed: list[tuple[date, date]] = []
+        for entry in kid.school_year_ranges or []:
+            try:
+                school_year_ranges_parsed.append(
+                    (date.fromisoformat(entry["start"]), date.fromisoformat(entry["end"]))
+                )
+            except (KeyError, ValueError):
+                continue
+
         enrollment_rows = (
             await s.execute(
                 select(Enrollment, Offering)
@@ -106,6 +125,9 @@ async def get_kid_calendar(
                 range_from=from_,
                 range_to=to,
             ):
+                # School blocks: hide on holiday dates. Other blocks unchanged.
+                if block.source == "school" and occ.date in school_holiday_dates:
+                    continue
                 events.append(
                     CalendarEventOut(
                         id=f"unavailability:{block.id}:{occ.date.isoformat()}",
@@ -120,6 +142,28 @@ async def get_kid_calendar(
                         from_enrollment_id=block.source_enrollment_id,
                     )
                 )
+
+        # Emit explicit Holiday events for holiday dates that fall in range
+        # AND inside at least one school_year_range (closed interval). A
+        # holiday outside the school year would imply school is being
+        # cancelled on a day that's already free, which is misleading.
+        for h in sorted(school_holiday_dates):
+            if h < from_ or h > to:
+                continue
+            in_school_year = any(start <= h <= end for start, end in school_year_ranges_parsed)
+            if not in_school_year:
+                continue
+            events.append(
+                CalendarEventOut(
+                    id=f"holiday:{kid_id}:{h.isoformat()}",
+                    kind="holiday",
+                    date=h,
+                    time_start=None,
+                    time_end=None,
+                    all_day=True,
+                    title="Holiday",
+                )
+            )
 
         # 3. Match overlay (opt-in).
         if include_matches:

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -67,7 +67,7 @@ async def get_kid_calendar(
                 school_year_ranges_parsed.append(
                     (date.fromisoformat(entry["start"]), date.fromisoformat(entry["end"]))
                 )
-            except (KeyError, ValueError):
+            except KeyError, ValueError:
                 continue
 
         enrollment_rows = (

--- a/src/yas/web/routes/kid_calendar_schemas.py
+++ b/src/yas/web/routes/kid_calendar_schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 
 class CalendarEventOut(BaseModel):
     id: str
-    kind: Literal["enrollment", "unavailability", "match"]
+    kind: Literal["enrollment", "unavailability", "match", "holiday"]
     date: date
     time_start: time | None = None
     time_end: time | None = None

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -574,8 +574,7 @@ async def _seed_kid_with_school(
                 school_weekdays=["mon", "tue", "wed", "thu", "fri"],
                 school_time_start=time(8, 0),
                 school_time_end=time(15, 0),
-                school_year_ranges=year_ranges
-                or [{"start": "2026-04-01", "end": "2026-06-30"}],
+                school_year_ranges=year_ranges or [{"start": "2026-04-01", "end": "2026-06-30"}],
                 school_holidays=holidays or [],
             )
         )

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -552,3 +552,129 @@ async def test_match_overlay_includes_offering_whose_mute_expired(client):
     body = r.json()
     matches = [e for e in body["events"] if e["kind"] == "match"]
     assert len(matches) == 1
+
+
+# Phase 8-2 holiday / school-year integration
+
+
+async def _seed_kid_with_school(
+    engine,
+    *,
+    kid_id: int = 1,
+    holidays: list[str] | None = None,
+    year_ranges: list[dict[str, str]] | None = None,
+    school_block: bool = True,
+) -> None:
+    async with session_scope(engine) as s:
+        s.add(
+            Kid(
+                id=kid_id,
+                name="Sam",
+                dob=date(2019, 5, 1),
+                school_weekdays=["mon", "tue", "wed", "thu", "fri"],
+                school_time_start=time(8, 0),
+                school_time_end=time(15, 0),
+                school_year_ranges=year_ranges
+                or [{"start": "2026-04-01", "end": "2026-06-30"}],
+                school_holidays=holidays or [],
+            )
+        )
+        if school_block:
+            s.add(
+                UnavailabilityBlock(
+                    kid_id=kid_id,
+                    source=UnavailabilitySource.school.value,
+                    label="School",
+                    days_of_week=["mon", "tue", "wed", "thu", "fri"],
+                    time_start=time(8, 0),
+                    time_end=time(15, 0),
+                    date_start=date(2026, 4, 1),
+                    date_end=date(2026, 6, 30),
+                    active=True,
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_holiday_skips_school_block_render(client):
+    """A holiday on a school weekday hides the school occurrence."""
+    c, engine = client
+    # Wed 2026-04-29 is a school weekday.
+    await _seed_kid_with_school(engine, holidays=["2026-04-29"])
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    school_on_holiday = [
+        e for e in body["events"] if e["kind"] == "unavailability" and e["date"] == "2026-04-29"
+    ]
+    assert school_on_holiday == []
+
+
+@pytest.mark.asyncio
+async def test_holiday_event_emitted_in_range_and_school_year(client):
+    """Holidays within range and inside a school_year_range get a holiday event."""
+    c, engine = client
+    await _seed_kid_with_school(engine, holidays=["2026-04-29"])
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    holidays = [e for e in body["events"] if e["kind"] == "holiday"]
+    assert len(holidays) == 1
+    assert holidays[0]["date"] == "2026-04-29"
+    assert holidays[0]["all_day"] is True
+    assert holidays[0]["title"] == "Holiday"
+
+
+@pytest.mark.asyncio
+async def test_holiday_outside_school_year_not_emitted(client):
+    """A holiday date outside any school_year_range is not rendered."""
+    c, engine = client
+    # July 4 falls outside 2026-04-01..2026-06-30.
+    await _seed_kid_with_school(engine, holidays=["2026-07-04"])
+
+    r = await c.get("/api/kids/1/calendar?from=2026-07-01&to=2026-07-08")
+    body = r.json()
+    holidays = [e for e in body["events"] if e["kind"] == "holiday"]
+    assert holidays == []
+
+
+@pytest.mark.asyncio
+async def test_holiday_outside_request_range_not_emitted(client):
+    """A holiday date outside the from/to window is not rendered."""
+    c, engine = client
+    await _seed_kid_with_school(engine, holidays=["2026-04-29"])
+
+    r = await c.get("/api/kids/1/calendar?from=2026-05-04&to=2026-05-11")
+    body = r.json()
+    holidays = [e for e in body["events"] if e["kind"] == "holiday"]
+    assert holidays == []
+
+
+@pytest.mark.asyncio
+async def test_non_school_block_unaffected_by_holidays(client):
+    """A manual unavailability block on a holiday date still renders."""
+    c, engine = client
+    await _seed_kid_with_school(engine, holidays=["2026-04-29"], school_block=False)
+    async with session_scope(engine) as s:
+        s.add(
+            UnavailabilityBlock(
+                kid_id=1,
+                source=UnavailabilitySource.manual.value,
+                label="Doctor",
+                days_of_week=["wed"],
+                time_start=time(10, 0),
+                time_end=time(11, 0),
+                date_start=date(2026, 4, 29),
+                date_end=date(2026, 4, 29),
+                active=True,
+            )
+        )
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04")
+    body = r.json()
+    manual = [
+        e
+        for e in body["events"]
+        if e["kind"] == "unavailability" and e["source"] == "manual" and e["date"] == "2026-04-29"
+    ]
+    assert len(manual) == 1


### PR DESCRIPTION
## Summary

Closes roadmap §6 Phase 8-2. Two coordinated changes that make \`kid.school_holidays\` "just work" on the calendar — the matcher already respects them.

### Backend bug fix

\`GET /api/kids/{id}/calendar\`: when expanding \`UnavailabilityBlock\` rows, skip occurrences where \`block.source == 'school'\` AND \`occ.date\` is in \`kid.school_holidays\`. Manual / enrollment-derived blocks unaffected.

### New \`holiday\` event kind

The endpoint emits one all-day \`holiday\` event per date in \`kid.school_holidays\` that falls within the request range AND inside at least one \`school_year_range\` (closed interval — \`start <= holiday <= end\`). A holiday outside the school year is meaningless ("today is a school holiday" doesn't apply when it's summer).

### Frontend

- \`CalendarEventKind\` extended with \`'holiday'\`
- \`CalendarView\`'s chained-ternary kind→className replaced with an exhaustive \`Record<CalendarEventKind, string>\` lookup. The compiler now flags any future kind that forgets a class — was a silent fall-through before.
- New \`.rbc-event-holiday\` CSS (amber-100 bg, amber-700 text, amber-300 border — color-blind safe)
- \`CombinedCalendarFilters\` gains a \`Holiday\` checkbox alongside Enrollment/Unavailability/Match. Defaults on; user can hide.

## Why both layers

Bug fix alone leaves the day silently empty (confusing — "no school but why?"). Holiday event alone leaves school still rendered (worse). Both together produce the right UX: no school, plus an explicit "Holiday" marker.

## Master §10 terminal criteria delta

None — Phase 8 is polish.

## Test plan

- [x] uv run pytest -q (600 passing, +5 holiday tests)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean
- [x] Backend tests cover: skip school on holiday; emit holiday in range + school year; outside school year not emitted; outside request range not emitted; manual block unaffected
- [ ] CI passes
- [ ] Manual smoke: add a holiday to a kid; verify school block disappears that day; holiday marker renders amber

## Spec

\`docs/superpowers/specs/2026-05-02-phase-8-2-holiday-school-year-design.md\`