### PR TITLE
phase 8-3: distinguish watchlist matches on calendar

### DIFF
--- a/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
@@ -101,7 +101,7 @@ Estimated size: 4 PRs.
 
 - Phase 8-1: Multi-kid combined calendar (deferred from 5c-1)
 - Phase 8-2: ✅ shipped 2026-05-02. Calendar respects `kid.school_holidays` (school blocks skip holiday dates) and emits explicit `holiday` events for in-range, in-school-year holidays.
-- Phase 8-3: Watchlist on calendar (visually distinct from matches)
+- Phase 8-3: ✅ shipped 2026-05-02. Match events now carry a `watchlist_hit: bool` flag (set from `Match.reasons.watchlist_hit`); frontend renders watchlist-driven matches with a solid gold ring vs the default dashed border.
 - Phase 8-4: Bulk operations (close-many alerts, mute-many offerings, enroll-many)
 - Phase 8-5: E2E test automation in CI (`scripts/e2e_phase5a.sh` is a manual gate today)
 - Phase 8-6: Address pre-existing `format:check` failures (~28 files)

--- a/frontend/src/components/calendar/CalendarView.tsx
+++ b/frontend/src/components/calendar/CalendarView.tsx
@@ -89,9 +89,14 @@ export function CalendarView({
         eventPropGetter={(rbc) => {
           const ev = (rbc as RbcEvent).resource;
           const kindClass = KIND_CLASS[ev.kind];
+          // Watchlist matches get an extra modifier class on top of the
+          // base match class so the user can recognize personally-flagged
+          // hits at a glance (gold ring vs the default dashed border).
+          const watchlistClass =
+            ev.kind === 'match' && ev.watchlist_hit ? 'rbc-event-watchlist' : '';
           const override = eventStyle?.(ev);
           return {
-            className: [kindClass, override?.className].filter(Boolean).join(' '),
+            className: [kindClass, watchlistClass, override?.className].filter(Boolean).join(' '),
             ...(override?.style ? { style: override.style } : {}),
           };
         }}

--- a/frontend/src/components/calendar/calendar-overrides.css
+++ b/frontend/src/components/calendar/calendar-overrides.css
@@ -24,6 +24,14 @@
   border: 1px solid rgb(252 211 77); /* amber-300 */
 }
 
+/* Modifier on top of .rbc-event-match: a watchlist-driven match (the
+ * user explicitly flagged this pattern, not just a high-score discovery).
+ * Solid gold ring distinguishes it from the dashed default. */
+.rbc-event-match.rbc-event-watchlist {
+  border: 2px solid rgb(202 138 4); /* yellow-600 */
+  border-style: solid;
+}
+
 .rbc-today {
   background-color: hsl(var(--accent));
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -307,6 +307,7 @@ export interface CalendarEvent {
   // match-only:
   score?: number | null;
   registration_url?: string | null;
+  watchlist_hit?: boolean;
 }
 
 export interface KidCalendarResponse {

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -207,6 +207,7 @@ async def get_kid_calendar(
                             location_id=offering.location_id,
                             score=match.score,
                             registration_url=offering.registration_url,
+                            watchlist_hit=bool((match.reasons or {}).get("watchlist_hit")),
                         )
                     )
 

--- a/src/yas/web/routes/kid_calendar_schemas.py
+++ b/src/yas/web/routes/kid_calendar_schemas.py
@@ -25,6 +25,11 @@ class CalendarEventOut(BaseModel):
     from_enrollment_id: int | None = None
     score: float | None = None
     registration_url: str | None = None
+    # True when this match event was driven by a watchlist entry hit (vs.
+    # score-based discovery). Frontend renders watchlist hits with a distinct
+    # visual treatment so the user can recognize "things I personally flagged"
+    # at a glance. Always false for non-match events.
+    watchlist_hit: bool = False
 
 
 class KidCalendarOut(BaseModel):

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -677,3 +677,85 @@ async def test_non_school_block_unaffected_by_holidays(client):
         if e["kind"] == "unavailability" and e["source"] == "manual" and e["date"] == "2026-04-29"
     ]
     assert len(manual) == 1
+
+
+# Phase 8-3 watchlist-on-calendar
+
+
+async def _seed_match_with_reasons(
+    engine, *, kid_id: int, offering_id: int, score: float, reasons: dict
+) -> None:
+    async with session_scope(engine) as s:
+        s.add(
+            Match(
+                kid_id=kid_id,
+                offering_id=offering_id,
+                score=score,
+                reasons=reasons,
+                computed_at=datetime.now(UTC),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_match_watchlist_hit_flag_true_when_reasons_has_watchlist_hit(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    await _seed_match_with_reasons(
+        engine,
+        kid_id=1,
+        offering_id=2,
+        score=0.9,
+        reasons={"watchlist_hit": {"entry_id": 5, "pattern": "soccer*"}},
+    )
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    matches = [e for e in body["events"] if e["kind"] == "match"]
+    assert len(matches) == 1
+    assert matches[0]["watchlist_hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_match_watchlist_hit_flag_false_for_score_only_match(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer",
+                normalized_name="soccer",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.85)
+
+    r = await c.get("/api/kids/1/calendar?from=2026-04-27&to=2026-05-04&include_matches=true")
+    body = r.json()
+    matches = [e for e in body["events"] if e["kind"] == "match"]
+    assert len(matches) == 1
+    assert matches[0]["watchlist_hit"] is False


### PR DESCRIPTION
## Summary

Closes roadmap §6 Phase 8-3.

Match events emitted from \`/api/kids/{id}/calendar\` now carry a \`watchlist_hit: bool\` flag, set from \`Match.reasons.watchlist_hit\` (which the matcher already populates when a \`WatchlistEntry\` pattern triggered the match). Frontend renders watchlist-driven matches with an extra \`.rbc-event-watchlist\` class — solid gold ring vs the default dashed border on score-only matches.

## Why a flag, not a new event kind

YAGNI. The roadmap line says \"visually distinct from matches,\" not \"separately filterable.\" User still toggles via the existing \`Match\` type checkbox in the combined-calendar filter. If real usage later shows a need for \"show only watchlist matches\" filtering, we split the kind then — the data is already there in \`reasons\`.

## Master §10 terminal criteria delta

None — Phase 8 is polish.

## Test plan

- [x] uv run pytest -q (602 passing, +2 watchlist_hit cases)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean
- [x] Backend tests: \`watchlist_hit=true\` when \`reasons\` has the key; \`false\` for score-only matches
- [ ] CI passes
- [ ] Manual smoke: kid with a watchlist entry, calendar with \`?include_matches=true\`, watchlist-match offerings render with gold ring