### PR TITLE
feat(post-v1): drive-time matcher gate [2/3]

### DIFF
--- a/alembic/versions/0006_kid_max_drive_minutes.py
+++ b/alembic/versions/0006_kid_max_drive_minutes.py
@@ -1,0 +1,28 @@
+"""add kids.max_drive_minutes for drive-time gate.
+
+Revision ID: 0006_kid_max_drive_minutes
+Revises: 0005_drive_time_cache
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006_kid_max_drive_minutes"
+down_revision: str | Sequence[str] | None = "0005_drive_time_cache"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "kids",
+        sa.Column("max_drive_minutes", sa.Integer, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("kids", "max_drive_minutes")

--- a/frontend/src/components/kids/KidForm.test.tsx
+++ b/frontend/src/components/kids/KidForm.test.tsx
@@ -31,6 +31,7 @@ const seedKid = (overrides: Partial<KidDetail> = {}): KidDetail => ({
   active: true,
   availability: {},
   max_distance_mi: null,
+  max_drive_minutes: null,
   alert_score_threshold: 0.6,
   alert_on: {},
   school_weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'],

--- a/frontend/src/lib/mutations.test.tsx
+++ b/frontend/src/lib/mutations.test.tsx
@@ -539,6 +539,7 @@ const seedKid = (overrides: Partial<KidDetail> = {}): KidDetail => ({
   active: true,
   availability: {},
   max_distance_mi: null,
+  max_drive_minutes: null,
   alert_score_threshold: 0.6,
   alert_on: {},
   school_weekdays: ['mon', 'tue', 'wed', 'thu', 'fri'],

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -157,6 +157,7 @@ export interface WatchlistEntry {
 export interface KidDetail extends KidBrief {
   availability: Record<string, unknown>;
   max_distance_mi: number | null;
+  max_drive_minutes: number | null;
   alert_score_threshold: number;
   alert_on: Record<string, boolean>;
   school_weekdays: string[];

--- a/src/yas/db/models/kid.py
+++ b/src/yas/db/models/kid.py
@@ -21,6 +21,11 @@ class Kid(Base):
     interests: Mapped[list[str]] = mapped_column(JSON, default=list)
     availability: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     max_distance_mi: Mapped[float | None] = mapped_column(nullable=True)
+    # Drive-time cap (minutes). When set AND the household has
+    # YAS_DRIVE_TIME_ENABLED=true, the matcher uses this cap instead of
+    # max_distance_mi. Nullable so existing kids (great-circle only)
+    # keep working.
+    max_drive_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
     alert_score_threshold: Mapped[float] = mapped_column(default=0.6)
     alert_on: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     # School schedule — source of truth; unavailability_blocks with source=school

--- a/src/yas/matching/gates.py
+++ b/src/yas/matching/gates.py
@@ -59,7 +59,35 @@ def distance_fits(
     *,
     distance_mi: float | None,
     household_default: float | None,
+    drive_minutes: float | None = None,
 ) -> GateResult:
+    """Distance gate.
+
+    Two modes, in order of preference:
+    1. **Drive-time gate** — used when `kid.max_drive_minutes` is set
+       AND `drive_minutes` is provided. The drive_minutes value is
+       computed by the matcher's drive-time helper (which respects
+       the `YAS_DRIVE_TIME_ENABLED` setting and falls back to None
+       on provider failure).
+    2. **Great-circle miles gate** — original behavior. Used when
+       drive-time isn't available, when no drive-time cap is set, or
+       when drive-time is misconfigured. Compares `distance_mi`
+       against `kid.max_distance_mi` or `household_default`.
+
+    A None on whichever side we'd consult means we let the offering
+    through with a `*_unknown` reason so it's surfaced rather than
+    silently dropped.
+    """
+    drive_cap = getattr(kid, "max_drive_minutes", None)
+    if drive_cap is not None and drive_minutes is not None:
+        if offering.location_id is None:
+            return GateResult(True, "drive_time_unknown", "location not geocoded")
+        if drive_minutes <= drive_cap:
+            return GateResult(
+                True, "drive_time_ok", f"{drive_minutes:.0f}min of {drive_cap}min max"
+            )
+        return GateResult(False, "too_far_drive", f"{drive_minutes:.0f}min > {drive_cap}min max")
+
     cap = kid.max_distance_mi if kid.max_distance_mi is not None else household_default
     if cap is None:
         return GateResult(True, "distance_unlimited", "no distance cap configured")

--- a/src/yas/matching/matcher.py
+++ b/src/yas/matching/matcher.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from yas.alerts.enqueuer import enqueue_new_match, enqueue_watchlist_hit
+from yas.config import get_settings
 from yas.db.models import (
     Enrollment,
     HouseholdSettings,
@@ -22,6 +23,7 @@ from yas.db.models import (
 )
 from yas.db.models._types import OfferingStatus
 from yas.geo.distance import great_circle_miles
+from yas.geo.drive_time import DriveTimeProvider, OsrmClient, compute_drive_time
 from yas.logging import get_logger
 from yas.matching.aliases import INTEREST_ALIASES
 from yas.matching.gates import (
@@ -88,6 +90,45 @@ async def _compute_distance_mi(
     if coords is None:
         return None
     return great_circle_miles(home[0], home[1], coords[0], coords[1])
+
+
+# Module-level OSRM client. Lazily constructed on first use (and only
+# when YAS_DRIVE_TIME_ENABLED=true) so the default opt-out path costs
+# nothing. Re-used across rematch calls so we don't churn HTTP clients.
+_drive_time_provider: DriveTimeProvider | None = None
+
+
+def _get_drive_time_provider() -> DriveTimeProvider | None:
+    global _drive_time_provider
+    settings = get_settings()
+    if not settings.drive_time_enabled:
+        return None
+    if _drive_time_provider is None:
+        _drive_time_provider = OsrmClient(base_url=settings.osrm_base_url)
+    return _drive_time_provider
+
+
+def _reset_drive_time_provider() -> None:
+    """Test-only: clear the module-level provider singleton."""
+    global _drive_time_provider
+    _drive_time_provider = None
+
+
+async def _compute_drive_minutes(
+    session: AsyncSession,
+    home: tuple[float, float] | None,
+    offering: Offering,
+) -> float | None:
+    """Cache-first drive-time lookup. Returns None when feature disabled,
+    when no home/offering coords, or when the OSRM provider fails."""
+    provider = _get_drive_time_provider()
+    if provider is None or home is None:
+        return None
+    coords = await _offering_coords(session, offering)
+    if coords is None:
+        return None
+    result = await compute_drive_time(session, provider, home, coords)
+    return result.drive_minutes if result is not None else None
 
 
 async def _kid_blocks(session: AsyncSession, kid_id: int) -> list[UnavailabilityBlock]:
@@ -194,6 +235,7 @@ async def _evaluate_pair(
     enrollment_offering_map: dict[int, int] | None = None,
 ) -> tuple[bool, float, dict[str, Any]]:
     distance_mi = await _compute_distance_mi(session, home, offering)
+    drive_minutes = await _compute_drive_minutes(session, home, offering)
     if blocks is None:
         blocks = await _kid_blocks(session, kid.id)
     if watchlist_entries is None:
@@ -216,7 +258,11 @@ async def _evaluate_pair(
     gates = [
         age_fits(kid, offering, today=today),
         distance_fits(
-            kid, offering, distance_mi=distance_mi, household_default=default_max_distance
+            kid,
+            offering,
+            distance_mi=distance_mi,
+            household_default=default_max_distance,
+            drive_minutes=drive_minutes,
         ),
         interests_overlap(kid, offering, INTEREST_ALIASES),
         offering_active_and_not_ended(offering, today=today),
@@ -231,6 +277,11 @@ async def _evaluate_pair(
     )
     include = watchlist is not None or _gates_passed(gates)
     reasons = _reasons_payload(gates, breakdown, watchlist)
+    # Stash drive-time minutes in reasons so the UI can render an
+    # "X min drive" chip when present. Float | None — None means
+    # either the feature is off or computation failed.
+    if drive_minutes is not None:
+        reasons["drive_minutes"] = round(drive_minutes, 1)
     # Surface soft (tight) conflicts on included matches so the UI can
     # warn about near-misses the hard gate let through. Computed only
     # for matches we'd surface anyway — pure waste otherwise.

--- a/src/yas/web/routes/kids_schemas.py
+++ b/src/yas/web/routes/kids_schemas.py
@@ -45,6 +45,7 @@ class KidCreate(BaseModel):
     interests: list[str] = Field(default_factory=list)
     availability: dict[str, Any] = Field(default_factory=dict)
     max_distance_mi: float | None = None
+    max_drive_minutes: int | None = None
     alert_score_threshold: float = 0.6
     alert_on: dict[str, Any] = Field(default_factory=dict)
     school_weekdays: list[str] = Field(default_factory=lambda: ["mon", "tue", "wed", "thu", "fri"])
@@ -66,6 +67,7 @@ class KidUpdate(BaseModel):
     interests: list[str] | None = None
     availability: dict[str, Any] | None = None
     max_distance_mi: float | None = None
+    max_drive_minutes: int | None = None
     alert_score_threshold: float | None = None
     alert_on: dict[str, Any] | None = None
     school_weekdays: list[str] | None = None
@@ -142,6 +144,7 @@ class KidDetailOut(BaseModel):
     interests: list[str]
     availability: dict[str, Any]
     max_distance_mi: float | None
+    max_drive_minutes: int | None = None
     alert_score_threshold: float
     alert_on: dict[str, Any]
     school_weekdays: list[str]

--- a/tests/unit/test_gates.py
+++ b/tests/unit/test_gates.py
@@ -18,6 +18,7 @@ class _Kid:
     dob: date = date(2019, 5, 1)
     interests: list[str] = None
     max_distance_mi: float | None = None
+    max_drive_minutes: int | None = None
     school_holidays: list[str] = None
 
     def __post_init__(self):
@@ -169,6 +170,53 @@ def test_distance_no_cap_set_passes():
     r = distance_fits(kid, offering, distance_mi=100.0, household_default=None)
     assert r.passed
     assert r.code == "distance_unlimited"
+
+
+# --- drive-time gate (preferred over miles when set) -------------------------
+
+
+def test_drive_time_under_cap_passes_and_overrides_miles():
+    """When max_drive_minutes is set AND drive_minutes provided, miles cap ignored."""
+    kid = _Kid(max_drive_minutes=20, max_distance_mi=5.0)  # tight miles cap
+    offering = _Offering(location_id=7)
+    # Offering is 50 miles by great-circle but only 15 min by car (e.g., highway).
+    r = distance_fits(kid, offering, distance_mi=50.0, household_default=None, drive_minutes=15.0)
+    assert r.passed
+    assert r.code == "drive_time_ok"
+
+
+def test_drive_time_over_cap_fails():
+    kid = _Kid(max_drive_minutes=20)
+    offering = _Offering(location_id=7)
+    r = distance_fits(kid, offering, distance_mi=5.0, household_default=None, drive_minutes=30.0)
+    assert not r.passed
+    assert r.code == "too_far_drive"
+
+
+def test_drive_time_falls_back_to_miles_when_drive_minutes_unavailable():
+    """Provider failed to compute drive time → fall through to miles gate."""
+    kid = _Kid(max_drive_minutes=20, max_distance_mi=15.0)
+    offering = _Offering(location_id=7)
+    r = distance_fits(kid, offering, distance_mi=5.0, household_default=None, drive_minutes=None)
+    assert r.passed
+    assert r.code == "distance_ok"
+
+
+def test_no_drive_cap_uses_miles_even_when_drive_minutes_provided():
+    """Without max_drive_minutes, drive_minutes value is ignored."""
+    kid = _Kid(max_drive_minutes=None, max_distance_mi=10.0)
+    offering = _Offering(location_id=7)
+    r = distance_fits(kid, offering, distance_mi=5.0, household_default=None, drive_minutes=30.0)
+    assert r.passed
+    assert r.code == "distance_ok"
+
+
+def test_drive_time_unknown_when_location_missing():
+    kid = _Kid(max_drive_minutes=20)
+    offering = _Offering(location_id=None)
+    r = distance_fits(kid, offering, distance_mi=None, household_default=None, drive_minutes=15.0)
+    assert r.passed
+    assert r.code == "drive_time_unknown"
 
 
 # --- interests gate -----------------------------------------------------------


### PR DESCRIPTION
PR 2 of 3 for §9 driving-time vs great-circle. Builds on #45's foundation. PR 3 will add the UI.

## What this PR does

When \`YAS_DRIVE_TIME_ENABLED=true\` and a kid has \`max_drive_minutes\` set, the matcher consults OSRM-routed driving minutes (cached, from #45) instead of great-circle miles. When the feature is off, the cap isn't set, or OSRM fails, the gate falls back to existing miles behavior — **no regression on the default opt-out path**.

### Backend

- **Migration 0006**: \`kids.max_drive_minutes\` (Integer, nullable). Existing kids stay on \`max_distance_mi\`.
- **\`gates.distance_fits\`**: dual-mode. Drive-time path takes priority when both \`kid.max_drive_minutes\` is set AND \`drive_minutes\` is provided. Otherwise falls through to the existing miles gate. New result codes: \`drive_time_ok\`, \`drive_time_unknown\`, \`too_far_drive\`.
- **\`matcher\`**: lazy module-level OSRM provider (constructed on first use only when \`drive_time_enabled\`). \`_compute_drive_minutes\` helper mirrors \`_compute_distance_mi\` shape; cache-first via \`compute_drive_time()\` from #45. Drive minutes stashed in \`Match.reasons.drive_minutes\` when available — PR 3 reads this for the UI chip.
- **Kid schemas** (KidCreate, KidUpdate, KidDetailOut) all gain \`max_drive_minutes\`.

### Frontend

- \`KidDetail\` TS type extended.
- Two test fixtures updated.

## What this PR does NOT do

- UI to set \`max_drive_minutes\` on the kid form (PR 3).
- UI chip showing "X min drive" on offering rows (PR 3).
- The KidForm mutation likely passes through the new field correctly via Zod schema, but I haven't verified end-to-end yet — PR 3 covers it.

## Master §10 terminal criteria delta

None — post-v1 polish.

## Test plan

- [x] uv run pytest -q (666 passing, +5 drive-time gate tests)
  - Drive-time under cap passes AND overrides a tighter miles cap
  - Drive-time over cap fails with \`too_far_drive\`
  - Falls back to miles when \`drive_minutes\` is None (provider failure)
  - When \`max_drive_minutes\` not set, miles gate runs even if drive_minutes provided
  - \`drive_time_unknown\` when location missing
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean
- [x] alembic upgrade head from a fresh DB applies all 6 migrations cleanly
- [ ] CI passes