### PR TITLE
refactor(channels): credentials by value, not env-var name [1/2 backend]

### DIFF
--- a/src/yas/alerts/channels/email.py
+++ b/src/yas/alerts/channels/email.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from email.message import EmailMessage
 from typing import Any, ClassVar, Protocol
 
@@ -14,6 +13,7 @@ from yas.alerts.channels.base import (
     NotifierMessage,
     SendResult,
 )
+from yas.config import Settings
 
 _FORWARDEMAIL_API_URL = "https://api.forwardemail.net/v1/emails"
 
@@ -66,7 +66,6 @@ class _SMTPTransport:
         to_addrs: list[str],
         username: str | None = None,
         password: str | None = None,
-        password_env: str | None = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -76,16 +75,7 @@ class _SMTPTransport:
         if username is not None and username == "":
             raise ValueError("smtp username must be non-empty if provided")
         self._username = username
-
-        if password is not None:
-            self._password: str | None = password
-        elif password_env is not None:
-            resolved = os.environ.get(password_env)
-            if resolved is None:
-                raise ValueError(f"channel disabled: missing env var {password_env}")
-            self._password = resolved
-        else:
-            self._password = None
+        self._password = password if password else None
 
     async def send(self, msg: NotifierMessage) -> SendResult:
         email = _build_email(
@@ -151,14 +141,16 @@ class _SMTPTransport:
 class _ForwardEmailTransport:
     def __init__(
         self,
-        api_token_env: str,
+        api_token: str,
         from_addr: str,
         to_addrs: list[str],
     ) -> None:
-        token = os.environ.get(api_token_env)
-        if token is None:
-            raise ValueError(f"channel disabled: missing env var {api_token_env}")
-        self._token = token
+        if not api_token:
+            raise ValueError(
+                "channel disabled: forwardemail api token not set "
+                "(form override or YAS_FORWARDEMAIL_API_TOKEN env var)"
+            )
+        self._token = api_token
         self._from_addr = from_addr
         self._to_addrs = to_addrs
         self._client = httpx.AsyncClient()
@@ -216,13 +208,15 @@ class EmailChannel:
     name: str = "email"
     capabilities: ClassVar[set[NotifierCapability]] = {NotifierCapability.email}
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], settings: Settings) -> None:
         transport_name = config.get("transport")
         from_addr = str(config["from_addr"])
         to_addrs = [str(a) for a in config["to_addrs"]]
 
         if transport_name == "smtp":
-            password_env = config.get("password_env")
+            # Resolution: form-stored value → conventional env var. SMTP
+            # password is optional (some servers use IP-based auth).
+            password = config.get("password_value") or settings.smtp_password
             self._transport: _EmailTransport = _SMTPTransport(
                 host=str(config["host"]),
                 port=int(config["port"]),
@@ -230,11 +224,12 @@ class EmailChannel:
                 from_addr=from_addr,
                 to_addrs=to_addrs,
                 username=str(config["username"]) if "username" in config else None,
-                password_env=str(password_env) if password_env is not None else None,
+                password=password if password else None,
             )
         elif transport_name == "forwardemail":
+            api_token = config.get("api_token_value") or settings.forwardemail_api_token or ""
             self._transport = _ForwardEmailTransport(
-                api_token_env=str(config["api_token_env"]),
+                api_token=api_token,
                 from_addr=from_addr,
                 to_addrs=to_addrs,
             )

--- a/src/yas/alerts/channels/ntfy.py
+++ b/src/yas/alerts/channels/ntfy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any, ClassVar
 
 import httpx
@@ -12,26 +11,21 @@ from yas.alerts.channels.base import (
     NotifierMessage,
     SendResult,
 )
+from yas.config import Settings
 
 
 class NtfyChannel:
     name: str = "ntfy"
     capabilities: ClassVar[set[NotifierCapability]] = {NotifierCapability.push}
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any], settings: Settings) -> None:
         self._base_url = str(config["base_url"]).rstrip("/")
         self._topic = str(config["topic"])
 
-        auth_token_env: str | None = config.get("auth_token_env")
-        if auth_token_env is not None:
-            token = os.environ.get(auth_token_env)
-            if token is None:
-                raise ValueError(f"channel disabled: missing env var {auth_token_env}")
-            if token == "":
-                raise ValueError(f"channel disabled: env var {auth_token_env} is set but empty")
-            self._token: str | None = token
-        else:
-            self._token = None
+        # ntfy auth is optional. Resolution: form-stored value → conventional
+        # env var → unauthenticated. Treat empty form value as "use env".
+        token: str | None = config.get("auth_token_value") or settings.ntfy_auth_token or None
+        self._token = token if token else None
 
         self._client = httpx.AsyncClient()
 

--- a/src/yas/alerts/channels/pushover.py
+++ b/src/yas/alerts/channels/pushover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from typing import Any, ClassVar
 
 import httpx
@@ -13,6 +12,7 @@ from yas.alerts.channels.base import (
     NotifierMessage,
     SendResult,
 )
+from yas.config import Settings
 from yas.db.models._types import AlertType
 
 _PUSHOVER_URL = "https://api.pushover.net/1/messages.json"
@@ -25,21 +25,23 @@ class PushoverChannel:
         NotifierCapability.push_emergency,
     }
 
-    def __init__(self, config: dict[str, Any]) -> None:
-        user_key_env = str(config["user_key_env"])
-        user_key = os.environ.get(user_key_env)
-        if user_key is None:
-            raise ValueError(f"channel disabled: missing env var {user_key_env}")
-        if user_key == "":
-            raise ValueError(f"channel disabled: env var {user_key_env} is set but empty")
+    def __init__(self, config: dict[str, Any], settings: Settings) -> None:
+        # Resolution: form-stored value → conventional env var. Form value
+        # wins when both are set so the user can override env in the UI.
+        user_key = config.get("user_key_value") or settings.pushover_user_key
+        if not user_key:
+            raise ValueError(
+                "channel disabled: pushover user key not set "
+                "(form override or YAS_PUSHOVER_USER_KEY env var)"
+            )
         self._user_key = user_key
 
-        app_token_env = str(config["app_token_env"])
-        app_token = os.environ.get(app_token_env)
-        if app_token is None:
-            raise ValueError(f"channel disabled: missing env var {app_token_env}")
-        if app_token == "":
-            raise ValueError(f"channel disabled: env var {app_token_env} is set but empty")
+        app_token = config.get("app_token_value") or settings.pushover_app_token
+        if not app_token:
+            raise ValueError(
+                "channel disabled: pushover app token not set "
+                "(form override or YAS_PUSHOVER_APP_TOKEN env var)"
+            )
         self._app_token = app_token
 
         devices: list[str] = list(config.get("devices") or [])

--- a/src/yas/web/routes/household.py
+++ b/src/yas/web/routes/household.py
@@ -9,11 +9,12 @@ from fastapi import APIRouter, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from yas.config import Settings
 from yas.crawl.normalize import normalize_name
 from yas.db.models import GeocodeAttempt, HouseholdSettings, Location
 from yas.db.session import session_scope
 from yas.geo.client import Geocoder
-from yas.web.routes.household_schemas import HouseholdOut, HouseholdPatch
+from yas.web.routes.household_schemas import CredentialStatus, HouseholdOut, HouseholdPatch
 
 router = APIRouter(prefix="/api/household", tags=["household"])
 
@@ -35,12 +36,73 @@ async def _load_or_create(session: AsyncSession) -> HouseholdSettings:
     return hh
 
 
-async def _to_out(s: AsyncSession, hh: HouseholdSettings) -> HouseholdOut:
+def _credential_status(
+    cfg: dict[str, Any] | None,
+    *,
+    value_key: str,
+    env_var_name: str,
+    settings_value: str | None,
+) -> CredentialStatus:
+    """Resolve where a single credential comes from.
+
+    Form value wins over env. Returns via=None when neither is set so
+    the UI can render an "unconfigured" state without guessing.
+    """
+    form_value = cfg.get(value_key) if cfg else None
+    if form_value:
+        return CredentialStatus(via="form", env_var=env_var_name)
+    if settings_value:
+        return CredentialStatus(via="env", env_var=env_var_name)
+    return CredentialStatus(via=None, env_var=env_var_name)
+
+
+def _settings(req: Request) -> Settings:
+    return req.app.state.yas.settings  # type: ignore[no-any-return]
+
+
+async def _to_out(s: AsyncSession, hh: HouseholdSettings, settings: Settings) -> HouseholdOut:
     loc = None
     if hh.home_location_id is not None:
         loc = (
             await s.execute(select(Location).where(Location.id == hh.home_location_id))
         ).scalar_one_or_none()
+    cred_status: dict[str, CredentialStatus] = {}
+    smtp = hh.smtp_config_json
+    if smtp is not None and smtp.get("transport") == "smtp":
+        cred_status["smtp_password"] = _credential_status(
+            smtp,
+            value_key="password_value",
+            env_var_name="YAS_SMTP_PASSWORD",
+            settings_value=settings.smtp_password,
+        )
+    if smtp is not None and smtp.get("transport") == "forwardemail":
+        cred_status["forwardemail_api_token"] = _credential_status(
+            smtp,
+            value_key="api_token_value",
+            env_var_name="YAS_FORWARDEMAIL_API_TOKEN",
+            settings_value=settings.forwardemail_api_token,
+        )
+    if hh.ntfy_config_json is not None:
+        cred_status["ntfy_auth_token"] = _credential_status(
+            hh.ntfy_config_json,
+            value_key="auth_token_value",
+            env_var_name="YAS_NTFY_AUTH_TOKEN",
+            settings_value=settings.ntfy_auth_token,
+        )
+    if hh.pushover_config_json is not None:
+        cred_status["pushover_user_key"] = _credential_status(
+            hh.pushover_config_json,
+            value_key="user_key_value",
+            env_var_name="YAS_PUSHOVER_USER_KEY",
+            settings_value=settings.pushover_user_key,
+        )
+        cred_status["pushover_app_token"] = _credential_status(
+            hh.pushover_config_json,
+            value_key="app_token_value",
+            env_var_name="YAS_PUSHOVER_APP_TOKEN",
+            settings_value=settings.pushover_app_token,
+        )
+
     return HouseholdOut(
         id=hh.id,
         home_location_id=hh.home_location_id,
@@ -56,6 +118,7 @@ async def _to_out(s: AsyncSession, hh: HouseholdSettings) -> HouseholdOut:
         email_configured=hh.smtp_config_json is not None,
         ntfy_configured=hh.ntfy_config_json is not None,
         pushover_configured=hh.pushover_config_json is not None,
+        credential_status=cred_status,
     )
 
 
@@ -63,7 +126,7 @@ async def _to_out(s: AsyncSession, hh: HouseholdSettings) -> HouseholdOut:
 async def get_household(request: Request) -> HouseholdOut:
     async with session_scope(_engine(request)) as s:
         hh = await _load_or_create(s)
-        return await _to_out(s, hh)
+        return await _to_out(s, hh, _settings(request))
 
 
 @router.patch("", response_model=HouseholdOut)
@@ -129,4 +192,4 @@ async def patch_household(patch: HouseholdPatch, request: Request) -> HouseholdO
             setattr(hh, key, value)
 
         await s.flush()
-        return await _to_out(s, hh)
+        return await _to_out(s, hh, _settings(request))

--- a/src/yas/web/routes/household_schemas.py
+++ b/src/yas/web/routes/household_schemas.py
@@ -5,6 +5,19 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 
 
+class CredentialStatus(BaseModel):
+    """Per-credential status: where the value resolves from, if anywhere.
+
+    via:
+      - "form" — user pasted a value into the Settings UI (stored in DB)
+      - "env"  — conventional env var is set (e.g. YAS_PUSHOVER_USER_KEY)
+      - null   — neither; channel can't construct
+    """
+
+    via: str | None
+    env_var: str
+
+
 class HouseholdOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: int
@@ -21,6 +34,10 @@ class HouseholdOut(BaseModel):
     email_configured: bool
     ntfy_configured: bool
     pushover_configured: bool
+    # Per-credential status: tells the UI whether each secret resolves
+    # from a form-stored override, an env var, or is unset. Empty when
+    # the corresponding *_config_json is null (channel not configured).
+    credential_status: dict[str, CredentialStatus] = {}
 
 
 class HouseholdPatch(BaseModel):

--- a/src/yas/web/routes/notifier_test.py
+++ b/src/yas/web/routes/notifier_test.py
@@ -50,10 +50,12 @@ async def test_notifier(channel: str, request: Request) -> TestSendOut:
         config = getattr(hh, field, None) if hh else None
     if config is None:
         raise HTTPException(status_code=503, detail=f"{channel} not configured")
-    # Channel constructors raise ValueError if a referenced *_env var is missing.
-    # Surface as ok=false rather than 500.
+    # Channel constructors raise ValueError if a credential is missing in
+    # both the form-stored value and the conventional env var. Surface as
+    # ok=false rather than 500.
+    settings = request.app.state.yas.settings
     try:
-        ch = channel_cls(config)
+        ch = channel_cls(config, settings)
     except ValueError as exc:
         return TestSendOut(ok=False, detail=f"channel init failed: {exc}")
     result = await ch.send(_test_message(channel))

--- a/src/yas/worker/runner.py
+++ b/src/yas/worker/runner.py
@@ -63,9 +63,14 @@ def _build_notifiers(
         if config is None:
             continue
         try:
-            notifiers[channel_name] = channel_cls(config)
+            notifiers[channel_name] = channel_cls(config, settings)
         except ValueError as exc:
             log.warning("channel.disabled", channel=channel_name, reason=str(exc))
+
+    if notifiers:
+        log.info("channels.constructed", channels=sorted(notifiers.keys()))
+    else:
+        log.warning("channels.none_constructed", note="all channels disabled or unconfigured")
 
     return notifiers
 

--- a/tests/unit/test_alerts_email_channel.py
+++ b/tests/unit/test_alerts_email_channel.py
@@ -13,11 +13,21 @@ import respx
 from tests.fakes.smtp_server import fake_smtp_server
 from yas.alerts.channels.base import NotifierCapability, NotifierMessage
 from yas.alerts.channels.email import EmailChannel, _ForwardEmailTransport, _SMTPTransport
+from yas.config import Settings
 from yas.db.models._types import AlertType
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _settings(**overrides: object) -> Settings:
+    """Build a Settings with credentials stubbed. Pass kwargs to override
+    specific credential fields; otherwise they default to None so tests
+    fully control resolution via the config dict."""
+    defaults: dict = {"anthropic_api_key": "sk-test"}
+    defaults.update(overrides)
+    return Settings(**defaults)
 
 
 def _msg(
@@ -46,11 +56,11 @@ async def test_smtp_transport_sends_message():
         transport = _SMTPTransport(
             host=server.host,
             port=server.port,
-            username=None,
-            password=None,
             use_tls=False,
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
+            username=None,
+            password=None,
         )
         msg = _msg()
         result = await transport.send(msg)
@@ -67,11 +77,11 @@ async def test_smtp_transport_message_headers():
         transport = _SMTPTransport(
             host=server.host,
             port=server.port,
-            username=None,
-            password=None,
             use_tls=False,
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
+            username=None,
+            password=None,
         )
         msg = _msg(subject="Hello Scheduler")
         await transport.send(msg)
@@ -91,11 +101,11 @@ async def test_smtp_transport_multipart_alternative():
         transport = _SMTPTransport(
             host=server.host,
             port=server.port,
-            username=None,
-            password=None,
             use_tls=False,
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
+            username=None,
+            password=None,
         )
         msg = _msg(body_plain="Plain text.", body_html="<p>HTML</p>")
         await transport.send(msg)
@@ -116,11 +126,11 @@ async def test_smtp_transport_send_result_detail():
         transport = _SMTPTransport(
             host=server.host,
             port=server.port,
-            username=None,
-            password=None,
             use_tls=False,
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
+            username=None,
+            password=None,
         )
         result = await transport.send(_msg())
 
@@ -139,11 +149,11 @@ async def test_smtp_4xx_is_transient(monkeypatch):
     transport = _SMTPTransport(
         host="127.0.0.1",
         port=9999,
-        username=None,
-        password=None,
         use_tls=False,
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
+        username=None,
+        password=None,
     )
     result = await transport.send(_msg())
 
@@ -164,11 +174,11 @@ async def test_smtp_5xx_is_non_transient(monkeypatch):
     transport = _SMTPTransport(
         host="127.0.0.1",
         port=9999,
-        username=None,
-        password=None,
         use_tls=False,
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
+        username=None,
+        password=None,
     )
     result = await transport.send(_msg())
 
@@ -188,11 +198,11 @@ async def test_smtp_transport_421_transient(monkeypatch):
     transport = _SMTPTransport(
         host="127.0.0.1",
         port=9999,
-        username=None,
-        password=None,
         use_tls=False,
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
+        username=None,
+        password=None,
     )
     result = await transport.send(_msg())
 
@@ -212,11 +222,11 @@ async def test_smtp_transport_connect_error_transient(monkeypatch):
     transport = _SMTPTransport(
         host="127.0.0.1",
         port=9999,
-        username=None,
-        password=None,
         use_tls=False,
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
+        username=None,
+        password=None,
     )
     result = await transport.send(_msg())
 
@@ -236,33 +246,16 @@ async def test_smtp_transport_timeout_transient(monkeypatch):
     transport = _SMTPTransport(
         host="127.0.0.1",
         port=9999,
-        username=None,
-        password=None,
         use_tls=False,
         from_addr="from@example.com",
         to_addrs=["to@example.com"],
+        username=None,
+        password=None,
     )
     result = await transport.send(_msg())
 
     assert result.ok is False
     assert result.transient_failure is True
-
-
-@pytest.mark.asyncio
-async def test_smtp_password_env_missing_raises(monkeypatch):
-    """password_env set but env var absent → ValueError at init."""
-    monkeypatch.delenv("YAS_SMTP_PASSWORD", raising=False)
-
-    with pytest.raises(ValueError, match="YAS_SMTP_PASSWORD"):
-        _SMTPTransport(
-            host="smtp.example.com",
-            port=587,
-            username="user",
-            password_env="YAS_SMTP_PASSWORD",
-            use_tls=True,
-            from_addr="from@example.com",
-            to_addrs=["to@example.com"],
-        )
 
 
 @pytest.mark.asyncio
@@ -275,11 +268,11 @@ async def test_smtp_recipients_refused_is_transient():
         transport = _SMTPTransport(
             host="127.0.0.1",
             port=9999,
-            username=None,
-            password=None,
             use_tls=False,
             from_addr="from@example.com",
             to_addrs=["bad@example.com"],
+            username=None,
+            password=None,
         )
         result = await transport.send(_msg())
 
@@ -293,16 +286,14 @@ async def test_smtp_recipients_refused_is_transient():
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_posts_to_api(monkeypatch):
+async def test_forwardemail_transport_posts_to_api():
     """POST to ForwardEmail API with correct URL and Basic Auth."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "test-api-token")
-
     with respx.mock:
         route = respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(200, json={"id": "abc123"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="test-api-token",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -314,16 +305,14 @@ async def test_forwardemail_transport_posts_to_api(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_basic_auth(monkeypatch):
+async def test_forwardemail_transport_basic_auth():
     """Basic Auth uses the token as username, empty password."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "my-secret-token")
-
     with respx.mock:
         route = respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(200, json={"id": "abc123"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="my-secret-token",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -339,16 +328,14 @@ async def test_forwardemail_transport_basic_auth(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_form_fields(monkeypatch):
+async def test_forwardemail_transport_form_fields():
     """Form fields: from, to, subject, text, html."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         route = respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(200, json={"id": "x"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="yas@example.com",
             to_addrs=["user@example.com", "user2@example.com"],
         )
@@ -370,16 +357,14 @@ async def test_forwardemail_transport_form_fields(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_http_200_detail(monkeypatch):
+async def test_forwardemail_transport_http_200_detail():
     """detail is 'http 200' on success."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(200, json={"id": "x"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -389,16 +374,14 @@ async def test_forwardemail_transport_http_200_detail(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_4xx_non_transient(monkeypatch):
+async def test_forwardemail_transport_4xx_non_transient():
     """4xx (not 429) → ok=False, transient_failure=False."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(400, json={"message": "Bad request"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -410,16 +393,14 @@ async def test_forwardemail_transport_4xx_non_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_429_transient(monkeypatch):
+async def test_forwardemail_transport_429_transient():
     """429 → ok=False, transient_failure=True."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(429, json={"message": "rate limited"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -430,16 +411,14 @@ async def test_forwardemail_transport_429_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_5xx_transient(monkeypatch):
+async def test_forwardemail_transport_5xx_transient():
     """5xx → ok=False, transient_failure=True."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(503, json={"message": "unavailable"})
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -450,16 +429,14 @@ async def test_forwardemail_transport_5xx_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_transport_timeout_transient(monkeypatch):
+async def test_forwardemail_transport_timeout_transient():
     """httpx.TimeoutException → transient failure."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             side_effect=httpx.TimeoutException("timed out")
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -470,16 +447,14 @@ async def test_forwardemail_transport_timeout_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_forwardemail_connect_error_is_transient(monkeypatch):
+async def test_forwardemail_connect_error_is_transient():
     """httpx.ConnectError (DNS failure, connection refused) → transient failure."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     with respx.mock:
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             side_effect=httpx.ConnectError("dns failure")
         )
         transport = _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="tok",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -489,14 +464,11 @@ async def test_forwardemail_connect_error_is_transient(monkeypatch):
     assert result.transient_failure is True
 
 
-@pytest.mark.asyncio
-async def test_forwardemail_token_env_missing_raises(monkeypatch):
-    """api_token_env set but env var absent → ValueError at init."""
-    monkeypatch.delenv("YAS_FE_TOKEN", raising=False)
-
-    with pytest.raises(ValueError, match="YAS_FE_TOKEN"):
+def test_forwardemail_token_missing_raises():
+    """Empty api_token → ValueError at init."""
+    with pytest.raises(ValueError, match="not set"):
         _ForwardEmailTransport(
-            api_token_env="YAS_FE_TOKEN",
+            api_token="",
             from_addr="from@example.com",
             to_addrs=["to@example.com"],
         )
@@ -508,7 +480,7 @@ async def test_forwardemail_token_env_missing_raises(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_email_channel_selects_smtp(monkeypatch):
+async def test_email_channel_selects_smtp():
     """EmailChannel with transport=smtp creates a working SMTP channel."""
     async with fake_smtp_server() as server:
         config = {
@@ -519,7 +491,7 @@ async def test_email_channel_selects_smtp(monkeypatch):
             "from_addr": "yas@example.com",
             "to_addrs": ["user@example.com"],
         }
-        channel = EmailChannel(config)
+        channel = EmailChannel(config, _settings())
         result = await channel.send(_msg())
         await channel.aclose()
 
@@ -528,13 +500,11 @@ async def test_email_channel_selects_smtp(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_email_channel_selects_forwardemail(monkeypatch):
+async def test_email_channel_selects_forwardemail():
     """EmailChannel with transport=forwardemail creates a working FE channel."""
-    monkeypatch.setenv("YAS_FE_TOKEN", "tok")
-
     config = {
         "transport": "forwardemail",
-        "api_token_env": "YAS_FE_TOKEN",
+        "api_token_value": "tok",
         "from_addr": "yas@example.com",
         "to_addrs": ["user@example.com"],
     }
@@ -542,11 +512,41 @@ async def test_email_channel_selects_forwardemail(monkeypatch):
         respx.post("https://api.forwardemail.net/v1/emails").mock(
             return_value=httpx.Response(200, json={"id": "x"})
         )
-        channel = EmailChannel(config)
+        channel = EmailChannel(config, _settings())
         result = await channel.send(_msg())
         await channel.aclose()
 
     assert result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_email_channel_forwardemail_uses_settings_fallback():
+    """When config has no api_token_value, EmailChannel falls back to Settings."""
+    config = {
+        "transport": "forwardemail",
+        "from_addr": "yas@example.com",
+        "to_addrs": ["user@example.com"],
+    }
+    with respx.mock:
+        respx.post("https://api.forwardemail.net/v1/emails").mock(
+            return_value=httpx.Response(200, json={"id": "x"})
+        )
+        channel = EmailChannel(config, _settings(forwardemail_api_token="env-tok"))
+        result = await channel.send(_msg())
+        await channel.aclose()
+
+    assert result.ok is True
+
+
+def test_email_channel_forwardemail_missing_token_raises():
+    """forwardemail with neither config value nor settings → ValueError."""
+    config = {
+        "transport": "forwardemail",
+        "from_addr": "yas@example.com",
+        "to_addrs": ["user@example.com"],
+    }
+    with pytest.raises(ValueError, match="not set"):
+        EmailChannel(config, _settings())
 
 
 def test_email_channel_unknown_transport_raises():
@@ -557,18 +557,11 @@ def test_email_channel_unknown_transport_raises():
         "to_addrs": ["c@d.com"],
     }
     with pytest.raises(ValueError, match="pigeon"):
-        EmailChannel(config)
+        EmailChannel(config, _settings())
 
 
 def test_email_channel_capabilities():
     """EmailChannel reports email capability."""
-    # Use fake_smtp_server is overkill here — just verify without sending.
-    # We can't easily construct without a running SMTP so we check the class attr.
-    assert hasattr(EmailChannel, "__init__")
-    # Verify via a mock config (smtp without tls/auth)
-    # We can't start a server synchronously so inspect the capability in the
-    # channel_selects_smtp test — but also verify the class has the right set.
-    # Instantiate with a port that won't be used for init (smtp init is lazy).
     config = {
         "transport": "smtp",
         "host": "127.0.0.1",
@@ -577,6 +570,6 @@ def test_email_channel_capabilities():
         "from_addr": "a@b.com",
         "to_addrs": ["c@d.com"],
     }
-    ch = EmailChannel(config)
+    ch = EmailChannel(config, _settings())
     assert NotifierCapability.email in ch.capabilities
     assert ch.name == "email"

--- a/tests/unit/test_alerts_ntfy_channel.py
+++ b/tests/unit/test_alerts_ntfy_channel.py
@@ -8,6 +8,7 @@ import respx
 
 from yas.alerts.channels.base import NotifierCapability, NotifierMessage
 from yas.alerts.channels.ntfy import NtfyChannel
+from yas.config import Settings
 from yas.db.models._types import AlertType
 
 # ---------------------------------------------------------------------------
@@ -16,6 +17,15 @@ from yas.db.models._types import AlertType
 
 _BASE_URL = "https://ntfy.example.com"
 _TOPIC = "mytopic"
+
+
+def _settings(**overrides: object) -> Settings:
+    """Build a Settings with credentials stubbed. Pass kwargs to override
+    specific credential fields; otherwise they default to None so tests
+    fully control resolution via the config dict."""
+    defaults: dict = {"anthropic_api_key": "sk-test"}
+    defaults.update(overrides)
+    return Settings(**defaults)
 
 
 def _cfg(**kwargs: object) -> dict:
@@ -46,7 +56,7 @@ def _msg(
 
 
 def test_ntfy_capabilities():
-    ch = NtfyChannel(_cfg())
+    ch = NtfyChannel(_cfg(), _settings())
     assert ch.capabilities == {NotifierCapability.push}
     assert ch.name == "ntfy"
 
@@ -60,7 +70,7 @@ def test_ntfy_capabilities():
 async def test_ntfy_posts_to_exact_url():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -73,7 +83,7 @@ async def test_ntfy_posts_to_exact_url():
 async def test_ntfy_title_header_is_subject():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         await ch.send(_msg(subject="Hello World"))
         await ch.aclose()
 
@@ -84,7 +94,7 @@ async def test_ntfy_title_header_is_subject():
 async def test_ntfy_body_is_body_plain_bytes():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         await ch.send(_msg(body_plain="my body text"))
         await ch.aclose()
 
@@ -100,7 +110,7 @@ async def test_ntfy_body_is_body_plain_bytes():
 async def test_ntfy_priority_high_when_urgent():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         await ch.send(_msg(urgent=True))
         await ch.aclose()
 
@@ -111,7 +121,7 @@ async def test_ntfy_priority_high_when_urgent():
 async def test_ntfy_priority_header_absent_when_not_urgent():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         await ch.send(_msg(urgent=False))
         await ch.aclose()
 
@@ -127,7 +137,7 @@ async def test_ntfy_priority_header_absent_when_not_urgent():
 async def test_ntfy_click_header_set_when_url_given():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         await ch.send(_msg(url="https://example.com/register"))
         await ch.aclose()
 
@@ -138,7 +148,7 @@ async def test_ntfy_click_header_set_when_url_given():
 async def test_ntfy_click_header_absent_when_no_url():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         await ch.send(_msg(url=None))
         await ch.aclose()
 
@@ -151,12 +161,10 @@ async def test_ntfy_click_header_absent_when_no_url():
 
 
 @pytest.mark.asyncio
-async def test_ntfy_auth_header_when_token_configured(monkeypatch):
-    monkeypatch.setenv("YAS_NTFY_TOKEN", "secret-token")
-
+async def test_ntfy_auth_header_when_token_in_config():
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg(auth_token_env="YAS_NTFY_TOKEN"))
+        ch = NtfyChannel(_cfg(auth_token_value="secret-token"), _settings())
         await ch.send(_msg())
         await ch.aclose()
 
@@ -164,28 +172,32 @@ async def test_ntfy_auth_header_when_token_configured(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ntfy_auth_header_absent_when_no_token_env():
+async def test_ntfy_auth_header_when_token_in_settings():
+    """Token in Settings (env fallback) is used when config has no value."""
     with respx.mock() as m:
         route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())  # no auth_token_env
+        ch = NtfyChannel(_cfg(), _settings(ntfy_auth_token="env-token"))
+        await ch.send(_msg())
+        await ch.aclose()
+
+    assert route.calls.last.request.headers["Authorization"] == "Bearer env-token"
+
+
+@pytest.mark.asyncio
+async def test_ntfy_auth_header_absent_when_no_token():
+    with respx.mock() as m:
+        route = m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
+        ch = NtfyChannel(_cfg(), _settings())  # no token anywhere
         await ch.send(_msg())
         await ch.aclose()
 
     assert "Authorization" not in route.calls.last.request.headers
 
 
-def test_ntfy_missing_token_env_raises(monkeypatch):
-    monkeypatch.delenv("YAS_NTFY_TOKEN", raising=False)
-
-    with pytest.raises(ValueError, match="YAS_NTFY_TOKEN"):
-        NtfyChannel(_cfg(auth_token_env="YAS_NTFY_TOKEN"))
-
-
-def test_ntfy_blank_token_env_raises(monkeypatch):
-    monkeypatch.setenv("YAS_NTFY_TOKEN", "")
-
-    with pytest.raises(ValueError, match="set but empty"):
-        NtfyChannel(_cfg(auth_token_env="YAS_NTFY_TOKEN"))
+def test_ntfy_blank_token_treated_as_unauthenticated():
+    """An empty-string auth_token_value with no env fallback yields anonymous."""
+    ch = NtfyChannel(_cfg(auth_token_value=""), _settings())
+    assert ch._token is None
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +209,7 @@ def test_ntfy_blank_token_env_raises(monkeypatch):
 async def test_ntfy_2xx_ok():
     with respx.mock() as m:
         m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(200, text="ok"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -209,7 +221,7 @@ async def test_ntfy_2xx_ok():
 async def test_ntfy_4xx_non_transient():
     with respx.mock() as m:
         m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(403, text="forbidden"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -221,7 +233,7 @@ async def test_ntfy_4xx_non_transient():
 async def test_ntfy_429_transient():
     with respx.mock() as m:
         m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(429, text="rate limited"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -233,7 +245,7 @@ async def test_ntfy_429_transient():
 async def test_ntfy_5xx_transient():
     with respx.mock() as m:
         m.post(f"{_BASE_URL}/{_TOPIC}").mock(return_value=httpx.Response(503, text="unavailable"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -250,7 +262,7 @@ async def test_ntfy_5xx_transient():
 async def test_ntfy_timeout_is_transient():
     with respx.mock() as m:
         m.post(f"{_BASE_URL}/{_TOPIC}").mock(side_effect=httpx.TimeoutException("timed out"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -263,7 +275,7 @@ async def test_ntfy_timeout_is_transient():
 async def test_ntfy_connect_error_is_transient():
     with respx.mock() as m:
         m.post(f"{_BASE_URL}/{_TOPIC}").mock(side_effect=httpx.ConnectError("dns failure"))
-        ch = NtfyChannel(_cfg())
+        ch = NtfyChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -283,7 +295,7 @@ async def test_ntfy_trailing_slash_base_url_is_normalised():
         route = m.post("https://ntfy.example.com/mytopic").mock(
             return_value=httpx.Response(200, text="ok")
         )
-        ch = NtfyChannel(_cfg(base_url="https://ntfy.example.com/"))
+        ch = NtfyChannel(_cfg(base_url="https://ntfy.example.com/"), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 

--- a/tests/unit/test_alerts_pushover_channel.py
+++ b/tests/unit/test_alerts_pushover_channel.py
@@ -10,6 +10,7 @@ import respx
 
 from yas.alerts.channels.base import NotifierCapability, NotifierMessage
 from yas.alerts.channels.pushover import PushoverChannel
+from yas.config import Settings
 from yas.db.models._types import AlertType
 
 _PUSHOVER_URL = "https://api.pushover.net/1/messages.json"
@@ -20,10 +21,19 @@ _PUSHOVER_URL = "https://api.pushover.net/1/messages.json"
 # ---------------------------------------------------------------------------
 
 
+def _settings(**overrides: object) -> Settings:
+    """Build a Settings with credentials stubbed. Pass kwargs to override
+    specific credential fields; otherwise they default to None so tests
+    fully control resolution via the config dict."""
+    defaults: dict = {"anthropic_api_key": "sk-test"}
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
 def _cfg(**kwargs: object) -> dict:
     base: dict = {
-        "user_key_env": "YAS_PO_USER",
-        "app_token_env": "YAS_PO_TOKEN",
+        "user_key_value": "user123",
+        "app_token_value": "tok123",
         "emergency_retry_s": 30,
         "emergency_expire_s": 600,
     }
@@ -58,10 +68,8 @@ def _parse_form(request: httpx.Request) -> dict[str, list[str]]:
 # ---------------------------------------------------------------------------
 
 
-def test_pushover_capabilities(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-    ch = PushoverChannel(_cfg())
+def test_pushover_capabilities():
+    ch = PushoverChannel(_cfg(), _settings())
     assert ch.capabilities == {NotifierCapability.push, NotifierCapability.push_emergency}
     assert ch.name == "pushover"
 
@@ -72,15 +80,12 @@ def test_pushover_capabilities(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_posts_to_api_url(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_posts_to_api_url():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -89,15 +94,12 @@ async def test_pushover_posts_to_api_url(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_form_fields_token_user_title_message(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_form_fields_token_user_title_message():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         await ch.send(_msg(subject="My Subject", body_plain="My body"))
         await ch.aclose()
 
@@ -114,15 +116,12 @@ async def test_pushover_form_fields_token_user_title_message(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_url_and_url_title_set_when_url_given(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_url_and_url_title_set_when_url_given():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         await ch.send(_msg(subject="Sign Up", url="https://example.com/reg"))
         await ch.aclose()
 
@@ -132,15 +131,12 @@ async def test_pushover_url_and_url_title_set_when_url_given(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_url_fields_absent_when_no_url(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_url_fields_absent_when_no_url():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         await ch.send(_msg(url=None))
         await ch.aclose()
 
@@ -155,16 +151,13 @@ async def test_pushover_url_fields_absent_when_no_url(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_priority_2_for_reg_opens_now(monkeypatch):
+async def test_pushover_priority_2_for_reg_opens_now():
     """reg_opens_now → form contains priority=2 plus retry/expire from config."""
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg(emergency_retry_s=30, emergency_expire_s=600))
+        ch = PushoverChannel(_cfg(emergency_retry_s=30, emergency_expire_s=600), _settings())
         await ch.send(_msg(alert_type=AlertType.reg_opens_now))
         await ch.aclose()
 
@@ -175,16 +168,13 @@ async def test_pushover_priority_2_for_reg_opens_now(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_priority_0_for_non_emergency(monkeypatch):
+async def test_pushover_priority_0_for_non_emergency():
     """Non-emergency alert types → priority=0, no retry/expire."""
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         await ch.send(_msg(alert_type=AlertType.reg_opens_24h))
         await ch.aclose()
 
@@ -200,15 +190,12 @@ async def test_pushover_priority_0_for_non_emergency(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_devices_comma_joined_when_list_nonempty(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_devices_comma_joined_when_list_nonempty():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg(devices=["iphone", "ipad"]))
+        ch = PushoverChannel(_cfg(devices=["iphone", "ipad"]), _settings())
         await ch.send(_msg())
         await ch.aclose()
 
@@ -217,15 +204,12 @@ async def test_pushover_devices_comma_joined_when_list_nonempty(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_device_field_absent_when_no_devices(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_device_field_absent_when_no_devices():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())  # no devices key
+        ch = PushoverChannel(_cfg(), _settings())  # no devices key
         await ch.send(_msg())
         await ch.aclose()
 
@@ -234,15 +218,12 @@ async def test_pushover_device_field_absent_when_no_devices(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_device_field_absent_when_empty_list(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_device_field_absent_when_empty_list():
     with respx.mock() as m:
         route = m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg(devices=[]))
+        ch = PushoverChannel(_cfg(devices=[]), _settings())
         await ch.send(_msg())
         await ch.aclose()
 
@@ -256,15 +237,12 @@ async def test_pushover_device_field_absent_when_empty_list(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_status_1_ok(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_status_1_ok():
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(200, json={"status": 1, "request": "abc"})
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -273,11 +251,8 @@ async def test_pushover_status_1_ok(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_status_0_non_transient(monkeypatch):
+async def test_pushover_status_0_non_transient():
     """HTTP 200 with JSON status:0 → ok=False, transient_failure=False, detail contains errors."""
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(
@@ -285,7 +260,7 @@ async def test_pushover_status_0_non_transient(monkeypatch):
                 json={"status": 0, "errors": ["user key is invalid"]},
             )
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -295,13 +270,10 @@ async def test_pushover_status_0_non_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_http_429_transient(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_http_429_transient():
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(return_value=httpx.Response(429, json={}))
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -310,13 +282,10 @@ async def test_pushover_http_429_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_http_5xx_transient(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_http_5xx_transient():
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(return_value=httpx.Response(503, json={}))
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -325,10 +294,7 @@ async def test_pushover_http_5xx_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_http_4xx_status_0_non_transient(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_http_4xx_status_0_non_transient():
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(
             return_value=httpx.Response(
@@ -336,7 +302,7 @@ async def test_pushover_http_4xx_status_0_non_transient(monkeypatch):
                 json={"status": 0, "errors": ["token is invalid"]},
             )
         )
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -350,13 +316,10 @@ async def test_pushover_http_4xx_status_0_non_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_timeout_is_transient(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_timeout_is_transient():
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(side_effect=httpx.TimeoutException("timed out"))
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -366,13 +329,10 @@ async def test_pushover_timeout_is_transient(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pushover_connect_error_is_transient(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
+async def test_pushover_connect_error_is_transient():
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(side_effect=httpx.ConnectError("dns failure"))
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 
@@ -382,51 +342,45 @@ async def test_pushover_connect_error_is_transient(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Missing env vars
+# Missing credentials
 # ---------------------------------------------------------------------------
 
 
-def test_pushover_missing_user_key_env_raises(monkeypatch):
-    monkeypatch.delenv("YAS_PO_USER", raising=False)
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
-    with pytest.raises(ValueError, match="YAS_PO_USER"):
-        PushoverChannel(_cfg())
+def test_pushover_missing_user_key_raises():
+    with pytest.raises(ValueError, match="not set"):
+        PushoverChannel(_cfg(user_key_value=None), _settings())
 
 
-def test_pushover_missing_app_token_env_raises(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.delenv("YAS_PO_TOKEN", raising=False)
-
-    with pytest.raises(ValueError, match="YAS_PO_TOKEN"):
-        PushoverChannel(_cfg())
+def test_pushover_missing_app_token_raises():
+    with pytest.raises(ValueError, match="not set"):
+        PushoverChannel(_cfg(app_token_value=None), _settings())
 
 
-def test_pushover_blank_user_key_env_raises(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
-    with pytest.raises(ValueError, match="set but empty"):
-        PushoverChannel(_cfg())
+def test_pushover_blank_user_key_raises():
+    with pytest.raises(ValueError, match="not set"):
+        PushoverChannel(_cfg(user_key_value=""), _settings())
 
 
-def test_pushover_blank_app_token_env_raises(monkeypatch):
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "")
+def test_pushover_blank_app_token_raises():
+    with pytest.raises(ValueError, match="not set"):
+        PushoverChannel(_cfg(app_token_value=""), _settings())
 
-    with pytest.raises(ValueError, match="set but empty"):
-        PushoverChannel(_cfg())
+
+def test_pushover_falls_back_to_settings_env():
+    """When form value is unset, channel uses Settings (env-loaded) credentials."""
+    cfg = _cfg(user_key_value=None, app_token_value=None)
+    settings = _settings(pushover_user_key="env-user", pushover_app_token="env-tok")
+    ch = PushoverChannel(cfg, settings)
+    assert ch._user_key == "env-user"
+    assert ch._app_token == "env-tok"
 
 
 @pytest.mark.asyncio
-async def test_pushover_malformed_json_response(monkeypatch):
+async def test_pushover_malformed_json_response():
     """Non-JSON body (e.g. HTML error page) → body={}, status defaults to 0, non-transient."""
-    monkeypatch.setenv("YAS_PO_USER", "user123")
-    monkeypatch.setenv("YAS_PO_TOKEN", "tok123")
-
     with respx.mock() as m:
         m.post(_PUSHOVER_URL).mock(return_value=httpx.Response(200, text="<html>error</html>"))
-        ch = PushoverChannel(_cfg())
+        ch = PushoverChannel(_cfg(), _settings())
         result = await ch.send(_msg())
         await ch.aclose()
 


### PR DESCRIPTION
## What's wrong with the current design

The Settings UI asked the user to type the **name** of an env var (e.g. \`YAS_PUSHOVER_USER_KEY\`), then separately set that env var to the actual value. Two-step indirection confused real users — when one told me \"all three envs are set,\" they had done the env half but missed the form half. Compounded by #49's \`[object Object]\` rendering bug masking the validation message that would have explained which form field was empty.

The indirection adds zero value: the project already declares conventional env vars (\`Settings.pushover_user_key\` etc., loaded by Pydantic from \`YAS_PUSHOVER_USER_KEY\`). Letting the user pick a *different* name for the env var was never useful.

## New resolution order

1. \`config['*_value']\` — form-stored override (DB), wins when set.
2. \`settings.*\` — conventional env var (\`YAS_PUSHOVER_USER_KEY\`, \`YAS_PUSHOVER_APP_TOKEN\`, \`YAS_SMTP_PASSWORD\`, \`YAS_FORWARDEMAIL_API_TOKEN\`, \`YAS_NTFY_AUTH_TOKEN\`).
3. \`ValueError\` \"not set (form override or YAS_* env var)\".

## What this PR does

- **Channel constructors** \`PushoverChannel\`, \`NtfyChannel\`, \`EmailChannel\` take \`(config, settings)\`. Read \`*_value\` first, fall back to settings.
- **\`_SMTPTransport\` and \`_ForwardEmailTransport\`** take direct \`password\` / \`api_token\` strings; caller resolves them. Drops the env-name resolution from transport internals.
- **\`worker/runner._build_notifiers\`** passes settings; logs \`channels.constructed\` (or \`channels.none_constructed\` as a warning) at startup so silent-failure debugging is easier — addresses the \`delivery.notifier_missing\` log spam observed in production.
- **\`notifier_test\` test-send endpoint** passes settings.
- **New \`CredentialStatus\` schema** in \`household_schemas.py\`. \`/api/household\` response now includes \`credential_status: {pushover_user_key: {via: 'env'|'form'|null, env_var: 'YAS_PUSHOVER_USER_KEY'}, ...}\`. Frontend (PR 2) renders this as a status badge next to each form field.

## What this PR does NOT do

- **Drop the \`*_env\` keys from form schemas** — Settings UI still has the old \`*_env\` inputs. PR 2 swaps them for masked \`*_value\` inputs + the new status badge.
- **Migrate existing data** — existing JSON rows with \`user_key_env: \"YAS_PUSHOVER_USER_KEY\"\` are silently ignored on the new code path. The credential then resolves from the env var itself (which is the same value the indirection was pointing at), so existing setups keep working with zero user intervention.

## Master §10 terminal criteria delta

None. UX/refactor.

## Test plan

- [x] uv run pytest -q (668 passing, +2 env-fallback tests across pushover/ntfy/email test files)
- [x] uv run ruff check / format / mypy clean
- [x] cd frontend && npm run typecheck / lint / test all clean (301; no functional change)
- [ ] CI passes
- [ ] After merge: worker logs \`channels.constructed\` at startup naming each one that built successfully