### PR TITLE
feat(post-v1): drive-time UI [3/3]

### DIFF
--- a/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
+++ b/docs/superpowers/specs/2026-04-30-v1-completion-roadmap.md
@@ -162,7 +162,7 @@ These remain open from each shipped phase's "Out of scope":
 - **Pushover channel** (master § 9) — ✅ already shipped during Phase 7-1 Settings work (`PushoverChannel` + Settings UI + routing matrix + test-send all wired). The roadmap line was a pre-Phase-7 carry-over.
 - **Gotify channel** (master § 9) — ❌ not implemented. Small slice when actually needed (mirror PushoverChannel against Gotify's HTTP API).
 - **`.ics` calendar export** (master § 9) — ✅ shipped 2026-05-03. Per-kid feed at `GET /api/kids/{id}/calendar.ics`; default −7d/+90d window, 400-day cap. Match suggestions excluded; enrollment/unavailability/holiday included. Subscribe link on per-kid calendar page. (.ics *import* still deferred.)
-- **Driving-time vs great-circle distance** (master § 9) — only if real usage shows great-circle is misleading
+- **Driving-time vs great-circle distance** (master § 9) — ✅ shipped 2026-05-03 across PRs #45/#46/#47. New `drive_time_cache` table + `OsrmClient` (open-source, no API key); `kid.max_drive_minutes` column + form field; matcher's distance gate prefers drive-time when both `kid.max_drive_minutes` is set AND drive_minutes is computable, falls back to great-circle miles otherwise. Off by default (`YAS_DRIVE_TIME_ENABLED=false`).
 - **Soft conflicts as warnings** (master § 9) — ✅ shipped 2026-05-03. Matcher computes near-misses against unavailability blocks (default 15-min buffer); stored in `Match.reasons.soft_conflicts`; surfaced as a "⚠ Tight" chip on offering rows.
 - **Mute reasons / per-channel mute** (5d-1 §1.2) — only if mute volume justifies it
 - **User-controllable match score threshold** (5c-2 §1.2) — only if 0.6 fixed feels wrong

--- a/frontend/src/components/kids/KidForm.tsx
+++ b/frontend/src/components/kids/KidForm.tsx
@@ -31,6 +31,7 @@ function kidToFormValues(k: KidDetail): KidFormValues {
     school_year_ranges: k.school_year_ranges,
     school_holidays: k.school_holidays,
     max_distance_mi: k.max_distance_mi,
+    max_drive_minutes: k.max_drive_minutes,
     alert_score_threshold: k.alert_score_threshold,
     alert_on: k.alert_on,
     notes: k.notes,
@@ -48,6 +49,7 @@ const DEFAULT_CREATE_VALUES: KidFormValues = {
   school_year_ranges: [],
   school_holidays: [],
   max_distance_mi: null,
+  max_drive_minutes: null,
   alert_score_threshold: 0.6,
   alert_on: {},
   notes: null,
@@ -311,6 +313,52 @@ export function KidForm({ mode, id }: KidFormProps) {
                   }}
                 />
                 No limit
+              </label>
+            </div>
+            {field.state.meta.errors.map((err, i) => (
+              <p key={i} className="mt-1 text-xs text-destructive">
+                {String(err)}
+              </p>
+            ))}
+          </div>
+        )}
+      />
+
+      <form.Field
+        name="max_drive_minutes"
+        children={(field) => (
+          <div>
+            <label htmlFor="max_drive_minutes" className="block text-sm font-medium">
+              Max Drive Time (minutes)
+            </label>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Routed driving minutes via OSRM. Takes precedence over Max Distance when set, but only
+              if <code>YAS_DRIVE_TIME_ENABLED=true</code> on the server.
+            </p>
+            <div className="mt-2 flex items-center gap-3">
+              <input
+                id="max_drive_minutes"
+                type="number"
+                min="1"
+                max="180"
+                step="1"
+                disabled={field.state.value === null}
+                value={field.state.value ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value ? parseInt(e.target.value, 10) : null;
+                  field.handleChange(val);
+                }}
+                className="block flex-1 rounded border border-input px-3 py-2 disabled:opacity-50"
+              />
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={field.state.value === null}
+                  onChange={(e) => {
+                    field.handleChange(e.target.checked ? null : 30);
+                  }}
+                />
+                Use distance instead
               </label>
             </div>
             {field.state.meta.errors.map((err, i) => (

--- a/frontend/src/components/kids/kidSchema.ts
+++ b/frontend/src/components/kids/kidSchema.ts
@@ -16,6 +16,7 @@ export const kidSchema = z
     school_year_ranges: z.array(z.object({ start: z.string(), end: z.string() })),
     school_holidays: z.array(z.string()),
     max_distance_mi: z.number().min(1).max(50).nullable(),
+    max_drive_minutes: z.number().int().min(1).max(180).nullable(),
     alert_score_threshold: z.number().min(0).max(1),
     alert_on: z.record(z.string(), z.boolean()),
     notes: z.string().max(2000).nullable(),

--- a/frontend/src/lib/offeringsFilters.ts
+++ b/frontend/src/lib/offeringsFilters.ts
@@ -204,7 +204,20 @@ export function chipsForOffering(
       className: 'bg-purple-100 text-purple-900 dark:bg-purple-900/30 dark:text-purple-200',
     });
   }
-  // 6. Tight (soft conflict — matcher flagged a near-miss against an
+  // 6. Drive time (matcher computed routed driving minutes; surface them
+  // when present so the user sees "21 min drive" alongside the other chips)
+  const driveMinutesValues = row.matches
+    .map((m) => (m.reasons as { drive_minutes?: unknown }).drive_minutes)
+    .filter((v): v is number => typeof v === 'number');
+  if (driveMinutesValues.length > 0) {
+    const min = Math.round(Math.min(...driveMinutesValues));
+    chips.push({
+      kind: 'drive_time',
+      label: `🚗 ${min} min drive`,
+      className: 'bg-sky-100 text-sky-900 dark:bg-sky-900/30 dark:text-sky-200',
+    });
+  }
+  // 7. Tight (soft conflict — matcher flagged a near-miss against an
   // unavailability block, e.g., school ends 3pm and offering starts 3:10pm)
   const tight = row.matches.some(
     (m) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -51,7 +51,8 @@ export type ChipKind =
   | 'opens_this_week'
   | 'near_home'
   | 'in_interests'
-  | 'tight';
+  | 'tight'
+  | 'drive_time';
 
 export interface Chip {
   kind: ChipKind;


### PR DESCRIPTION
Final PR for §9 driving-time. Wires the foundation (#45) and matcher gate (#46) into the user-visible surface.

## Frontend

- **KidForm**: new \"Max Drive Time (minutes)\" field with \"Use distance instead\" toggle. Defaults to 30 min when enabled. Inline note explains it only takes effect when \`YAS_DRIVE_TIME_ENABLED=true\` on the server.
- **kidSchema**: \`max_drive_minutes\` (int 1-180, nullable).
- **chipsForOffering**: new \`drive_time\` ChipKind. Reads \`m.reasons.drive_minutes\` (which the matcher in #46 stashes when the feature is enabled) and renders \`🚗 X min drive\` with a sky-blue palette. Uses the smallest drive_minutes across the row's matches (closest is most useful).
- \`ChipKind\` union extended.

## §9 closes for driving-time

This PR series (#45 / #46 / #47) is the complete §9 driving-time item:
- Provider + cache (#45)
- Matcher gate (#46)
- UI (this PR)

## Master §10 terminal criteria delta

None — post-v1 polish.

## Test plan

- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (298)
- [x] uv run pytest -q (666; backend unchanged from #46)
- [ ] CI passes
- [ ] Manual smoke: enable feature with \`YAS_DRIVE_TIME_ENABLED=true\`; set a kid's max-drive-minutes via Edit form; trigger a re-match; verify offering rows show \`🚗 X min drive\` chip; verify a tight cap rejects a high-mileage offering that great-circle would have accepted