### PR TITLE
feat(post-v1): drive-time foundation (OSRM + cache) [1/3]

### DIFF
--- a/alembic/versions/0005_drive_time_cache.py
+++ b/alembic/versions/0005_drive_time_cache.py
@@ -1,0 +1,38 @@
+"""add drive_time_cache table for routed-driving distance/duration.
+
+Revision ID: 0005_drive_time_cache
+Revises: 0004_alert_close
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_drive_time_cache"
+down_revision: str | Sequence[str] | None = "0004_alert_close"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Composite primary key on rounded coordinates: 4-decimal precision
+    # is ~11 meters, plenty of granularity. Rounding before storage
+    # makes "same trip" cache hits robust against geocode jitter.
+    op.create_table(
+        "drive_time_cache",
+        sa.Column("home_lat", sa.Float, primary_key=True),
+        sa.Column("home_lon", sa.Float, primary_key=True),
+        sa.Column("dest_lat", sa.Float, primary_key=True),
+        sa.Column("dest_lon", sa.Float, primary_key=True),
+        sa.Column("drive_minutes", sa.Float, nullable=False),
+        sa.Column("drive_meters", sa.Float, nullable=False),
+        sa.Column("provider", sa.String, nullable=False),
+        sa.Column("computed_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("drive_time_cache")

--- a/src/yas/config.py
+++ b/src/yas/config.py
@@ -46,6 +46,13 @@ class Settings(BaseSettings):
     geocode_batch_size: int = 20
     geocode_nominatim_min_interval_s: float = 1.0
 
+    # Drive-time (OSRM-backed routed driving distance/duration). Off
+    # by default so existing great-circle behavior is unchanged. When
+    # enabled, the matcher uses drive minutes against
+    # `kid.max_drive_minutes` instead of haversine miles.
+    drive_time_enabled: bool = False
+    osrm_base_url: str = "https://router.project-osrm.org"
+
     # Daily sweep
     sweep_enabled: bool = True
     sweep_time_utc: str = "07:00"

--- a/src/yas/db/models/__init__.py
+++ b/src/yas/db/models/__init__.py
@@ -1,6 +1,7 @@
 from yas.db.models.alert import Alert
 from yas.db.models.alert_routing import AlertRouting
 from yas.db.models.crawl_run import CrawlRun
+from yas.db.models.drive_time_cache import DriveTimeCache
 from yas.db.models.enrollment import Enrollment
 from yas.db.models.extraction_cache import ExtractionCache
 from yas.db.models.geocode_attempt import GeocodeAttempt
@@ -19,6 +20,7 @@ __all__ = [
     "Alert",
     "AlertRouting",
     "CrawlRun",
+    "DriveTimeCache",
     "Enrollment",
     "ExtractionCache",
     "GeocodeAttempt",

--- a/src/yas/db/models/drive_time_cache.py
+++ b/src/yas/db/models/drive_time_cache.py
@@ -1,0 +1,28 @@
+"""Memoized routed driving distance/duration between geocoded points."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from yas.db.base import Base
+
+
+class DriveTimeCache(Base):
+    __tablename__ = "drive_time_cache"
+
+    # Coordinates are rounded to 4 decimals (~11 m) before write so
+    # geocode jitter doesn't fragment the cache. The four-column
+    # primary key avoids needing a secondary id.
+    home_lat: Mapped[float] = mapped_column(Float, primary_key=True)
+    home_lon: Mapped[float] = mapped_column(Float, primary_key=True)
+    dest_lat: Mapped[float] = mapped_column(Float, primary_key=True)
+    dest_lon: Mapped[float] = mapped_column(Float, primary_key=True)
+
+    drive_minutes: Mapped[float] = mapped_column(Float, nullable=False)
+    drive_meters: Mapped[float] = mapped_column(Float, nullable=False)
+    # "osrm" today; future providers (mapbox, google) reuse the same table.
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/src/yas/geo/drive_time.py
+++ b/src/yas/geo/drive_time.py
@@ -1,0 +1,197 @@
+"""Routed driving distance/duration via OSRM, with DB-backed caching.
+
+Every (home, dest) pair becomes a row in `drive_time_cache` once
+computed. Coordinates are rounded to 4 decimals (~11 m) before lookup
+and write so geocode jitter doesn't fragment the cache.
+
+OSRM is the default provider — open-source, no API key. Public
+endpoint at router.project-osrm.org works for low-volume use; for
+higher volume, point YAS_OSRM_BASE_URL at a self-hosted instance.
+
+Failures (transport, HTTP, parse) return None. Callers decide whether
+to fall back to great-circle distance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from yas.db.models import DriveTimeCache
+
+_COORD_PRECISION = 4
+PROVIDER_OSRM = "osrm"
+
+
+def _round(c: float) -> float:
+    return round(c, _COORD_PRECISION)
+
+
+@dataclass(frozen=True)
+class DriveTimeResult:
+    drive_minutes: float
+    drive_meters: float
+    provider: str
+
+
+class DriveTimeProvider(Protocol):
+    async def query(
+        self,
+        home: tuple[float, float],
+        dest: tuple[float, float],
+    ) -> DriveTimeResult | None: ...
+
+
+class OsrmClient:
+    """OSRM /route/v1/driving fetcher.
+
+    The public endpoint at https://router.project-osrm.org has rate
+    limits but is fine for a single household's lifetime usage. For
+    higher volume, set YAS_OSRM_BASE_URL to a self-hosted instance.
+    """
+
+    DEFAULT_BASE_URL = "https://router.project-osrm.org"
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = (base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self._owns_client = http_client is None
+        self._http = http_client or httpx.AsyncClient(timeout=httpx.Timeout(15.0))
+
+    async def query(
+        self,
+        home: tuple[float, float],
+        dest: tuple[float, float],
+    ) -> DriveTimeResult | None:
+        # OSRM expects lon,lat (NOT lat,lon). Pre-coordinate-pair order is critical.
+        url = (
+            f"{self._base_url}/route/v1/driving/"
+            f"{home[1]:.6f},{home[0]:.6f};{dest[1]:.6f},{dest[0]:.6f}"
+            "?overview=false&alternatives=false"
+        )
+        try:
+            r = await self._http.get(url)
+        except httpx.TransportError:
+            return None
+        if r.status_code >= 400:
+            return None
+        try:
+            data: dict[str, Any] = r.json()
+        except ValueError:
+            return None
+        if data.get("code") != "Ok":
+            return None
+        routes = data.get("routes") or []
+        if not routes:
+            return None
+        first = routes[0]
+        try:
+            duration_s = float(first["duration"])
+            distance_m = float(first["distance"])
+        except KeyError, TypeError, ValueError:
+            return None
+        return DriveTimeResult(
+            drive_minutes=duration_s / 60.0,
+            drive_meters=distance_m,
+            provider=PROVIDER_OSRM,
+        )
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._http.aclose()
+
+
+async def get_cached_drive_time(
+    session: AsyncSession,
+    home: tuple[float, float],
+    dest: tuple[float, float],
+) -> DriveTimeResult | None:
+    """Return a cached drive time if present, else None. Coordinates rounded."""
+    h_lat, h_lon = _round(home[0]), _round(home[1])
+    d_lat, d_lon = _round(dest[0]), _round(dest[1])
+    row = (
+        await session.execute(
+            select(DriveTimeCache).where(
+                DriveTimeCache.home_lat == h_lat,
+                DriveTimeCache.home_lon == h_lon,
+                DriveTimeCache.dest_lat == d_lat,
+                DriveTimeCache.dest_lon == d_lon,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return DriveTimeResult(
+        drive_minutes=row.drive_minutes,
+        drive_meters=row.drive_meters,
+        provider=row.provider,
+    )
+
+
+async def store_drive_time(
+    session: AsyncSession,
+    home: tuple[float, float],
+    dest: tuple[float, float],
+    result: DriveTimeResult,
+) -> None:
+    """Upsert a cache row. Caller is responsible for commit/flush."""
+    h_lat, h_lon = _round(home[0]), _round(home[1])
+    d_lat, d_lon = _round(dest[0]), _round(dest[1])
+    existing = (
+        await session.execute(
+            select(DriveTimeCache).where(
+                DriveTimeCache.home_lat == h_lat,
+                DriveTimeCache.home_lon == h_lon,
+                DriveTimeCache.dest_lat == d_lat,
+                DriveTimeCache.dest_lon == d_lon,
+            )
+        )
+    ).scalar_one_or_none()
+    now = datetime.now(UTC)
+    if existing is not None:
+        existing.drive_minutes = result.drive_minutes
+        existing.drive_meters = result.drive_meters
+        existing.provider = result.provider
+        existing.computed_at = now
+        return
+    session.add(
+        DriveTimeCache(
+            home_lat=h_lat,
+            home_lon=h_lon,
+            dest_lat=d_lat,
+            dest_lon=d_lon,
+            drive_minutes=result.drive_minutes,
+            drive_meters=result.drive_meters,
+            provider=result.provider,
+            computed_at=now,
+        )
+    )
+
+
+async def compute_drive_time(
+    session: AsyncSession,
+    provider: DriveTimeProvider,
+    home: tuple[float, float],
+    dest: tuple[float, float],
+) -> DriveTimeResult | None:
+    """Cache-first lookup. On miss, query the provider and persist.
+
+    Returns None if the provider call fails — callers fall back to
+    great-circle distance.
+    """
+    cached = await get_cached_drive_time(session, home, dest)
+    if cached is not None:
+        return cached
+    result = await provider.query(home, dest)
+    if result is None:
+        return None
+    await store_drive_time(session, home, dest, result)
+    return result

--- a/tests/unit/test_drive_time.py
+++ b/tests/unit/test_drive_time.py
@@ -1,0 +1,216 @@
+"""Unit tests for OSRM client + drive-time caching."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from yas.geo.drive_time import (
+    PROVIDER_OSRM,
+    DriveTimeResult,
+    OsrmClient,
+    compute_drive_time,
+    get_cached_drive_time,
+    store_drive_time,
+)
+
+# ---- OsrmClient ----------------------------------------------------------------
+
+
+class _FakeTransport(httpx.AsyncBaseTransport):
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return self._handler(request)
+
+
+def _ok_response(*, duration_s: float, distance_m: float) -> dict[str, Any]:
+    return {
+        "code": "Ok",
+        "routes": [{"duration": duration_s, "distance": distance_m}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_osrm_client_parses_ok_response():
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Verify lon,lat order in the URL (OSRM expects it inverted) and
+        # that 6-decimal formatting is used.
+        assert "/route/v1/driving/-122.419400,37.774900;-118.243700,34.052200" in str(request.url)
+        return httpx.Response(200, json=_ok_response(duration_s=21600.0, distance_m=600000.0))
+
+    client = OsrmClient(http_client=httpx.AsyncClient(transport=_FakeTransport(handler)))
+    result = await client.query(home=(37.7749, -122.4194), dest=(34.0522, -118.2437))
+    assert result is not None
+    assert result.drive_minutes == pytest.approx(360.0)  # 21600s = 360 min
+    assert result.drive_meters == 600000.0
+    assert result.provider == PROVIDER_OSRM
+
+
+@pytest.mark.asyncio
+async def test_osrm_client_returns_none_on_no_route():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"code": "NoRoute"})
+
+    client = OsrmClient(http_client=httpx.AsyncClient(transport=_FakeTransport(handler)))
+    result = await client.query(home=(0.0, 0.0), dest=(1.0, 1.0))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_osrm_client_returns_none_on_4xx():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"code": "InvalidQuery"})
+
+    client = OsrmClient(http_client=httpx.AsyncClient(transport=_FakeTransport(handler)))
+    result = await client.query(home=(0.0, 0.0), dest=(1.0, 1.0))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_osrm_client_returns_none_on_transport_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    client = OsrmClient(http_client=httpx.AsyncClient(transport=_FakeTransport(handler)))
+    result = await client.query(home=(0.0, 0.0), dest=(1.0, 1.0))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_osrm_client_uses_custom_base_url():
+    seen_url: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_url.append(str(request.url))
+        return httpx.Response(200, json=_ok_response(duration_s=60.0, distance_m=1000.0))
+
+    client = OsrmClient(
+        base_url="http://my-osrm.local:5000/",
+        http_client=httpx.AsyncClient(transport=_FakeTransport(handler)),
+    )
+    await client.query(home=(1.0, 2.0), dest=(3.0, 4.0))
+    assert seen_url[0].startswith("http://my-osrm.local:5000/route/v1/driving/")
+
+
+@pytest.mark.asyncio
+async def test_osrm_client_returns_none_on_malformed_routes():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"code": "Ok", "routes": []})
+
+    client = OsrmClient(http_client=httpx.AsyncClient(transport=_FakeTransport(handler)))
+    assert await client.query(home=(0.0, 0.0), dest=(1.0, 1.0)) is None
+
+
+# ---- cache layer ---------------------------------------------------------------
+
+
+@pytest.fixture
+async def session(tmp_path):
+    from yas.db.base import Base
+    from yas.db.session import create_engine_for, session_scope
+
+    engine = create_engine_for(f"sqlite+aiosqlite:///{tmp_path}/dt.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with session_scope(engine) as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_returns_none(session):
+    out = await get_cached_drive_time(session, (1.0, 2.0), (3.0, 4.0))
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_store_then_get_roundtrip(session):
+    res = DriveTimeResult(drive_minutes=12.5, drive_meters=8000.0, provider=PROVIDER_OSRM)
+    await store_drive_time(session, (1.0, 2.0), (3.0, 4.0), res)
+    await session.flush()
+    cached = await get_cached_drive_time(session, (1.0, 2.0), (3.0, 4.0))
+    assert cached is not None
+    assert cached.drive_minutes == 12.5
+    assert cached.drive_meters == 8000.0
+    assert cached.provider == PROVIDER_OSRM
+
+
+@pytest.mark.asyncio
+async def test_cache_rounds_coordinates_to_4_decimals(session):
+    """Geocode jitter at the 5th decimal must hit the same cache row."""
+    res = DriveTimeResult(drive_minutes=10.0, drive_meters=5000.0, provider=PROVIDER_OSRM)
+    # Both stored and lookup coords rounded to 4 decimals should land on
+    # (37.7749, -122.4194) and (34.0522, -118.2437) respectively.
+    await store_drive_time(session, (37.7749, -122.4194), (34.0522, -118.2437), res)
+    await session.flush()
+    # 5th-decimal jitter that doesn't push past the rounding boundary.
+    cached = await get_cached_drive_time(session, (37.77492, -122.41943), (34.05222, -118.24373))
+    assert cached is not None
+    assert cached.drive_minutes == 10.0
+
+
+@pytest.mark.asyncio
+async def test_store_overwrites_existing_row(session):
+    a = DriveTimeResult(drive_minutes=10.0, drive_meters=5000.0, provider=PROVIDER_OSRM)
+    b = DriveTimeResult(drive_minutes=15.0, drive_meters=7500.0, provider=PROVIDER_OSRM)
+    await store_drive_time(session, (1.0, 2.0), (3.0, 4.0), a)
+    await session.flush()
+    await store_drive_time(session, (1.0, 2.0), (3.0, 4.0), b)
+    await session.flush()
+    cached = await get_cached_drive_time(session, (1.0, 2.0), (3.0, 4.0))
+    assert cached is not None
+    assert cached.drive_minutes == 15.0
+
+
+# ---- compute_drive_time -------------------------------------------------------
+
+
+class _StubProvider:
+    def __init__(self, result: DriveTimeResult | None):
+        self.result = result
+        self.calls = 0
+
+    async def query(self, home, dest):
+        self.calls += 1
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_compute_returns_cached_without_calling_provider(session):
+    res = DriveTimeResult(drive_minutes=10.0, drive_meters=5000.0, provider=PROVIDER_OSRM)
+    await store_drive_time(session, (1.0, 2.0), (3.0, 4.0), res)
+    await session.flush()
+    provider = _StubProvider(result=None)
+    out = await compute_drive_time(session, provider, (1.0, 2.0), (3.0, 4.0))
+    assert out is not None
+    assert out.drive_minutes == 10.0
+    assert provider.calls == 0  # cache hit; provider untouched
+
+
+@pytest.mark.asyncio
+async def test_compute_calls_provider_on_miss_and_caches(session):
+    new_res = DriveTimeResult(drive_minutes=22.0, drive_meters=15000.0, provider=PROVIDER_OSRM)
+    provider = _StubProvider(result=new_res)
+    out = await compute_drive_time(session, provider, (1.0, 2.0), (3.0, 4.0))
+    assert out is not None
+    assert out.drive_minutes == 22.0
+    assert provider.calls == 1
+    # Second call should hit cache.
+    await session.flush()
+    out2 = await compute_drive_time(session, provider, (1.0, 2.0), (3.0, 4.0))
+    assert out2 is not None
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_compute_returns_none_when_provider_fails(session):
+    provider = _StubProvider(result=None)
+    out = await compute_drive_time(session, provider, (1.0, 2.0), (3.0, 4.0))
+    assert out is None
+    # Nothing was cached either — failed lookups stay open for retry.
+    cached = await get_cached_drive_time(session, (1.0, 2.0), (3.0, 4.0))
+    assert cached is None


### PR DESCRIPTION
PR 1 of 3 for §9 driving-time vs great-circle. Pure infrastructure — no matcher or UI behavior change. The follow-up PRs build on this foundation.

## What this PR does

- **Migration 0005**: \`drive_time_cache\` table. Composite PK on \`(home_lat, home_lon, dest_lat, dest_lon)\` rounded to 4 decimals (~11m precision). Storing rounded coords means geocode jitter doesn't fragment the cache.
- **\`src/yas/geo/drive_time.py\`**:
  - \`OsrmClient\` (open-source, no API key required). Targets \`/route/v1/driving/{lon,lat;lon,lat}?overview=false&alternatives=false\`. Note the lon,lat order — OSRM is the inverse of most other geo APIs.
  - \`compute_drive_time(session, provider, home, dest)\` — cache-first; on miss, queries the provider and persists. Provider failures return None so callers can fall back to great-circle distance.
  - \`DriveTimeProvider\` Protocol so future providers (Mapbox, Google) reuse the cache + compute helpers.
- **\`DriveTimeCache\` SQLAlchemy model** registered in \`db.models.__init__\`.
- **Settings**:
  - \`YAS_DRIVE_TIME_ENABLED\` — default \`false\`. Opt-in so existing great-circle behavior is unchanged.
  - \`YAS_OSRM_BASE_URL\` — default \`https://router.project-osrm.org\`. Self-host by changing this URL.

## What this PR does NOT do

- Matcher integration (PR 2 will add \`kid.max_drive_minutes\` + the gate).
- UI surfacing (PR 3 will add the chip + kid-form field).

The setting being default-off means this PR ships zero behavioral change. It's all dormant infrastructure until PR 2 wires it in.

## Master §10 terminal criteria delta

None — post-v1 polish.

## Test plan

- [x] uv run pytest -q (661 passing, +13 in test_drive_time.py)
- [x] uv run ruff check / format / mypy clean
- [x] alembic upgrade head from a fresh DB applies all 5 migrations including 0005 cleanly
- [ ] CI passes