### PR TITLE
feat(ui): version + short git sha in footer of every page

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from 'react';
+import { Footer } from './Footer';
 import { TopBar } from './TopBar';
 
 export function AppShell({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
       <TopBar />
-      <main className="container max-w-5xl py-6">{children}</main>
+      <main className="container max-w-5xl flex-1 py-6">{children}</main>
+      <Footer />
     </div>
   );
 }

--- a/frontend/src/components/layout/Footer.test.tsx
+++ b/frontend/src/components/layout/Footer.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { Footer } from './Footer';
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function renderFooter() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <Footer />
+    </QueryClientProvider>,
+  );
+}
+
+describe('Footer', () => {
+  it('renders version and short git sha as a commit link', async () => {
+    server.use(
+      http.get('/healthz', () =>
+        HttpResponse.json({
+          status: 'ok',
+          git_sha: '6871d4e94bc681a4c0c0d7ff02b81eaf0801c572',
+          version: '0.1.0',
+        }),
+      ),
+    );
+    renderFooter();
+    expect(await screen.findByText(/YAS v0\.1\.0/)).toBeInTheDocument();
+    const link = await screen.findByRole('link', { name: '6871d4e' });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/owine/youth-activity-scheduler/commit/6871d4e94bc681a4c0c0d7ff02b81eaf0801c572',
+    );
+    expect(link).toHaveAttribute('title', '6871d4e94bc681a4c0c0d7ff02b81eaf0801c572');
+  });
+
+  it('renders only version when git_sha is unknown (local dev)', async () => {
+    server.use(
+      http.get('/healthz', () =>
+        HttpResponse.json({ status: 'ok', git_sha: 'unknown', version: '0.1.0' }),
+      ),
+    );
+    renderFooter();
+    expect(await screen.findByText(/YAS v0\.1\.0/)).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('renders nothing while healthz is still loading', () => {
+    server.use(
+      http.get('/healthz', async () => {
+        await new Promise(() => {}); // never resolves
+        return HttpResponse.json({});
+      }),
+    );
+    const { container } = renderFooter();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,0 +1,32 @@
+import { useHealthz } from '@/lib/queries';
+
+const REPO_URL = 'https://github.com/owine/youth-activity-scheduler';
+
+export function Footer() {
+  const { data } = useHealthz();
+  if (!data) return null;
+  const shortSha = data.git_sha === 'unknown' ? null : data.git_sha.slice(0, 7);
+  return (
+    <footer className="border-t border-border mt-8 px-4 py-3 text-xs text-muted-foreground">
+      <div className="container max-w-5xl flex items-center justify-between">
+        <span>
+          YAS v{data.version}
+          {shortSha && (
+            <>
+              {' · '}
+              <a
+                href={`${REPO_URL}/commit/${data.git_sha}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono hover:text-foreground hover:underline"
+                title={data.git_sha}
+              >
+                {shortSha}
+              </a>
+            </>
+          )}
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -46,6 +46,23 @@ export function useKids() {
   });
 }
 
+interface HealthzResponse {
+  status: string;
+  git_sha: string;
+  version: string;
+}
+
+export function useHealthz() {
+  return useQuery({
+    queryKey: ['healthz'],
+    queryFn: () => api.get<HealthzResponse>('/healthz'),
+    // git_sha doesn't change while a container is up. Skip refetch on
+    // focus/window events to avoid pointless requests.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+}
+
 export function useKid(id: number) {
   return useQuery({
     queryKey: ['kids', id],

--- a/src/yas/web/app.py
+++ b/src/yas/web/app.py
@@ -33,16 +33,24 @@ def create_app(
     async def healthz() -> dict[str, str]:
         import os
 
-        return {"status": "ok", "git_sha": os.environ.get("YAS_GIT_SHA", "unknown")}
+        return {
+            "status": "ok",
+            "git_sha": os.environ.get("YAS_GIT_SHA", "unknown"),
+            "version": app.version,
+        }
 
     @app.get("/readyz")
     async def readyz(response: Response) -> dict[str, object]:
+        import os
+
         readiness = await check_readiness(state.engine, state.settings.worker_heartbeat_staleness_s)
         response.status_code = 200 if readiness.ready else 503
         return {
             "db_reachable": readiness.db_reachable,
             "heartbeat_fresh": readiness.heartbeat_fresh,
             "heartbeat_age_s": readiness.heartbeat_age_s,
+            "git_sha": os.environ.get("YAS_GIT_SHA", "unknown"),
+            "version": app.version,
         }
 
     from yas.web.routes import (

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -31,6 +31,7 @@ async def test_healthz_returns_ok(app_with_db):
     body = r.json()
     assert body["status"] == "ok"
     assert "git_sha" in body  # default "unknown" outside CI; SHA in CI builds
+    assert body["version"] == "0.1.0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Small QoL feature: every page now shows \`YAS v0.1.0 · 6871d4e\` in a footer, where the SHA is a link to the GitHub commit. Users (and future-me debugging) can tell at a glance which build is running.

## Backend

- \`/healthz\` now returns \`{status, git_sha, version}\`. Version from \`app.version\` (already 0.1.0); \`git_sha\` from \`YAS_GIT_SHA\` env (baked into images by the Dockerfile per #34).
- \`/readyz\` also extended with the same two fields. Both health endpoints carry identity info.

## Frontend

- \`useHealthz()\` query hook. \`staleTime: Infinity\` since git_sha can't change while a container is up.
- \`Footer\` component renders \`YAS v{version}\` always; renders short SHA + commit link only when \`git_sha !== 'unknown'\` (graceful local-dev fallback). \`title\` attribute carries the full 40-char SHA for hover.
- \`AppShell\` → \`flex flex-col min-h-screen\` so the footer sticks to the bottom of short pages.

## Master §10 terminal criteria delta

None. Pure UX polish. Useful for Phase 9 observation since it makes \"which commit is this serving?\" answerable from inside the running browser.

## Test plan

- [x] uv run pytest -q (666; existing healthz test extended)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (301, +3)
  - Footer renders version + short SHA as commit link
  - Footer renders only version when git_sha is 'unknown'
  - Footer renders nothing while healthz is still loading
- [ ] CI passes
- [ ] Manual smoke: visit / and verify footer appears at bottom; click SHA → opens GitHub commit page; in local dev, expect just \"YAS v0.1.0\" with no link