### PR TITLE
feat(post-v1): soft-conflict warnings on near-miss matches

### DIFF
--- a/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
@@ -163,7 +163,7 @@ These remain open from each shipped phase's "Out of scope":
 - **Gotify channel** (master § 9) — ❌ not implemented. Small slice when actually needed (mirror PushoverChannel against Gotify's HTTP API).
 - **`.ics` calendar export** (master § 9) — ✅ shipped 2026-05-03. Per-kid feed at `GET /api/kids/{id}/calendar.ics`; default −7d/+90d window, 400-day cap. Match suggestions excluded; enrollment/unavailability/holiday included. Subscribe link on per-kid calendar page. (.ics *import* still deferred.)
 - **Driving-time vs great-circle distance** (master § 9) — only if real usage shows great-circle is misleading
-- **Soft conflicts as warnings** (master § 9) — e.g., "offering ends at 3:15pm but school ends at 3:00pm — too tight?"
+- **Soft conflicts as warnings** (master § 9) — ✅ shipped 2026-05-03. Matcher computes near-misses against unavailability blocks (default 15-min buffer); stored in `Match.reasons.soft_conflicts`; surfaced as a "⚠ Tight" chip on offering rows.
 - **Mute reasons / per-channel mute** (5d-1 §1.2) — only if mute volume justifies it
 - **User-controllable match score threshold** (5c-2 §1.2) — only if 0.6 fixed feels wrong
 - **Watchlist on calendar** (5c-1 §1.2) — ✅ shipped 2026-05-02 as Phase 8-3

--- a/frontend/src/lib/offeringsFilters.ts
+++ b/frontend/src/lib/offeringsFilters.ts
@@ -204,5 +204,19 @@ export function chipsForOffering(
       className: 'bg-purple-100 text-purple-900 dark:bg-purple-900/30 dark:text-purple-200',
     });
   }
+  // 6. Tight (soft conflict — matcher flagged a near-miss against an
+  // unavailability block, e.g., school ends 3pm and offering starts 3:10pm)
+  const tight = row.matches.some(
+    (m) =>
+      Array.isArray((m.reasons as { soft_conflicts?: unknown }).soft_conflicts) &&
+      ((m.reasons as { soft_conflicts: unknown[] }).soft_conflicts?.length ?? 0) > 0,
+  );
+  if (tight) {
+    chips.push({
+      kind: 'tight',
+      label: '⚠ Tight',
+      className: 'bg-yellow-100 text-yellow-900 dark:bg-yellow-900/30 dark:text-yellow-200',
+    });
+  }
   return chips.slice(0, 3);
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -45,7 +45,13 @@ export interface OfferingSummary {
 // Phase 7-2 types
 export type SortKey = 'best_score' | 'soonest_start' | 'soonest_reg';
 
-export type ChipKind = 'watchlist' | 'top_match' | 'opens_this_week' | 'near_home' | 'in_interests';
+export type ChipKind =
+  | 'watchlist'
+  | 'top_match'
+  | 'opens_this_week'
+  | 'near_home'
+  | 'in_interests'
+  | 'tight';
 
 export interface Chip {
   kind: ChipKind;

--- a/src/yas/matching/matcher.py
+++ b/src/yas/matching/matcher.py
@@ -33,6 +33,7 @@ from yas.matching.gates import (
     offering_active_and_not_ended,
 )
 from yas.matching.scoring import compute_score
+from yas.matching.soft_conflicts import find_soft_conflicts
 from yas.matching.watchlist import matches_watchlist
 
 log = get_logger("yas.matching.matcher")
@@ -230,6 +231,13 @@ async def _evaluate_pair(
     )
     include = watchlist is not None or _gates_passed(gates)
     reasons = _reasons_payload(gates, breakdown, watchlist)
+    # Surface soft (tight) conflicts on included matches so the UI can
+    # warn about near-misses the hard gate let through. Computed only
+    # for matches we'd surface anyway — pure waste otherwise.
+    if include:
+        soft = find_soft_conflicts(offering, filtered_blocks, school_holidays, today=today)
+        if soft:
+            reasons["soft_conflicts"] = [sc.to_dict() for sc in soft]
     return include, score, reasons
 
 

--- a/src/yas/matching/soft_conflicts.py
+++ b/src/yas/matching/soft_conflicts.py
@@ -1,0 +1,159 @@
+"""Detect soft (tight) conflicts between an offering and unavailability blocks.
+
+A soft conflict is a near-miss the hard gate would have allowed but a
+human would still want to know about: e.g., school ends at 3:00pm and
+T-Ball starts at 3:15pm — technically no overlap, but realistically the
+kid can't get from school to the field on time.
+
+Returns short human-readable warning strings. Empty list when nothing
+is tight enough to flag.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, time, timedelta
+from typing import Any
+
+DEFAULT_BUFFER_MINUTES = 15
+
+
+@dataclass(frozen=True)
+class SoftConflict:
+    label: str
+    gap_min: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {"label": self.label, "gap_min": self.gap_min}
+
+
+_DAY_NAMES = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+
+def _weekday_name(d: date) -> str:
+    return _DAY_NAMES[d.weekday()]
+
+
+def _to_minutes(t: time) -> int:
+    return t.hour * 60 + t.minute
+
+
+def _fmt_time(t: time) -> str:
+    """Format like '3:15pm' (no leading zero on hour)."""
+    h = t.hour % 12 or 12
+    suffix = "am" if t.hour < 12 else "pm"
+    if t.minute == 0:
+        return f"{h}{suffix}"
+    return f"{h}:{t.minute:02d}{suffix}"
+
+
+def _gap_minutes(
+    offering_start: time,
+    offering_end: time,
+    block_start: time,
+    block_end: time,
+) -> int | None:
+    """Return the smallest minute gap if the two intervals don't overlap.
+
+    None if they overlap (the hard gate handles that). Positive int
+    otherwise — the smaller of (offering_start - block_end) and
+    (block_start - offering_end).
+    """
+    o_s, o_e = _to_minutes(offering_start), _to_minutes(offering_end)
+    b_s, b_e = _to_minutes(block_start), _to_minutes(block_end)
+    if o_s < b_e and b_s < o_e:
+        return None  # overlap
+    # Two non-overlap cases: offering before block, or offering after block.
+    if o_e <= b_s:
+        return b_s - o_e
+    return o_s - b_e
+
+
+def find_soft_conflicts(
+    offering: Any,
+    blocks: list[Any],
+    school_holidays: set[date],
+    *,
+    today: date,
+    buffer_minutes: int = DEFAULT_BUFFER_MINUTES,
+) -> list[SoftConflict]:
+    """Return SoftConflict warnings for tight (non-overlap, < buffer) gaps.
+
+    Mirrors the iteration shape of `no_conflict_with_unavailability` —
+    same date range, same weekday filter, same school-holiday handling.
+    Skips offerings or blocks without complete schedules; nothing to
+    measure against if either side has missing time bounds.
+    """
+    if (
+        offering.start_date is None
+        or offering.end_date is None
+        or not offering.days_of_week
+        or offering.time_start is None
+        or offering.time_end is None
+    ):
+        return []
+
+    offering_days = {d.lower() for d in (getattr(d, "value", d) for d in offering.days_of_week)}
+    active_blocks = [b for b in blocks if b.active]
+    if not active_blocks:
+        return []
+
+    # Dedupe: emit one warning per (block_id, side) combo across the
+    # date range, since the same school-end-vs-tball-start tightness
+    # repeats every Tuesday for the whole season.
+    seen: set[tuple[Any, str]] = set()
+    out: list[SoftConflict] = []
+
+    cur = offering.start_date
+    end = offering.end_date
+    while cur <= end:
+        weekday = _weekday_name(cur)
+        if weekday in offering_days:
+            for block in active_blocks:
+                source = getattr(block.source, "value", block.source)
+                if source == "school" and cur in school_holidays:
+                    continue
+                if block.date_start is not None and cur < block.date_start:
+                    continue
+                if block.date_end is not None and cur > block.date_end:
+                    continue
+                block_days = {
+                    d.lower() for d in (getattr(d, "value", d) for d in (block.days_of_week or []))
+                }
+                if block_days and weekday not in block_days:
+                    continue
+                if block.time_start is None or block.time_end is None:
+                    continue  # all-day block; hard gate would have caught this
+
+                gap = _gap_minutes(
+                    offering.time_start, offering.time_end, block.time_start, block.time_end
+                )
+                if gap is None:
+                    continue  # overlap → hard gate's problem
+                if gap >= buffer_minutes:
+                    continue
+                # Decide which side: is offering AFTER the block (block-end → offering-start),
+                # or BEFORE the block (offering-end → block-start)?
+                if _to_minutes(offering.time_start) >= _to_minutes(block.time_end):
+                    side = "after"
+                    label = (
+                        f"{(block.label or source).strip().capitalize()} ends "
+                        f"{_fmt_time(block.time_end)}; "
+                        f"{offering.name} starts {_fmt_time(offering.time_start)} "
+                        f"({gap} min gap)"
+                    )
+                else:
+                    side = "before"
+                    label = (
+                        f"{offering.name} ends {_fmt_time(offering.time_end)}; "
+                        f"{(block.label or source).strip().capitalize()} starts "
+                        f"{_fmt_time(block.time_start)} ({gap} min gap)"
+                    )
+                key = (block.id, side)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(SoftConflict(label=label, gap_min=gap))
+        cur += timedelta(days=1)
+
+    return out

--- a/tests/unit/test_soft_conflicts.py
+++ b/tests/unit/test_soft_conflicts.py
@@ -1,0 +1,218 @@
+"""Unit tests for soft-conflict detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, time
+
+import pytest
+
+from yas.matching.soft_conflicts import (
+    DEFAULT_BUFFER_MINUTES,
+    SoftConflict,
+    find_soft_conflicts,
+)
+
+
+@dataclass
+class _Offering:
+    name: str
+    days_of_week: list[str]
+    time_start: time | None
+    time_end: time | None
+    start_date: date | None
+    end_date: date | None
+
+
+@dataclass
+class _Block:
+    id: int
+    source: str
+    label: str | None
+    days_of_week: list[str]
+    time_start: time | None
+    time_end: time | None
+    date_start: date | None
+    date_end: date | None
+    active: bool = True
+
+
+_TODAY = date(2026, 5, 4)  # Monday
+_SEASON_START = date(2026, 5, 5)  # Tuesday
+_SEASON_END = date(2026, 6, 30)
+
+
+def _school_block() -> _Block:
+    return _Block(
+        id=1,
+        source="school",
+        label="School",
+        days_of_week=["mon", "tue", "wed", "thu", "fri"],
+        time_start=time(8, 0),
+        time_end=time(15, 0),
+        date_start=date(2026, 4, 1),
+        date_end=date(2026, 6, 30),
+    )
+
+
+def _offering(*, time_start: time, time_end: time, days: list[str] | None = None) -> _Offering:
+    return _Offering(
+        name="T-Ball",
+        days_of_week=days or ["tue", "thu"],
+        time_start=time_start,
+        time_end=time_end,
+        start_date=_SEASON_START,
+        end_date=_SEASON_END,
+    )
+
+
+def test_15_min_gap_is_NOT_flagged_default_buffer_is_strict_less_than():
+    """At exactly the buffer threshold, no warning. Buffer is < not <=."""
+    offering = _offering(time_start=time(15, 15), time_end=time(16, 15))
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert out == []
+
+
+def test_14_min_gap_is_flagged():
+    offering = _offering(time_start=time(15, 14), time_end=time(16, 14))
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert len(out) == 1
+    assert "14 min gap" in out[0].label
+
+
+def test_overlap_returns_no_soft_conflict_hard_gate_problem():
+    """Hard gate handles overlap; soft-conflict only flags non-overlapping near-misses."""
+    offering = _offering(time_start=time(14, 30), time_end=time(15, 30))
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert out == []
+
+
+def test_wide_gap_returns_no_soft_conflict():
+    offering = _offering(time_start=time(16, 0), time_end=time(17, 0))  # 60 min after school
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert out == []
+
+
+def test_offering_BEFORE_block_emits_warning_when_tight():
+    """Morning offering ending right before school starts."""
+    offering = _offering(
+        time_start=time(7, 0), time_end=time(7, 50), days=["mon"]
+    )  # ends 7:50, school 8:00 → 10 min
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert len(out) == 1
+    assert "T-Ball ends 7:50am" in out[0].label
+    assert "School starts 8am" in out[0].label
+    assert "10 min gap" in out[0].label
+
+
+def test_school_holiday_skips_school_block_check():
+    """A holiday on the offering date means there's no school to be tight against."""
+    school_only_tuesday = _Block(
+        id=1,
+        source="school",
+        label="School",
+        days_of_week=["tue"],
+        time_start=time(8, 0),
+        time_end=time(15, 0),
+        date_start=date(2026, 5, 5),
+        date_end=date(2026, 5, 5),  # only the one Tuesday
+    )
+    offering = _offering(
+        time_start=time(15, 5), time_end=time(16, 0), days=["tue"]
+    )  # would be 5 min gap
+    holiday = {date(2026, 5, 5)}
+    out = find_soft_conflicts(offering, [school_only_tuesday], holiday, today=_TODAY)
+    assert out == []
+
+
+def test_inactive_block_ignored():
+    inactive = _school_block()
+    inactive.active = False
+    offering = _offering(time_start=time(15, 5), time_end=time(16, 0))
+    out = find_soft_conflicts(offering, [inactive], set(), today=_TODAY)
+    assert out == []
+
+
+def test_dedupe_across_date_range_one_warning_per_block_side():
+    """Tight every Tuesday for the season → one warning, not 8 of them."""
+    offering = _offering(time_start=time(15, 5), time_end=time(16, 0))
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert len(out) == 1
+
+
+def test_offering_with_partial_schedule_returns_empty():
+    offering = _offering(time_start=time(15, 5), time_end=time(16, 0))
+    offering.time_start = None
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY)
+    assert out == []
+
+
+def test_block_without_time_bounds_skipped():
+    """All-day blocks are the hard gate's concern, not soft-conflict's."""
+    all_day = _Block(
+        id=1,
+        source="manual",
+        label="Vacation",
+        days_of_week=[],
+        time_start=None,
+        time_end=None,
+        date_start=date(2026, 5, 5),
+        date_end=date(2026, 5, 5),
+    )
+    offering = _offering(time_start=time(9, 0), time_end=time(10, 0), days=["tue"])
+    out = find_soft_conflicts(offering, [all_day], set(), today=_TODAY)
+    assert out == []
+
+
+def test_block_outside_date_range_ignored():
+    out_of_range = _school_block()
+    out_of_range.date_start = date(2027, 1, 1)
+    out_of_range.date_end = date(2027, 6, 30)
+    offering = _offering(time_start=time(15, 5), time_end=time(16, 0))
+    out = find_soft_conflicts(offering, [out_of_range], set(), today=_TODAY)
+    assert out == []
+
+
+def test_no_blocks_returns_empty():
+    offering = _offering(time_start=time(15, 5), time_end=time(16, 0))
+    out = find_soft_conflicts(offering, [], set(), today=_TODAY)
+    assert out == []
+
+
+def test_to_dict_returns_label_and_gap_min():
+    sc = SoftConflict(label="hi", gap_min=5)
+    assert sc.to_dict() == {"label": "hi", "gap_min": 5}
+
+
+def test_default_buffer_is_15_minutes():
+    assert DEFAULT_BUFFER_MINUTES == 15
+
+
+def test_custom_buffer_threshold():
+    """Tighter buffer means more things qualify; looser means fewer."""
+    offering = _offering(time_start=time(15, 20), time_end=time(16, 0))  # 20 min gap
+    # Default 15-min buffer: not tight enough.
+    assert find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY) == []
+    # Looser 30-min buffer: now flagged.
+    out = find_soft_conflicts(offering, [_school_block()], set(), today=_TODAY, buffer_minutes=30)
+    assert len(out) == 1
+    assert "20 min gap" in out[0].label
+
+
+@pytest.mark.parametrize(
+    "t,expected",
+    [
+        (time(15, 0), "3pm"),
+        (time(15, 15), "3:15pm"),
+        (time(8, 0), "8am"),
+        (time(7, 50), "7:50am"),
+        (time(0, 0), "12am"),
+        (time(12, 0), "12pm"),
+        (time(12, 30), "12:30pm"),
+    ],
+)
+def test_time_formatter(t: time, expected: str):
+    """Indirect test of _fmt_time via the label output."""
+    from yas.matching.soft_conflicts import _fmt_time
+
+    assert _fmt_time(t) == expected


### PR DESCRIPTION
Closes another §9 deferred item: soft conflicts as warnings.

The matcher already hard-gates on **overlap** with unavailability blocks. This adds parallel detection of **near-misses** — e.g., school ends 3pm, T-Ball starts 3:10pm. Technically no overlap (the hard gate lets it through), but the kid can't realistically get from one to the other.

## Backend

- **\`src/yas/matching/soft_conflicts.py\`** — pure helper \`find_soft_conflicts(offering, blocks, school_holidays, *, today, buffer_minutes=15)\`. Mirrors \`no_conflict_with_unavailability\`'s iteration shape (date range × weekday filter × school-holiday handling). Returns \`list[SoftConflict]\` with human-readable labels like \`\"School ends 3pm; T-Ball starts 3:15pm (15 min gap)\"\`.
- **Dedupes per \`(block.id, side)\`** — tightness that repeats every Tuesday for the season emits one warning, not eight.
- **Wired into \`matcher._evaluate_pair\`** — when a match is included, compute soft conflicts and merge into \`reasons.soft_conflicts\`. Omitted entirely if empty (no payload bloat).

## Frontend

- New \`'tight'\` \`ChipKind\`. Yellow palette (warning, not error).
- \`chipsForOffering\` reads \`m.reasons.soft_conflicts\` and emits a \`⚠ Tight\` chip when any match in the row has at least one soft conflict. Existing 3-chip display cap still applies.

## Master §10 terminal criteria delta

None — post-v1 polish.

## Test plan

- [x] uv run pytest -q (648 passing, +22 in test_soft_conflicts.py)
  - Buffer threshold (\`<\` not \`<=\`)
  - Overlap returns no soft conflict (hard gate's job)
  - Wide gap returns no soft conflict
  - Offering BEFORE block (morning offering ending right before school)
  - School holidays skip the school block check
  - Inactive blocks ignored
  - Dedupe across the date range
  - Partial-schedule offerings return empty
  - All-day blocks (no time bounds) skipped
  - Time-formatter parametrize matrix
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (298)
- [ ] CI passes
- [ ] Manual smoke: kid with school 8a-3p; offering Tue 3:10p-4p; verify '⚠ Tight' chip on offering row