### PR TITLE
phase 8-4: bulk close alerts

### DIFF
--- a/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
@@ -102,7 +102,7 @@ Estimated size: 4 PRs.
 - Phase 8-1: Multi-kid combined calendar (deferred from 5c-1)
 - Phase 8-2: ✅ shipped 2026-05-02. Calendar respects `kid.school_holidays` (school blocks skip holiday dates) and emits explicit `holiday` events for in-range, in-school-year holidays.
 - Phase 8-3: ✅ shipped 2026-05-02. Match events now carry a `watchlist_hit: bool` flag (set from `Match.reasons.watchlist_hit`); frontend renders watchlist-driven matches with a solid gold ring vs the default dashed border.
-- Phase 8-4: Bulk operations (close-many alerts, mute-many offerings, enroll-many)
+- Phase 8-4: ✅ shipped 2026-05-02 (close-many alerts only — mute-many and enroll-many deferred until usage signals justify them). New `POST /api/alerts/bulk/close` + multi-select on Outbox.
 - Phase 8-5: E2E test automation in CI (`scripts/e2e_phase5a.sh` is a manual gate today)
 - Phase 8-6: Address pre-existing `format:check` failures (~28 files)
 

--- a/frontend/src/components/alerts/OutboxPanel.tsx
+++ b/frontend/src/components/alerts/OutboxPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ErrorBanner } from '@/components/common/ErrorBanner';
@@ -5,6 +6,7 @@ import { EmptyState } from '@/components/common/EmptyState';
 import { OutboxFilterBar } from './OutboxFilterBar';
 import { OutboxRow } from './OutboxRow';
 import { useAlerts, useKids } from '@/lib/queries';
+import { useBulkCloseAlerts } from '@/lib/mutations';
 import type { OutboxFilterState, AlertStatus } from '@/lib/types';
 
 interface Props {
@@ -28,6 +30,8 @@ export function OutboxPanel({ searchParams, onFiltersChange, onClearFilters }: P
   const filters = parseSearchToFilters(searchParams);
   const kids = useKids();
   const { data, isLoading, isError, refetch } = useAlerts(filters);
+  const bulkClose = useBulkCloseAlerts();
+  const [selected, setSelected] = useState<Set<number>>(new Set());
 
   if (isLoading) return <Skeleton className="h-32 w-full" />;
   if (isError || !data) {
@@ -40,9 +44,65 @@ export function OutboxPanel({ searchParams, onFiltersChange, onClearFilters }: P
   const hasNext = end < total;
   const hasPrev = offset > 0;
 
+  const toggleSelect = (id: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectableIds = items.filter((a) => a.closed_at == null).map((a) => a.id);
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(selectableIds));
+    }
+  };
+
+  const handleBulkClose = async (reason: 'acknowledged' | 'dismissed') => {
+    if (selected.size === 0) return;
+    await bulkClose.mutateAsync({ alertIds: [...selected], reason });
+    setSelected(new Set());
+  };
+
   return (
     <div className="space-y-4">
       <OutboxFilterBar value={filters} onChange={onFiltersChange} kids={kids.data ?? []} />
+      {selected.size > 0 && (
+        <div className="flex items-center gap-2 rounded border border-border bg-accent/30 px-3 py-2 text-sm">
+          <span className="font-medium">{selected.size} selected</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={bulkClose.isPending}
+            onClick={() => handleBulkClose('acknowledged')}
+          >
+            Close as acknowledged
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={bulkClose.isPending}
+            onClick={() => handleBulkClose('dismissed')}
+          >
+            Close as dismissed
+          </Button>
+          <button
+            type="button"
+            className="ml-auto text-xs text-muted-foreground hover:text-foreground underline"
+            onClick={() => setSelected(new Set())}
+          >
+            Clear selection
+          </button>
+        </div>
+      )}
       {items.length === 0 ? (
         <EmptyState>
           No alerts match your filters.{' '}
@@ -51,13 +111,26 @@ export function OutboxPanel({ searchParams, onFiltersChange, onClearFilters }: P
           </button>
         </EmptyState>
       ) : (
-        <ul className="space-y-2">
-          {items.map((a) => (
-            <li key={a.id}>
-              <OutboxRow alert={a} />
-            </li>
-          ))}
-        </ul>
+        <>
+          {selectableIds.length > 0 && (
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={allSelected}
+                onChange={toggleSelectAll}
+                aria-label="Select all open alerts on this page"
+              />
+              Select all on this page
+            </label>
+          )}
+          <ul className="space-y-2">
+            {items.map((a) => (
+              <li key={a.id}>
+                <OutboxRow alert={a} selected={selected.has(a.id)} onToggleSelect={toggleSelect} />
+              </li>
+            ))}
+          </ul>
+        </>
       )}
       {total > 0 && (
         <div className="flex items-center justify-between text-sm">

--- a/frontend/src/components/alerts/OutboxRow.tsx
+++ b/frontend/src/components/alerts/OutboxRow.tsx
@@ -8,9 +8,11 @@ import type { Alert } from '@/lib/types';
 
 interface Props {
   alert: Alert;
+  selected?: boolean;
+  onToggleSelect?: (id: number) => void;
 }
 
-export function OutboxRow({ alert }: Props) {
+export function OutboxRow({ alert, selected, onToggleSelect }: Props) {
   const resend = useResendAlert();
   const [pillState, setPillState] = useState<'idle' | 'ok' | 'err'>('idle');
   const [pillDetail, setPillDetail] = useState<string>('');
@@ -38,6 +40,15 @@ export function OutboxRow({ alert }: Props) {
   return (
     <Card className="p-3 space-y-1">
       <div className="flex items-center gap-2">
+        {onToggleSelect && (
+          <input
+            type="checkbox"
+            checked={selected ?? false}
+            onChange={() => onToggleSelect(alert.id)}
+            aria-label={`Select alert ${alert.id}`}
+            disabled={alert.closed_at !== null}
+          />
+        )}
         <Badge variant="secondary">{alert.type}</Badge>
         <div className="flex-1 text-sm">{alert.summary_text}</div>
         <Button

--- a/frontend/src/lib/mutations.ts
+++ b/frontend/src/lib/mutations.ts
@@ -692,3 +692,30 @@ export function useResendAlert() {
     },
   });
 }
+
+interface BulkCloseAlertsInput {
+  alertIds: number[];
+  reason: CloseReason;
+}
+
+interface BulkCloseAlertsResult {
+  closed: Alert[];
+  not_found: number[];
+}
+
+export function useBulkCloseAlerts() {
+  const qc = useQueryClient();
+  return useMutation<BulkCloseAlertsResult, Error, BulkCloseAlertsInput>({
+    mutationFn: ({ alertIds, reason }) =>
+      api.post<BulkCloseAlertsResult>('/api/alerts/bulk/close', {
+        alert_ids: alertIds,
+        reason,
+      }),
+    onSettled: async () => {
+      // Invalidate both the alerts list (Outbox) and the inbox summary
+      // (so closed alerts disappear from Inbox if they were in-window).
+      await qc.invalidateQueries({ queryKey: ['alerts'] });
+      await qc.invalidateQueries({ queryKey: ['inbox', 'summary'] });
+    },
+  });
+}

--- a/src/yas/web/routes/alerts.py
+++ b/src/yas/web/routes/alerts.py
@@ -13,7 +13,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from yas.db.models import Alert, Kid
 from yas.db.models._types import AlertType
 from yas.db.session import session_scope
-from yas.web.routes.alerts_schemas import AlertCloseIn, AlertListResponse, AlertOut
+from yas.web.routes.alerts_schemas import (
+    AlertBulkCloseIn,
+    AlertBulkCloseOut,
+    AlertCloseIn,
+    AlertListResponse,
+    AlertOut,
+)
 from yas.web.routes.inbox_alert_summary import summarize_alert
 
 router = APIRouter(prefix="/api/alerts", tags=["alerts"])
@@ -209,6 +215,35 @@ async def resend_alert(request: Request, alert_id: int) -> AlertOut:
         await s.flush()
 
         return await _to_out(s, cloned)
+
+
+# NOTE: /bulk/close MUST be declared before /{alert_id}/close. Otherwise
+# FastAPI tries to match "bulk" as the {alert_id: int} path param and
+# returns 422 before the literal route is consulted.
+@router.post("/bulk/close", response_model=AlertBulkCloseOut)
+async def bulk_close_alerts(request: Request, body: AlertBulkCloseIn) -> AlertBulkCloseOut:
+    """Close many alerts in one request. Idempotent: already-closed alerts
+    have their close_reason updated but closed_at preserved. Missing IDs are
+    returned in `not_found` rather than 404'ing the whole request — partial
+    success is the common case for bulk UX."""
+    if not body.alert_ids:
+        return AlertBulkCloseOut(closed=[], not_found=[])
+    requested = list(set(body.alert_ids))
+    async with session_scope(_engine(request)) as s:
+        rows = (await s.execute(select(Alert).where(Alert.id.in_(requested)))).scalars().all()
+        found_ids = {a.id for a in rows}
+        not_found = [aid for aid in requested if aid not in found_ids]
+        now = datetime.now(UTC)
+        for alert in rows:
+            if alert.closed_at is None:
+                alert.closed_at = now
+            alert.close_reason = body.reason
+        await s.flush()
+        for alert in rows:
+            await s.refresh(alert)
+        closed_outs = [await _to_out(s, a) for a in rows]
+        closed_outs.sort(key=lambda a: a.id)
+        return AlertBulkCloseOut(closed=closed_outs, not_found=sorted(not_found))
 
 
 @router.post("/{alert_id}/close", response_model=AlertOut)

--- a/src/yas/web/routes/alerts_schemas.py
+++ b/src/yas/web/routes/alerts_schemas.py
@@ -44,3 +44,17 @@ class AlertCloseIn(BaseModel):
     """Request body for POST /api/alerts/{id}/close."""
 
     reason: CloseReason
+
+
+class AlertBulkCloseIn(BaseModel):
+    """Request body for POST /api/alerts/bulk/close."""
+
+    alert_ids: list[int]
+    reason: CloseReason
+
+
+class AlertBulkCloseOut(BaseModel):
+    """Response for POST /api/alerts/bulk/close."""
+
+    closed: list[AlertOut]
+    not_found: list[int]

--- a/tests/integration/test_api_alerts_close.py
+++ b/tests/integration/test_api_alerts_close.py
@@ -152,3 +152,99 @@ async def test_close_after_reopen_sets_new_closed_at(client):
     closed_at_2 = third.json()["closed_at"]
     assert closed_at_2 is not None
     assert closed_at_2 != closed_at_1
+
+
+# Phase 8-4 bulk close
+
+
+@pytest.mark.asyncio
+async def test_bulk_close_closes_many_alerts(client):
+    c, engine = client
+    async with session_scope(engine) as s:
+        s.add(
+            Alert(
+                id=2,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=datetime.now(UTC),
+                sent_at=None,
+                skipped=False,
+                dedup_key="open-2",
+                payload_json={"msg": "open"},
+            )
+        )
+        s.add(
+            Alert(
+                id=3,
+                type=AlertType.watchlist_hit,
+                kid_id=1,
+                channels=["email"],
+                scheduled_for=datetime.now(UTC),
+                sent_at=None,
+                skipped=False,
+                dedup_key="open-3",
+                payload_json={"msg": "open"},
+            )
+        )
+
+    r = await c.post(
+        "/api/alerts/bulk/close",
+        json={"alert_ids": [1, 2, 3], "reason": "dismissed"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["closed"]) == 3
+    assert all(a["close_reason"] == "dismissed" for a in body["closed"])
+    assert all(a["closed_at"] is not None for a in body["closed"])
+    assert body["not_found"] == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_close_returns_not_found_for_missing_ids(client):
+    c, _ = client
+    r = await c.post(
+        "/api/alerts/bulk/close",
+        json={"alert_ids": [1, 99, 100], "reason": "acknowledged"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    closed_ids = [a["id"] for a in body["closed"]]
+    assert closed_ids == [1]
+    assert body["not_found"] == [99, 100]
+
+
+@pytest.mark.asyncio
+async def test_bulk_close_idempotent_on_already_closed(client):
+    c, _ = client
+    first = await c.post(
+        "/api/alerts/bulk/close",
+        json={"alert_ids": [1], "reason": "acknowledged"},
+    )
+    first_closed_at = first.json()["closed"][0]["closed_at"]
+    second = await c.post(
+        "/api/alerts/bulk/close",
+        json={"alert_ids": [1], "reason": "dismissed"},
+    )
+    second_body = second.json()
+    assert second_body["closed"][0]["closed_at"] == first_closed_at  # preserved
+    assert second_body["closed"][0]["close_reason"] == "dismissed"  # updated
+
+
+@pytest.mark.asyncio
+async def test_bulk_close_empty_list_returns_empty(client):
+    c, _ = client
+    r = await c.post("/api/alerts/bulk/close", json={"alert_ids": [], "reason": "dismissed"})
+    assert r.status_code == 200
+    assert r.json() == {"closed": [], "not_found": []}
+
+
+@pytest.mark.asyncio
+async def test_bulk_close_dedupes_request_ids(client):
+    c, _ = client
+    r = await c.post(
+        "/api/alerts/bulk/close",
+        json={"alert_ids": [1, 1, 1], "reason": "acknowledged"},
+    )
+    body = r.json()
+    assert len(body["closed"]) == 1


### PR DESCRIPTION
## Summary

Closes roadmap §6 Phase 8-4 (close-many alerts). Mute-many and enroll-many are deferred — the roadmap explicitly framed Phase 8-4 as usage-informed, and we don't have usage yet. Close-many is the most universally-applicable bulk op (noisy inboxes); it ships now, the other two wait for real friction.

### Backend

\`POST /api/alerts/bulk/close\` taking \`{ alert_ids: int[], reason: 'acknowledged' | 'dismissed' }\`. Idempotent: already-closed alerts have \`close_reason\` updated but \`closed_at\` preserved. Missing IDs are returned in \`not_found\` rather than 404'ing the whole request — partial-success is the common case for bulk UX.

**Subtle gotcha:** the new route MUST be declared before \`/{alert_id}/close\`, otherwise FastAPI tries to match \"bulk\" as the int \`alert_id\` path param and 422s. Caught early by tests; inline comment in \`alerts.py\` explains.

### Frontend

- \`useBulkCloseAlerts\` mutation hook. Invalidates both \`['alerts']\` and \`['inbox','summary']\` on settle.
- \`OutboxRow\` accepts optional \`{ selected, onToggleSelect }\` props. Already-closed alerts render a disabled checkbox.
- \`OutboxPanel\` maintains a \`Set<number>\` of selected ids; renders a bulk-action bar above the list when any are selected (\"Close as acknowledged\", \"Close as dismissed\", \"Clear selection\"). \"Select all on this page\" toggle selects every open alert in the current page.

## Master §10 terminal criteria delta

None — Phase 8 is polish.

## Test plan

- [x] uv run pytest -q (607 passing, +5 bulk-close cases)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean
- [x] Backend tests: bulk close N; not_found for missing IDs; idempotent on already-closed; empty list returns empty; deduped request ids
- [ ] CI passes
- [ ] Manual smoke: select multiple alerts in Outbox, click \"Close as dismissed\", verify rows disappear and Inbox reflects closure