### PR TITLE
fix(ui): render form validation errors as messages, not [object Object]

### DIFF
--- a/frontend/src/components/kids/KidForm.tsx
+++ b/frontend/src/components/kids/KidForm.tsx
@@ -1,4 +1,5 @@
 import { useForm } from '@tanstack/react-form';
+import { formErrorMessage } from '@/lib/formError';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { kidSchema, type KidFormValues } from './kidSchema';
@@ -147,7 +148,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             />
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>
@@ -172,7 +173,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             />
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>
@@ -216,7 +217,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             </div>
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>
@@ -260,7 +261,7 @@ export function KidForm({ mode, id }: KidFormProps) {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>
@@ -317,7 +318,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             </div>
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>
@@ -363,7 +364,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             </div>
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>
@@ -392,7 +393,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             />
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>
@@ -424,7 +425,7 @@ export function KidForm({ mode, id }: KidFormProps) {
             />
             {field.state.meta.errors.map((err, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {String(err)}
+                {formErrorMessage(err)}
               </p>
             ))}
           </div>

--- a/frontend/src/components/settings/EmailChannelSection.tsx
+++ b/frontend/src/components/settings/EmailChannelSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formErrorMessage } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -157,7 +158,7 @@ export function EmailChannelSection() {
                         />
                         {field.state.meta.errors.map((err, i) => (
                           <p key={i} className="mt-1 text-xs text-destructive">
-                            {String(err)}
+                            {formErrorMessage(err)}
                           </p>
                         ))}
                       </div>
@@ -184,7 +185,7 @@ export function EmailChannelSection() {
                         />
                         {field.state.meta.errors.map((err, i) => (
                           <p key={i} className="mt-1 text-xs text-destructive">
-                            {String(err)}
+                            {formErrorMessage(err)}
                           </p>
                         ))}
                       </div>
@@ -269,7 +270,7 @@ export function EmailChannelSection() {
                       />
                       {field.state.meta.errors.map((err, i) => (
                         <p key={i} className="mt-1 text-xs text-destructive">
-                          {String(err)}
+                          {formErrorMessage(err)}
                         </p>
                       ))}
                       <span className="text-xs text-muted-foreground">
@@ -303,7 +304,7 @@ export function EmailChannelSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>
@@ -329,7 +330,7 @@ export function EmailChannelSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>

--- a/frontend/src/components/settings/HouseholdSection.tsx
+++ b/frontend/src/components/settings/HouseholdSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formErrorMessage } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -123,7 +124,7 @@ export function HouseholdSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
               {geocodePill && <div className="mt-2">{geocodePill}</div>}
@@ -149,7 +150,7 @@ export function HouseholdSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>
@@ -180,7 +181,7 @@ export function HouseholdSection() {
                 />
                 {field.state.meta.errors.map((err, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {String(err)}
+                    {formErrorMessage(err)}
                   </p>
                 ))}
               </div>
@@ -226,7 +227,7 @@ export function HouseholdSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>
@@ -252,7 +253,7 @@ export function HouseholdSection() {
                 />
                 {field.state.meta.errors.map((err, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {String(err)}
+                    {formErrorMessage(err)}
                   </p>
                 ))}
               </div>
@@ -277,7 +278,7 @@ export function HouseholdSection() {
                 />
                 {field.state.meta.errors.map((err, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {String(err)}
+                    {formErrorMessage(err)}
                   </p>
                 ))}
               </div>
@@ -308,7 +309,7 @@ export function HouseholdSection() {
               </div>
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>

--- a/frontend/src/components/settings/NtfyChannelSection.tsx
+++ b/frontend/src/components/settings/NtfyChannelSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formErrorMessage } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -73,7 +74,7 @@ export function NtfyChannelSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>
@@ -99,7 +100,7 @@ export function NtfyChannelSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
             </div>

--- a/frontend/src/components/settings/PushoverChannelSection.tsx
+++ b/frontend/src/components/settings/PushoverChannelSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formErrorMessage } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -84,7 +85,7 @@ export function PushoverChannelSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
               <span className="text-xs text-muted-foreground">
@@ -113,7 +114,7 @@ export function PushoverChannelSection() {
               />
               {field.state.meta.errors.map((err, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {String(err)}
+                  {formErrorMessage(err)}
                 </p>
               ))}
               <span className="text-xs text-muted-foreground">
@@ -165,7 +166,7 @@ export function PushoverChannelSection() {
                 />
                 {field.state.meta.errors.map((err, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {String(err)}
+                    {formErrorMessage(err)}
                   </p>
                 ))}
               </div>
@@ -191,7 +192,7 @@ export function PushoverChannelSection() {
                 />
                 {field.state.meta.errors.map((err, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {String(err)}
+                    {formErrorMessage(err)}
                   </p>
                 ))}
               </div>

--- a/frontend/src/components/watchlist/WatchlistEntrySheet.tsx
+++ b/frontend/src/components/watchlist/WatchlistEntrySheet.tsx
@@ -1,4 +1,5 @@
 import { useForm } from '@tanstack/react-form';
+import { formErrorMessage } from '@/lib/formError';
 import { useState } from 'react';
 import { z } from 'zod';
 import { useCreateWatchlistEntry, useUpdateWatchlistEntry } from '@/lib/mutations';
@@ -153,7 +154,7 @@ export function WatchlistEntrySheet({
                   />
                   {field.state.meta.errors.map((err, i) => (
                     <p key={i} className="mt-1 text-xs text-destructive">
-                      {String(err)}
+                      {formErrorMessage(err)}
                     </p>
                   ))}
                 </div>

--- a/frontend/src/lib/formError.ts
+++ b/frontend/src/lib/formError.ts
@@ -1,0 +1,25 @@
+/**
+ * Extract a renderable string from a TanStack Form error entry.
+ *
+ * `field.state.meta.errors` is `Array<unknown>` — what's in there depends
+ * on the validator. With Zod (via the standard schema adapter or direct
+ * use), errors are Zod issue objects of shape `{ message, path, ... }`.
+ * Plain strings happen too (custom validators). The bug we're fixing is
+ * forms that called `String(err)` on Zod issues, producing the literal
+ * "[object Object]".
+ */
+export function formErrorMessage(err: unknown): string {
+  if (err == null) return '';
+  if (typeof err === 'string') return err;
+  if (typeof err === 'object' && 'message' in err) {
+    const m = (err as { message: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  // Last-resort: try JSON, fall back to String() — at least we don't
+  // silently render "[object Object]" with no diagnostic value.
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}


### PR DESCRIPTION
Six form components in the Settings page (and elsewhere) called \`String(err)\` on \`field.state.meta.errors\`, which produces the literal string \`[object Object]\` for Zod issue objects of shape \`{ message, path, ... }\`. Users saw \`[object Object]\` under every invalid field — silently masking helpful schema messages like \"User key env var is required\".

## What broke

Caught while configuring Pushover/Email channels: empty fields rendered \`[object Object]\` instead of the actual schema message. Hid the fact that the form expects you to type the **name** of the env var (e.g., \`YAS_PUSHOVER_USER_KEY\`) into the box, not the value — confusing because the env var itself was already set in \`.env\`.

## Fix

New \`src/lib/formError.ts\` with \`formErrorMessage(err: unknown): string\`:
- Strings pass through.
- Objects with a string \`.message\` (Zod issues, JS Errors) → return \`message\`.
- Anything else → \`JSON.stringify\` (and final \`String()\` fallback).
- Never silently produces \`[object Object]\`.

Replaced \`String(err)\` with \`formErrorMessage(err)\` in:
- \`components/settings/EmailChannelSection.tsx\`
- \`components/settings/PushoverChannelSection.tsx\`
- \`components/settings/NtfyChannelSection.tsx\`
- \`components/settings/HouseholdSection.tsx\`
- \`components/kids/KidForm.tsx\`
- \`components/watchlist/WatchlistEntrySheet.tsx\`

## Master §10 terminal criteria delta

None. Pure UX bugfix.

## Test plan

- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (301)
- [x] Reviewed all six replacements; the imports were added at the top of each file
- [ ] CI passes
- [ ] Manual smoke after merge: clear a Pushover env-var field on Settings; verify the red error reads \"User key env var is required\" (or similar) instead of \"[object Object]\"