### PR TITLE
feat(post-v1): ICS calendar export per kid

### DIFF
--- a/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
@@ -160,7 +160,7 @@ The deviation root cause was **no re-audit step**. Each phase's spec referenced 
 These remain open from each shipped phase's "Out of scope":
 
 - **Pushover/Gotify channels** (master § 9) — small slice when needed
-- **`.ics` calendar export/import** (master § 9) — easy add on top of blocks model
+- **`.ics` calendar export** (master § 9) — ✅ shipped 2026-05-03. Per-kid feed at `GET /api/kids/{id}/calendar.ics`; default −7d/+90d window, 400-day cap. Match suggestions excluded; enrollment/unavailability/holiday included. Subscribe link on per-kid calendar page. (.ics *import* still deferred.)
 - **Driving-time vs great-circle distance** (master § 9) — only if real usage shows great-circle is misleading
 - **Soft conflicts as warnings** (master § 9) — e.g., "offering ends at 3:15pm but school ends at 3:00pm — too tight?"
 - **Mute reasons / per-channel mute** (5d-1 §1.2) — only if mute volume justifies it

--- a/frontend/src/routes/kids.$id.calendar.tsx
+++ b/frontend/src/routes/kids.$id.calendar.tsx
@@ -35,7 +35,14 @@ function KidCalendarPage() {
     <div>
       <h1 className="text-xl font-semibold mb-2">{kid.data.name}'s calendar</h1>
       <KidTabs kidId={kidId} />
-      <div className="my-2 flex justify-end">
+      <div className="my-2 flex items-center justify-end gap-4">
+        <a
+          href={`/api/kids/${kidId}/calendar.ics`}
+          className="text-xs text-muted-foreground underline hover:text-foreground"
+          title="iCalendar feed — subscribe in Apple Calendar / Google Calendar"
+        >
+          Subscribe (.ics)
+        </a>
         <label className="flex items-center gap-1 text-xs text-muted-foreground">
           <input
             type="checkbox"

--- a/src/yas/calendar/ics.py
+++ b/src/yas/calendar/ics.py
@@ -7,8 +7,8 @@ tests against the actual byte-for-byte structure.
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
-from typing import Iterable
+from collections.abc import Iterable
+from datetime import UTC, date, datetime
 
 from yas.web.routes.kid_calendar_schemas import CalendarEventOut
 
@@ -31,10 +31,7 @@ def _fmt_date(d: date) -> str:
 
 
 def _fmt_datetime_utc(d: datetime) -> str:
-    if d.tzinfo is None:
-        d = d.replace(tzinfo=timezone.utc)
-    else:
-        d = d.astimezone(timezone.utc)
+    d = d.replace(tzinfo=UTC) if d.tzinfo is None else d.astimezone(UTC)
     return d.strftime("%Y%m%dT%H%M%SZ")
 
 
@@ -94,7 +91,7 @@ def render_calendar_ics(
     - `now` is the DTSTAMP value. Defaults to `datetime.now(UTC)`.
     """
     if now is None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
     dtstamp = _fmt_datetime_utc(now)
     out: list[str] = [
         "BEGIN:VCALENDAR",

--- a/src/yas/calendar/ics.py
+++ b/src/yas/calendar/ics.py
@@ -1,0 +1,114 @@
+"""Render CalendarEventOut events as a VCALENDAR (RFC 5545) feed.
+
+Hand-rolled rather than pulling in the `icalendar` dep — the format is
+simple, the events are well-known shapes, and the output is verified by
+tests against the actual byte-for-byte structure.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Iterable
+
+from yas.web.routes.kid_calendar_schemas import CalendarEventOut
+
+# RFC 5545 mandates CRLF line endings. Some consumers tolerate LF, but
+# Apple Calendar and Google Calendar both enforce CRLF on import paths.
+_CRLF = "\r\n"
+
+# Match events are LLM-suggested — too noisy to import into a personal
+# calendar. Keep the export limited to commitments + structural blocks.
+_EXPORT_KINDS = {"enrollment", "unavailability", "holiday"}
+
+
+def _escape(text: str) -> str:
+    """Escape per RFC 5545 §3.3.11 (TEXT property values)."""
+    return text.replace("\\", "\\\\").replace(",", "\\,").replace(";", "\\;").replace("\n", "\\n")
+
+
+def _fmt_date(d: date) -> str:
+    return d.strftime("%Y%m%d")
+
+
+def _fmt_datetime_utc(d: datetime) -> str:
+    if d.tzinfo is None:
+        d = d.replace(tzinfo=timezone.utc)
+    else:
+        d = d.astimezone(timezone.utc)
+    return d.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _event_lines(ev: CalendarEventOut, *, dtstamp: str) -> list[str]:
+    """Render one VEVENT block for the given calendar event."""
+    lines = [
+        "BEGIN:VEVENT",
+        f"UID:yas-{ev.id}",
+        f"DTSTAMP:{dtstamp}",
+        f"SUMMARY:{_escape(ev.title)}",
+    ]
+    if ev.all_day:
+        # All-day per RFC 5545 §3.6.1: DTSTART;VALUE=DATE; DTEND is the
+        # day AFTER (exclusive end).
+        from datetime import timedelta as _td
+
+        next_day = ev.date + _td(days=1)
+        lines.append(f"DTSTART;VALUE=DATE:{_fmt_date(ev.date)}")
+        lines.append(f"DTEND;VALUE=DATE:{_fmt_date(next_day)}")
+    else:
+        # Timed event: combine the date with time fields. Times in our
+        # data model are local naive; we publish them as-floating
+        # (RFC 5545 "form 1") so subscribing apps render them in the
+        # viewer's local zone, matching how the SPA already shows them.
+        time_start = ev.time_start
+        time_end = ev.time_end
+        if time_start is None or time_end is None:
+            # Defensive: treat as all-day if a timed event somehow
+            # arrived without bounds.
+            from datetime import timedelta as _td
+
+            next_day = ev.date + _td(days=1)
+            lines.append(f"DTSTART;VALUE=DATE:{_fmt_date(ev.date)}")
+            lines.append(f"DTEND;VALUE=DATE:{_fmt_date(next_day)}")
+        else:
+            start_local = datetime.combine(ev.date, time_start)
+            end_local = datetime.combine(ev.date, time_end)
+            lines.append(f"DTSTART:{start_local.strftime('%Y%m%dT%H%M%S')}")
+            lines.append(f"DTEND:{end_local.strftime('%Y%m%dT%H%M%S')}")
+    lines.append("END:VEVENT")
+    return lines
+
+
+def render_calendar_ics(
+    *,
+    calendar_name: str,
+    events: Iterable[CalendarEventOut],
+    now: datetime | None = None,
+) -> str:
+    """Render a complete VCALENDAR document.
+
+    - `calendar_name` becomes both NAME and X-WR-CALNAME for broad
+      compatibility (RFC 7986 plus the older Apple/Google extension).
+    - `events` is filtered: only enrollment, unavailability, and
+      holiday kinds are exported. Match suggestions are intentionally
+      excluded — they would clutter a personal calendar.
+    - `now` is the DTSTAMP value. Defaults to `datetime.now(UTC)`.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    dtstamp = _fmt_datetime_utc(now)
+    out: list[str] = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Youth Activity Scheduler//yas//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        f"NAME:{_escape(calendar_name)}",
+        f"X-WR-CALNAME:{_escape(calendar_name)}",
+    ]
+    for ev in events:
+        if ev.kind not in _EXPORT_KINDS:
+            continue
+        out.extend(_event_lines(ev, dtstamp=dtstamp))
+    out.append("END:VCALENDAR")
+    out.append("")  # trailing CRLF per RFC
+    return _CRLF.join(out)

--- a/src/yas/web/routes/kid_calendar.py
+++ b/src/yas/web/routes/kid_calendar.py
@@ -1,14 +1,19 @@
-"""GET /api/kids/{kid_id}/calendar — aggregated per-kid event view."""
+"""GET /api/kids/{kid_id}/calendar — aggregated per-kid event view.
+
+Also serves an iCalendar (RFC 5545) export at the same path with a
+.ics suffix for subscription in Apple Calendar / Google Calendar / etc.
+"""
 
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, time
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from sqlalchemy import or_, select
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from yas.calendar.ics import render_calendar_ics
 from yas.calendar.occurrences import expand_recurring
 from yas.db.models import Enrollment, Kid, Match, Offering, Site, UnavailabilityBlock
 from yas.db.models._types import EnrollmentStatus
@@ -19,11 +24,197 @@ router = APIRouter(prefix="/api/kids", tags=["kids"])
 
 _MAX_RANGE_DAYS = 90
 _MATCH_THRESHOLD: float = 0.6
+# .ics export defaults: a sliding window so subscribed clients see
+# recent past + a meaningful future. Capped to keep the file small.
+_ICS_DEFAULT_PAST_DAYS = 7
+_ICS_DEFAULT_FUTURE_DAYS = 90
 
 
 def _engine(req: Request) -> AsyncEngine:
     engine: AsyncEngine = req.app.state.yas.engine
     return engine
+
+
+async def gather_kid_calendar_events(
+    session: AsyncSession,
+    *,
+    kid: Kid,
+    from_: date,
+    to: date,
+    include_matches: bool,
+) -> list[CalendarEventOut]:
+    """Build the sorted CalendarEventOut list for a kid in a date range.
+
+    Pure data-shaping; HTTP concerns live in the route handlers. Reused
+    by both the JSON endpoint and the .ics export.
+    """
+    s = session
+    kid_id = kid.id
+    now = datetime.now(UTC)
+    events: list[CalendarEventOut] = []
+
+    # School holidays: dates the matcher already skips for conflict checks.
+    # Used here to (a) hide school recurring blocks on those dates, and
+    # (b) emit explicit "Holiday" events for the same dates within the
+    # school-year ranges so the calendar isn't silently empty.
+    school_holiday_dates: set[date] = set()
+    for s_iso in kid.school_holidays or []:
+        try:
+            school_holiday_dates.add(date.fromisoformat(s_iso))
+        except ValueError:
+            continue
+    school_year_ranges_parsed: list[tuple[date, date]] = []
+    for entry in kid.school_year_ranges or []:
+        try:
+            school_year_ranges_parsed.append(
+                (date.fromisoformat(entry["start"]), date.fromisoformat(entry["end"]))
+            )
+        except KeyError, ValueError:
+            continue
+
+    enrollment_rows = (
+        await s.execute(
+            select(Enrollment, Offering)
+            .join(Offering, Offering.id == Enrollment.offering_id)
+            .where(Enrollment.kid_id == kid_id)
+            .where(Enrollment.status == EnrollmentStatus.enrolled.value)
+        )
+    ).all()
+    for enrollment, offering in enrollment_rows:
+        for occ in expand_recurring(
+            days_of_week=list(offering.days_of_week or []),
+            time_start=offering.time_start,
+            time_end=offering.time_end,
+            date_start=offering.start_date,
+            date_end=offering.end_date,
+            range_from=from_,
+            range_to=to,
+        ):
+            events.append(
+                CalendarEventOut(
+                    id=f"enrollment:{enrollment.id}:{occ.date.isoformat()}",
+                    kind="enrollment",
+                    date=occ.date,
+                    time_start=occ.time_start,
+                    time_end=occ.time_end,
+                    all_day=occ.all_day,
+                    title=offering.name,
+                    enrollment_id=enrollment.id,
+                    offering_id=offering.id,
+                    location_id=offering.location_id,
+                    status=enrollment.status,
+                )
+            )
+
+    block_rows = (
+        (
+            await s.execute(
+                select(UnavailabilityBlock)
+                .where(UnavailabilityBlock.kid_id == kid_id)
+                .where(UnavailabilityBlock.active.is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for block in block_rows:
+        for occ in expand_recurring(
+            days_of_week=list(block.days_of_week or []),
+            time_start=block.time_start,
+            time_end=block.time_end,
+            date_start=block.date_start,
+            date_end=block.date_end,
+            range_from=from_,
+            range_to=to,
+        ):
+            # School blocks: hide on holiday dates. Other blocks unchanged.
+            if block.source == "school" and occ.date in school_holiday_dates:
+                continue
+            events.append(
+                CalendarEventOut(
+                    id=f"unavailability:{block.id}:{occ.date.isoformat()}",
+                    kind="unavailability",
+                    date=occ.date,
+                    time_start=occ.time_start,
+                    time_end=occ.time_end,
+                    all_day=occ.all_day,
+                    title=block.label or block.source,
+                    block_id=block.id,
+                    source=block.source,
+                    from_enrollment_id=block.source_enrollment_id,
+                )
+            )
+
+    # Explicit Holiday events for holiday dates in range AND inside at
+    # least one school_year_range (closed interval).
+    for h in sorted(school_holiday_dates):
+        if h < from_ or h > to:
+            continue
+        in_school_year = any(start <= h <= end for start, end in school_year_ranges_parsed)
+        if not in_school_year:
+            continue
+        events.append(
+            CalendarEventOut(
+                id=f"holiday:{kid_id}:{h.isoformat()}",
+                kind="holiday",
+                date=h,
+                time_start=None,
+                time_end=None,
+                all_day=True,
+                title="Holiday",
+            )
+        )
+
+    # Match overlay (opt-in).
+    if include_matches:
+        committed_offering_ids = (
+            select(Enrollment.offering_id)
+            .where(Enrollment.kid_id == kid_id)
+            .where(Enrollment.status != EnrollmentStatus.cancelled.value)
+        )
+        match_rows = (
+            await s.execute(
+                select(Match, Offering)
+                .join(Offering, Offering.id == Match.offering_id)
+                .join(Site, Site.id == Offering.site_id)
+                .where(Match.kid_id == kid_id)
+                .where(Match.score >= _MATCH_THRESHOLD)
+                .where(~Match.offering_id.in_(committed_offering_ids))
+                .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= now))
+                .where(or_(Site.muted_until.is_(None), Site.muted_until <= now))
+            )
+        ).all()
+        for match, offering in match_rows:
+            for occ in expand_recurring(
+                days_of_week=list(offering.days_of_week or []),
+                time_start=offering.time_start,
+                time_end=offering.time_end,
+                date_start=offering.start_date,
+                date_end=offering.end_date,
+                range_from=from_,
+                range_to=to,
+            ):
+                events.append(
+                    CalendarEventOut(
+                        id=f"match:{offering.id}:{occ.date.isoformat()}",
+                        kind="match",
+                        date=occ.date,
+                        time_start=occ.time_start,
+                        time_end=occ.time_end,
+                        all_day=occ.all_day,
+                        title=offering.name,
+                        offering_id=offering.id,
+                        location_id=offering.location_id,
+                        score=match.score,
+                        registration_url=offering.registration_url,
+                        watchlist_hit=bool((match.reasons or {}).get("watchlist_hit")),
+                    )
+                )
+
+    # Sort by (date, time_start). time_start is `time | None`; coerce
+    # all-day events to `time.min` so we always compare time-to-time.
+    events.sort(key=lambda e: (e.date, e.time_start or time.min))
+    return events
 
 
 @router.get("/{kid_id}/calendar", response_model=KidCalendarOut, response_model_by_alias=True)
@@ -42,178 +233,56 @@ async def get_kid_calendar(
             detail=f"range exceeds {_MAX_RANGE_DAYS}-day cap",
         )
 
-    now = datetime.now(UTC)
+    async with session_scope(_engine(request)) as s:
+        kid = (await s.execute(select(Kid).where(Kid.id == kid_id))).scalar_one_or_none()
+        if kid is None:
+            raise HTTPException(status_code=404, detail=f"kid {kid_id} not found")
+        events = await gather_kid_calendar_events(
+            s, kid=kid, from_=from_, to=to, include_matches=include_matches
+        )
+        return KidCalendarOut(kid_id=kid_id, from_=from_, to=to, events=events)
+
+
+@router.get("/{kid_id}/calendar.ics")
+async def get_kid_calendar_ics(
+    request: Request,
+    kid_id: int,
+    from_: Annotated[date | None, Query(alias="from")] = None,
+    to: Annotated[date | None, Query()] = None,
+) -> Response:
+    """RFC 5545 iCalendar feed for subscription in external calendars.
+
+    Defaults to a -7d / +90d sliding window if no explicit range. Match
+    suggestions are NOT exported (they would clutter a personal calendar);
+    enrollment, unavailability, and holiday events are.
+    """
+    today = datetime.now(UTC).date()
+    if from_ is None:
+        from datetime import timedelta as _td
+
+        from_ = today - _td(days=_ICS_DEFAULT_PAST_DAYS)
+    if to is None:
+        from datetime import timedelta as _td
+
+        to = today + _td(days=_ICS_DEFAULT_FUTURE_DAYS)
+    if from_ >= to:
+        raise HTTPException(status_code=422, detail="from must be before to")
+    # Allow a wider range than the JSON endpoint since subscribers want a
+    # full year+ in advance for school blocks. Cap at 400 days.
+    if (to - from_).days > 400:
+        raise HTTPException(status_code=422, detail="range exceeds 400-day cap")
 
     async with session_scope(_engine(request)) as s:
         kid = (await s.execute(select(Kid).where(Kid.id == kid_id))).scalar_one_or_none()
         if kid is None:
             raise HTTPException(status_code=404, detail=f"kid {kid_id} not found")
-
-        events: list[CalendarEventOut] = []
-
-        # School holidays: dates the matcher already skips for conflict checks.
-        # Used here to (a) hide school recurring blocks on those dates, and
-        # (b) emit explicit "Holiday" events for the same dates within the
-        # school-year ranges so the calendar isn't silently empty.
-        school_holiday_dates: set[date] = set()
-        for s_iso in kid.school_holidays or []:
-            try:
-                school_holiday_dates.add(date.fromisoformat(s_iso))
-            except ValueError:
-                continue
-        school_year_ranges_parsed: list[tuple[date, date]] = []
-        for entry in kid.school_year_ranges or []:
-            try:
-                school_year_ranges_parsed.append(
-                    (date.fromisoformat(entry["start"]), date.fromisoformat(entry["end"]))
-                )
-            except KeyError, ValueError:
-                continue
-
-        enrollment_rows = (
-            await s.execute(
-                select(Enrollment, Offering)
-                .join(Offering, Offering.id == Enrollment.offering_id)
-                .where(Enrollment.kid_id == kid_id)
-                .where(Enrollment.status == EnrollmentStatus.enrolled.value)
-            )
-        ).all()
-        for enrollment, offering in enrollment_rows:
-            for occ in expand_recurring(
-                days_of_week=list(offering.days_of_week or []),
-                time_start=offering.time_start,
-                time_end=offering.time_end,
-                date_start=offering.start_date,
-                date_end=offering.end_date,
-                range_from=from_,
-                range_to=to,
-            ):
-                events.append(
-                    CalendarEventOut(
-                        id=f"enrollment:{enrollment.id}:{occ.date.isoformat()}",
-                        kind="enrollment",
-                        date=occ.date,
-                        time_start=occ.time_start,
-                        time_end=occ.time_end,
-                        all_day=occ.all_day,
-                        title=offering.name,
-                        enrollment_id=enrollment.id,
-                        offering_id=offering.id,
-                        location_id=offering.location_id,
-                        status=enrollment.status,
-                    )
-                )
-
-        block_rows = (
-            (
-                await s.execute(
-                    select(UnavailabilityBlock)
-                    .where(UnavailabilityBlock.kid_id == kid_id)
-                    .where(UnavailabilityBlock.active.is_(True))
-                )
-            )
-            .scalars()
-            .all()
+        events = await gather_kid_calendar_events(
+            s, kid=kid, from_=from_, to=to, include_matches=False
         )
-        for block in block_rows:
-            for occ in expand_recurring(
-                days_of_week=list(block.days_of_week or []),
-                time_start=block.time_start,
-                time_end=block.time_end,
-                date_start=block.date_start,
-                date_end=block.date_end,
-                range_from=from_,
-                range_to=to,
-            ):
-                # School blocks: hide on holiday dates. Other blocks unchanged.
-                if block.source == "school" and occ.date in school_holiday_dates:
-                    continue
-                events.append(
-                    CalendarEventOut(
-                        id=f"unavailability:{block.id}:{occ.date.isoformat()}",
-                        kind="unavailability",
-                        date=occ.date,
-                        time_start=occ.time_start,
-                        time_end=occ.time_end,
-                        all_day=occ.all_day,
-                        title=block.label or block.source,
-                        block_id=block.id,
-                        source=block.source,
-                        from_enrollment_id=block.source_enrollment_id,
-                    )
-                )
-
-        # Emit explicit Holiday events for holiday dates that fall in range
-        # AND inside at least one school_year_range (closed interval). A
-        # holiday outside the school year would imply school is being
-        # cancelled on a day that's already free, which is misleading.
-        for h in sorted(school_holiday_dates):
-            if h < from_ or h > to:
-                continue
-            in_school_year = any(start <= h <= end for start, end in school_year_ranges_parsed)
-            if not in_school_year:
-                continue
-            events.append(
-                CalendarEventOut(
-                    id=f"holiday:{kid_id}:{h.isoformat()}",
-                    kind="holiday",
-                    date=h,
-                    time_start=None,
-                    time_end=None,
-                    all_day=True,
-                    title="Holiday",
-                )
-            )
-
-        # 3. Match overlay (opt-in).
-        if include_matches:
-            committed_offering_ids = (
-                select(Enrollment.offering_id)
-                .where(Enrollment.kid_id == kid_id)
-                .where(Enrollment.status != EnrollmentStatus.cancelled.value)
-            )
-            match_rows = (
-                await s.execute(
-                    select(Match, Offering)
-                    .join(Offering, Offering.id == Match.offering_id)
-                    .join(Site, Site.id == Offering.site_id)
-                    .where(Match.kid_id == kid_id)
-                    .where(Match.score >= _MATCH_THRESHOLD)
-                    .where(~Match.offering_id.in_(committed_offering_ids))
-                    .where(or_(Offering.muted_until.is_(None), Offering.muted_until <= now))
-                    .where(or_(Site.muted_until.is_(None), Site.muted_until <= now))
-                )
-            ).all()
-            for match, offering in match_rows:
-                for occ in expand_recurring(
-                    days_of_week=list(offering.days_of_week or []),
-                    time_start=offering.time_start,
-                    time_end=offering.time_end,
-                    date_start=offering.start_date,
-                    date_end=offering.end_date,
-                    range_from=from_,
-                    range_to=to,
-                ):
-                    events.append(
-                        CalendarEventOut(
-                            id=f"match:{offering.id}:{occ.date.isoformat()}",
-                            kind="match",
-                            date=occ.date,
-                            time_start=occ.time_start,
-                            time_end=occ.time_end,
-                            all_day=occ.all_day,
-                            title=offering.name,
-                            offering_id=offering.id,
-                            location_id=offering.location_id,
-                            score=match.score,
-                            registration_url=offering.registration_url,
-                            watchlist_hit=bool((match.reasons or {}).get("watchlist_hit")),
-                        )
-                    )
-
-        # Sort by (date, time_start). time_start is `time | None`; coerce
-        # all-day events to `time.min` so we always compare time-to-time.
-        # Mixing `time` and `str` in the sort key crashes at runtime when
-        # both an all-day and a timed event fall on the same date.
-        events.sort(key=lambda e: (e.date, e.time_start or time.min))
-        return KidCalendarOut(kid_id=kid_id, from_=from_, to=to, events=events)
+        body = render_calendar_ics(calendar_name=f"{kid.name} — YAS", events=events)
+        # Filename hint for Save dialogs / subscription clients.
+        return Response(
+            content=body,
+            media_type="text/calendar; charset=utf-8",
+            headers={"Content-Disposition": f'inline; filename="{kid.name}-yas.ics"'},
+        )

--- a/tests/integration/test_api_kids_calendar.py
+++ b/tests/integration/test_api_kids_calendar.py
@@ -759,3 +759,77 @@ async def test_match_watchlist_hit_flag_false_for_score_only_match(client):
     matches = [e for e in body["events"] if e["kind"] == "match"]
     assert len(matches) == 1
     assert matches[0]["watchlist_hit"] is False
+
+
+# ICS export endpoint
+
+
+@pytest.mark.asyncio
+async def test_ics_export_returns_text_calendar_with_enrollment(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+
+    r = await c.get("/api/kids/1/calendar.ics?from=2026-04-27&to=2026-05-04")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/calendar")
+    body = r.text
+    assert "BEGIN:VCALENDAR" in body
+    assert "PRODID:-//Youth Activity Scheduler//yas//EN" in body
+    assert "NAME:Sam — YAS" in body
+    assert "SUMMARY:T-Ball" in body
+    assert body.rstrip("\r\n").endswith("END:VCALENDAR")
+
+
+@pytest.mark.asyncio
+async def test_ics_export_excludes_match_events(client):
+    """Match suggestions are NOT exported (would clutter personal calendar)."""
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    async with session_scope(engine) as s:
+        s.add(
+            Offering(
+                id=2,
+                site_id=1,
+                page_id=1,
+                name="Soccer Suggestion",
+                normalized_name="soccer-suggestion",
+                days_of_week=["wed"],
+                time_start=time(17, 0),
+                time_end=time(18, 0),
+                start_date=date(2026, 4, 1),
+                end_date=date(2026, 6, 30),
+                status=OfferingStatus.active.value,
+            )
+        )
+    await _seed_match(engine, kid_id=1, offering_id=2, score=0.9)
+
+    r = await c.get("/api/kids/1/calendar.ics?from=2026-04-27&to=2026-05-04")
+    body = r.text
+    assert "T-Ball" in body
+    assert "Soccer Suggestion" not in body
+
+
+@pytest.mark.asyncio
+async def test_ics_export_404_for_unknown_kid(client):
+    c, _ = client
+    r = await c.get("/api/kids/999/calendar.ics")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_ics_export_uses_default_window_when_no_range(client):
+    """No from/to → -7d to +90d sliding window, doesn't 422."""
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    r = await c.get("/api/kids/1/calendar.ics")
+    assert r.status_code == 200
+    assert "BEGIN:VCALENDAR" in r.text
+
+
+@pytest.mark.asyncio
+async def test_ics_export_400_day_cap_enforced(client):
+    c, engine = client
+    await _seed_kid_with_enrollment(engine, kid_id=1, offering_id=1)
+    r = await c.get("/api/kids/1/calendar.ics?from=2024-01-01&to=2026-01-01")
+    assert r.status_code == 422
+    assert "400-day" in r.json()["detail"]

--- a/tests/unit/test_ics.py
+++ b/tests/unit/test_ics.py
@@ -107,9 +107,7 @@ def test_dtstamp_is_utc_z_format():
 
 
 def test_calendar_name_with_special_chars_is_escaped():
-    out = render_calendar_ics(
-        calendar_name="Sam, the kid; cool", events=[], now=_NOW
-    )
+    out = render_calendar_ics(calendar_name="Sam, the kid; cool", events=[], now=_NOW)
     assert "NAME:Sam\\, the kid\\; cool\r\n" in out
 
 

--- a/tests/unit/test_ics.py
+++ b/tests/unit/test_ics.py
@@ -1,0 +1,152 @@
+"""Unit tests for VCALENDAR rendering."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time
+
+import pytest
+
+from yas.calendar.ics import render_calendar_ics
+from yas.web.routes.kid_calendar_schemas import CalendarEventOut
+
+
+def _ev(**overrides: object) -> CalendarEventOut:
+    """Helper: produce a minimal CalendarEventOut with sensible defaults."""
+    base = {
+        "id": "enrollment:1:2026-05-13",
+        "kind": "enrollment",
+        "date": date(2026, 5, 13),
+        "time_start": time(16, 0),
+        "time_end": time(17, 0),
+        "all_day": False,
+        "title": "T-Ball",
+    }
+    base.update(overrides)
+    return CalendarEventOut(**base)  # type: ignore[arg-type]
+
+
+_NOW = datetime(2026, 5, 2, 20, 0, 0, tzinfo=UTC)
+
+
+def test_renders_minimal_vcalendar_envelope():
+    out = render_calendar_ics(calendar_name="Sam — YAS", events=[], now=_NOW)
+    assert out.startswith("BEGIN:VCALENDAR\r\n")
+    assert "VERSION:2.0\r\n" in out
+    assert "PRODID:-//Youth Activity Scheduler//yas//EN\r\n" in out
+    assert "NAME:Sam — YAS\r\n" in out
+    assert "X-WR-CALNAME:Sam — YAS\r\n" in out
+    assert out.endswith("END:VCALENDAR\r\n")
+
+
+def test_timed_event_emits_floating_dtstart_dtend():
+    out = render_calendar_ics(calendar_name="cal", events=[_ev()], now=_NOW)
+    assert "BEGIN:VEVENT\r\n" in out
+    assert "UID:yas-enrollment:1:2026-05-13\r\n" in out
+    assert "DTSTART:20260513T160000\r\n" in out  # no Z — floating local time
+    assert "DTEND:20260513T170000\r\n" in out
+    assert "SUMMARY:T-Ball\r\n" in out
+
+
+def test_all_day_event_uses_value_date_and_exclusive_end():
+    ev = _ev(
+        id="holiday:1:2026-04-29",
+        kind="holiday",
+        date=date(2026, 4, 29),
+        time_start=None,
+        time_end=None,
+        all_day=True,
+        title="Holiday",
+    )
+    out = render_calendar_ics(calendar_name="cal", events=[ev], now=_NOW)
+    assert "DTSTART;VALUE=DATE:20260429\r\n" in out
+    assert "DTEND;VALUE=DATE:20260430\r\n" in out  # exclusive end
+
+
+def test_match_events_are_excluded():
+    """Match suggestions clutter a personal calendar; export skips them."""
+    timed = _ev()
+    match_ev = _ev(id="match:5:2026-05-13", kind="match", title="Maybe Soccer")
+    out = render_calendar_ics(calendar_name="cal", events=[timed, match_ev], now=_NOW)
+    assert "T-Ball" in out
+    assert "Maybe Soccer" not in out
+
+
+def test_unavailability_and_holiday_events_are_included():
+    school = _ev(
+        id="unavailability:7:2026-05-13",
+        kind="unavailability",
+        all_day=False,
+        time_start=time(8, 0),
+        time_end=time(15, 0),
+        title="School",
+    )
+    holiday = _ev(
+        id="holiday:1:2026-04-29",
+        kind="holiday",
+        date=date(2026, 4, 29),
+        time_start=None,
+        time_end=None,
+        all_day=True,
+        title="Holiday",
+    )
+    out = render_calendar_ics(calendar_name="cal", events=[school, holiday], now=_NOW)
+    assert "SUMMARY:School\r\n" in out
+    assert "SUMMARY:Holiday\r\n" in out
+
+
+def test_text_escape_handles_commas_semicolons_backslashes_newlines():
+    ev = _ev(title="Sam, Smith; coach\\team\nNotes")
+    out = render_calendar_ics(calendar_name="cal", events=[ev], now=_NOW)
+    # Per RFC 5545 §3.3.11.
+    assert "SUMMARY:Sam\\, Smith\\; coach\\\\team\\nNotes\r\n" in out
+
+
+def test_dtstamp_is_utc_z_format():
+    out = render_calendar_ics(calendar_name="cal", events=[_ev()], now=_NOW)
+    assert "DTSTAMP:20260502T200000Z\r\n" in out
+
+
+def test_calendar_name_with_special_chars_is_escaped():
+    out = render_calendar_ics(
+        calendar_name="Sam, the kid; cool", events=[], now=_NOW
+    )
+    assert "NAME:Sam\\, the kid\\; cool\r\n" in out
+
+
+def test_empty_event_list_still_valid():
+    out = render_calendar_ics(calendar_name="empty", events=[], now=_NOW)
+    assert "BEGIN:VEVENT" not in out
+    assert out.startswith("BEGIN:VCALENDAR")
+    assert out.endswith("END:VCALENDAR\r\n")
+
+
+def test_timed_event_missing_times_falls_back_to_all_day():
+    """Defensive path: a 'timed' event without bounds becomes all-day."""
+    ev = _ev(time_start=None, time_end=None, all_day=False)
+    out = render_calendar_ics(calendar_name="cal", events=[ev], now=_NOW)
+    assert "DTSTART;VALUE=DATE:" in out
+
+
+@pytest.mark.parametrize(
+    "kind,expect",
+    [
+        ("enrollment", True),
+        ("unavailability", True),
+        ("holiday", True),
+        ("match", False),
+    ],
+)
+def test_kind_filter_matrix(kind: str, expect: bool):
+    ev = _ev(
+        id=f"{kind}:1:2026-05-13",
+        kind=kind,  # type: ignore[arg-type]
+        all_day=(kind == "holiday"),
+        time_start=None if kind == "holiday" else time(9, 0),
+        time_end=None if kind == "holiday" else time(10, 0),
+        title=f"X-{kind}",
+    )
+    out = render_calendar_ics(calendar_name="cal", events=[ev], now=_NOW)
+    if expect:
+        assert f"SUMMARY:X-{kind}\r\n" in out
+    else:
+        assert f"X-{kind}" not in out


### PR DESCRIPTION
First post-v1 §9 deferred item shipped. New per-kid iCalendar feed at \`GET /api/kids/{id}/calendar.ics\` for subscription in Apple Calendar / Google Calendar / etc.

## Why this first

Highest delight per LOC of any §9 item. The data model is already correct (we just shipped the holiday-aware per-kid calendar in 8-2); this is one new endpoint that emits VCALENDAR. Subscribing the kid's URL in iCal/Google Cal means YAS events show up where you already look, no extra surface.

## Backend

- **\`src/yas/calendar/ics.py\`** — pure RFC 5545 renderer. Hand-rolled, no new deps (the format is simple and we want to keep the dep tree lean). Handles timed events (floating local time, no Z) and all-day events (DTSTART;VALUE=DATE with exclusive DTEND). Escapes commas/semicolons/backslashes/newlines per §3.3.11.
- **Refactor:** \`kid_calendar.py\` got a \`gather_kid_calendar_events()\` helper extracted from the existing handler. The JSON and ICS endpoints share the same SQL + filtering logic and differ only in serialization. ~130 lines of formerly-handler code become a reusable function.
- **New endpoint:** \`/{kid_id}/calendar.ics\`. Default sliding window −7d/+90d if no from/to. 400-day cap (wider than the JSON 90d since subscribers want school blocks far in advance). Match suggestions intentionally excluded; enrollment + unavailability + holiday included.

## Frontend

A single \`<a href=\"…/calendar.ics\">Subscribe (.ics)</a>\` link in the per-kid calendar header, next to the Show matches toggle.

## Master §10 terminal criteria delta

None — this is post-v1. Phase 9 (observation) is still the only remaining v1 work.

## Test plan

- [x] uv run pytest -q (626 passing, +19)
  - 14 new unit tests in tests/unit/test_ics.py (envelope, timed, all-day, kind filter, escape rules)
  - 5 new integration tests in tests/integration/test_api_kids_calendar.py (endpoint round-trip, 404, default window, 400d cap, match exclusion)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean
- [ ] CI passes
- [ ] Manual smoke: subscribe to the .ics URL in macOS Calendar (or curl + open) and verify events render with correct titles/times