### PR TITLE
refactor(ui): credentials by value with status badge [2/2 frontend]

### DIFF
--- a/frontend/src/components/settings/CredentialField.tsx
+++ b/frontend/src/components/settings/CredentialField.tsx
@@ -1,0 +1,109 @@
+import type { CredentialStatus } from '@/lib/types';
+
+interface Props {
+  /** Stable form-field id used by the <label htmlFor>. */
+  id: string;
+  /** Visible label, e.g. "User Key". */
+  label: string;
+  /** Current form value (the password override). Empty string when not set. */
+  value: string;
+  onChange: (next: string) => void;
+  onBlur?: () => void;
+  /** Server-resolved status: where the credential currently comes from. May
+   *  be undefined when no config row exists yet (channel pristine). */
+  status?: CredentialStatus;
+  /** Form-field validation errors (already resolved to strings). */
+  errors?: string[];
+  /** Optional inline helper text above the input. */
+  hint?: string;
+}
+
+/**
+ * One credential field with a masked password input and a status badge
+ * showing whether the credential is currently resolving via the form
+ * override (this DB row), the conventional env var, or is unset.
+ *
+ * The placeholder reads "•••••• (set via env)" when an env value is in
+ * effect — the user can leave the box empty to keep using env, or type
+ * a new value to override.
+ */
+export function CredentialField({
+  id,
+  label,
+  value,
+  onChange,
+  onBlur,
+  status,
+  errors,
+  hint,
+}: Props) {
+  const via = status?.via ?? null;
+  const envVar = status?.env_var;
+
+  const placeholder =
+    via === 'env'
+      ? `•••••• (set via ${envVar})`
+      : via === 'form'
+        ? '•••••• (saved value — type to replace)'
+        : envVar
+          ? `Paste value, or set ${envVar} env var`
+          : 'Paste value';
+
+  const badge =
+    via === 'env' ? (
+      <span
+        className="inline-flex items-center rounded bg-emerald-100 px-1.5 py-0.5 text-xs text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200"
+        title={`Resolves from ${envVar}`}
+      >
+        ✓ env
+      </span>
+    ) : via === 'form' ? (
+      <span
+        className="inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-900 dark:bg-blue-900/30 dark:text-blue-200"
+        title="Stored in DB; overrides any env var"
+      >
+        ✓ form
+      </span>
+    ) : (
+      <span
+        className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-200"
+        title={envVar ? `Set ${envVar} or paste a value above` : 'Unconfigured'}
+      >
+        ✗ not set
+      </span>
+    );
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <label htmlFor={id} className="block text-sm font-medium">
+          {label}
+        </label>
+        {badge}
+      </div>
+      {hint && <p className="mt-1 text-xs text-muted-foreground">{hint}</p>}
+      <input
+        id={id}
+        type="password"
+        autoComplete="off"
+        spellCheck={false}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        aria-invalid={Boolean(errors?.length)}
+        className="mt-1 block w-full rounded border border-input px-3 py-2 font-mono text-sm"
+        placeholder={placeholder}
+      />
+      {errors?.map((err, i) => (
+        <p key={i} className="mt-1 text-xs text-destructive">
+          {err}
+        </p>
+      ))}
+      {via === 'env' && (
+        <p className="mt-1 text-xs text-muted-foreground">
+          Currently using <code>{envVar}</code>. Leave blank to keep, or paste a value to override.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/EmailChannelSection.test.tsx
+++ b/frontend/src/components/settings/EmailChannelSection.test.tsx
@@ -51,7 +51,7 @@ describe('EmailChannelSection', () => {
     expect(screen.getByRole('button', { name: /send test email/i })).toBeInTheDocument();
   });
 
-  it('switching to forwardemail hides smtp fields, shows api_token_env', async () => {
+  it('switching to forwardemail hides smtp fields, shows api_token_value', async () => {
     const user = userEvent.setup();
     render(<EmailChannelSection />, { wrapper: wrap(makeQc(), baseHh) });
 
@@ -123,7 +123,7 @@ describe('EmailChannelSection', () => {
     await user.selectOptions(transportSelect, 'forwardemail');
 
     // Fill forwardemail form
-    await user.type(screen.getByLabelText(/ForwardEmail API Token/i), 'YAS_FWD_EMAIL_TOKEN');
+    await user.type(screen.getByLabelText(/ForwardEmail API Token/i), 'secret-api-token');
     await user.type(screen.getByLabelText(/From Address/i), 'noreply@forwardemail.example.com');
     await user.type(screen.getByLabelText(/To Addresses/i), 'admin@example.com');
 
@@ -134,7 +134,38 @@ describe('EmailChannelSection', () => {
       expect(captured).not.toBeNull();
       const config = (captured?.smtp_config_json as Record<string, unknown>) || {};
       expect(config.transport).toBe('forwardemail');
-      expect(config.api_token_env).toBe('YAS_FWD_EMAIL_TOKEN');
+      expect(config.api_token_value).toBe('secret-api-token');
+      expect(config.from_addr).toBe('noreply@forwardemail.example.com');
+      expect(config.to_addrs).toEqual(['admin@example.com']);
+    });
+  });
+
+  it('forwardemail save with no api_token_value succeeds and omits the key', async () => {
+    const user = userEvent.setup();
+    let captured: Record<string, unknown> | null = null;
+    server.use(
+      http.patch('/api/household', async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(baseHh);
+      }),
+    );
+
+    render(<EmailChannelSection />, { wrapper: wrap(makeQc(), baseHh) });
+
+    const transportSelect = screen.getByLabelText(/Transport/i) as HTMLSelectElement;
+    await user.selectOptions(transportSelect, 'forwardemail');
+
+    // Leave api_token_value blank — server falls back to YAS_FORWARDEMAIL_API_TOKEN env var.
+    await user.type(screen.getByLabelText(/From Address/i), 'noreply@forwardemail.example.com');
+    await user.type(screen.getByLabelText(/To Addresses/i), 'admin@example.com');
+
+    await user.click(screen.getByRole('button', { name: /^Save/i }));
+
+    await waitFor(() => {
+      expect(captured).not.toBeNull();
+      const config = (captured?.smtp_config_json as Record<string, unknown>) || {};
+      expect(config.transport).toBe('forwardemail');
+      expect(config.api_token_value).toBeUndefined();
       expect(config.from_addr).toBe('noreply@forwardemail.example.com');
       expect(config.to_addrs).toEqual(['admin@example.com']);
     });

--- a/frontend/src/components/settings/EmailChannelSection.tsx
+++ b/frontend/src/components/settings/EmailChannelSection.tsx
@@ -5,22 +5,24 @@ import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { ErrorBanner } from '@/components/common/ErrorBanner';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { CredentialField } from './CredentialField';
 import { TestSendButton } from './TestSendButton';
 import { useUpdateHousehold } from '@/lib/mutations';
+import { useHousehold } from '@/lib/queries';
 import { ApiError } from '@/lib/api';
 import type { SmtpConfig, ForwardEmailConfig } from '@/lib/types';
 
-// Zod schemas for smtp and forwardemail transports
+// Schemas: credentials are optional values now. Empty → fall back to env.
 const smtpSchema = z.object({
   transport: z.literal('smtp'),
   host: z.string().min(1, 'Host is required'),
   port: z.number().int().min(1).max(65535),
   username: z.string(),
-  password_env: z.string(),
+  password_value: z.string(),
   use_tls: z.boolean(),
   from_addr: z.string().email('Valid email required'),
   to_addrs: z.string().min(1, 'At least one recipient required'),
-  api_token_env: z.string(),
+  api_token_value: z.string(),
 });
 
 const forwardEmailSchema = z.object({
@@ -28,9 +30,9 @@ const forwardEmailSchema = z.object({
   host: z.string(),
   port: z.number(),
   username: z.string(),
-  password_env: z.string(),
+  password_value: z.string(),
   use_tls: z.boolean(),
-  api_token_env: z.string().min(1, 'API token env var required'),
+  api_token_value: z.string(),
   from_addr: z.string().email('Valid email required'),
   to_addrs: z.string().min(1, 'At least one recipient required'),
 });
@@ -39,8 +41,12 @@ const schema = z.discriminatedUnion('transport', [smtpSchema, forwardEmailSchema
 
 export function EmailChannelSection() {
   const update = useUpdateHousehold();
+  const household = useHousehold();
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
+
+  const smtpStatus = household.data?.credential_status?.['smtp_password'];
+  const fwdStatus = household.data?.credential_status?.['forwardemail_api_token'];
 
   // Note: Household does NOT expose smtp_config_json (only HouseholdSettings row has it).
   // The backend makes *_config_json write-only. So we always start with empty form.
@@ -52,17 +58,16 @@ export function EmailChannelSection() {
       host: '',
       port: 587,
       username: '',
-      password_env: '',
+      password_value: '',
       use_tls: true,
       from_addr: '',
       to_addrs: '',
-      api_token_env: '',
+      api_token_value: '',
     },
     validators: { onChange: schema, onMount: schema },
     onSubmit: async ({ value }) => {
       setErrorMsg(null);
       try {
-        // Parse to_addrs from comma-separated string to array, trimming and filtering
         const to_addrs = value.to_addrs
           .split(',')
           .map((s) => s.trim())
@@ -78,21 +83,26 @@ export function EmailChannelSection() {
             use_tls: value.use_tls,
             from_addr: value.from_addr,
             to_addrs,
-            // Omit username when blank — never send empty string
             ...(value.username?.trim() ? { username: value.username.trim() } : {}),
-            // Omit password_env when blank
-            ...(value.password_env?.trim() ? { password_env: value.password_env.trim() } : {}),
+            ...(value.password_value?.trim()
+              ? { password_value: value.password_value.trim() }
+              : {}),
           };
         } else {
           config = {
             transport: 'forwardemail',
-            api_token_env: value.api_token_env,
             from_addr: value.from_addr,
             to_addrs,
+            ...(value.api_token_value?.trim()
+              ? { api_token_value: value.api_token_value.trim() }
+              : {}),
           };
         }
 
         await update.mutateAsync({ smtp_config_json: config });
+        // Wipe the secret inputs after save so they don't sit in the DOM.
+        form.setFieldValue('password_value', '');
+        form.setFieldValue('api_token_value', '');
       } catch (err) {
         const detail = err instanceof ApiError ? (err.body as { detail?: string })?.detail : null;
         setErrorMsg(detail ?? (err as Error).message);
@@ -213,25 +223,18 @@ export function EmailChannelSection() {
                   />
 
                   <form.Field
-                    name="password_env"
+                    name="password_value"
                     children={(field) => (
-                      <div>
-                        <label htmlFor="password_env" className="block text-sm font-medium">
-                          Password Env Var (optional)
-                        </label>
-                        <input
-                          id="password_env"
-                          type="text"
-                          value={field.state.value}
-                          onChange={(e) => field.handleChange(e.target.value)}
-                          onBlur={field.handleBlur}
-                          className="mt-1 block w-full rounded border border-input px-3 py-2"
-                          placeholder="e.g. YAS_SMTP_PASSWORD"
-                        />
-                        <span className="text-xs text-muted-foreground">
-                          e.g. YAS_SMTP_PASSWORD — set this env var in your .env
-                        </span>
-                      </div>
+                      <CredentialField
+                        id="password_value"
+                        label="Password (optional)"
+                        hint="Optional. Some SMTP servers use IP-based auth."
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onBlur={field.handleBlur}
+                        status={smtpStatus}
+                        errors={field.state.meta.errors.map(formErrorMessage)}
+                      />
                     )}
                   />
 
@@ -252,31 +255,17 @@ export function EmailChannelSection() {
                 </>
               ) : (
                 <form.Field
-                  name="api_token_env"
+                  name="api_token_value"
                   children={(field) => (
-                    <div>
-                      <label htmlFor="api_token_env" className="block text-sm font-medium">
-                        ForwardEmail API Token
-                      </label>
-                      <input
-                        id="api_token_env"
-                        type="text"
-                        value={field.state.value}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        onBlur={field.handleBlur}
-                        aria-invalid={field.state.meta.errors.length > 0}
-                        className="mt-1 block w-full rounded border border-input px-3 py-2"
-                        placeholder="e.g. YAS_FORWARDEMAIL_TOKEN"
-                      />
-                      {field.state.meta.errors.map((err, i) => (
-                        <p key={i} className="mt-1 text-xs text-destructive">
-                          {formErrorMessage(err)}
-                        </p>
-                      ))}
-                      <span className="text-xs text-muted-foreground">
-                        e.g. YAS_FORWARDEMAIL_TOKEN — set this env var in your .env
-                      </span>
-                    </div>
+                    <CredentialField
+                      id="api_token_value"
+                      label="ForwardEmail API Token"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      status={fwdStatus}
+                      errors={field.state.meta.errors.map(formErrorMessage)}
+                    />
                   )}
                 />
               )}

--- a/frontend/src/components/settings/NtfyChannelSection.test.tsx
+++ b/frontend/src/components/settings/NtfyChannelSection.test.tsx
@@ -44,11 +44,11 @@ describe('NtfyChannelSection', () => {
     expect(topicInput.value).toBe('');
 
     // Verify other fields are present
-    expect(screen.getByLabelText(/Auth Token Env/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Auth Token/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /send test ntfy/i })).toBeInTheDocument();
   });
 
-  it('save POSTs PATCH with {ntfy_config_json: {base_url, topic}} and auth_token_env absent when blank', async () => {
+  it('save POSTs PATCH with {ntfy_config_json: {base_url, topic}} and auth_token_value absent when blank', async () => {
     const user = userEvent.setup();
     let captured: Record<string, unknown> | null = null;
     server.use(
@@ -72,7 +72,7 @@ describe('NtfyChannelSection', () => {
       const config = (captured?.ntfy_config_json as Record<string, unknown>) || {};
       expect(config.base_url).toBe('https://ntfy.sh');
       expect(config.topic).toBe('yas-test');
-      expect(config.auth_token_env).toBeUndefined(); // omitted when blank
+      expect(config.auth_token_value).toBeUndefined(); // omitted when blank
     });
   });
 

--- a/frontend/src/components/settings/NtfyChannelSection.tsx
+++ b/frontend/src/components/settings/NtfyChannelSection.tsx
@@ -5,27 +5,32 @@ import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { ErrorBanner } from '@/components/common/ErrorBanner';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { CredentialField } from './CredentialField';
 import { TestSendButton } from './TestSendButton';
 import { useUpdateHousehold } from '@/lib/mutations';
+import { useHousehold } from '@/lib/queries';
 import { ApiError } from '@/lib/api';
 import type { NtfyConfig } from '@/lib/types';
 
 const ntfySchema = z.object({
   base_url: z.string().url(),
   topic: z.string().min(1, 'Topic is required'),
-  auth_token_env: z.string(),
+  auth_token_value: z.string(),
 });
 
 export function NtfyChannelSection() {
   const update = useUpdateHousehold();
+  const household = useHousehold();
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
+
+  const authStatus = household.data?.credential_status?.['ntfy_auth_token'];
 
   const form = useForm({
     defaultValues: {
       base_url: 'https://ntfy.sh',
       topic: '',
-      auth_token_env: '',
+      auth_token_value: '',
     },
     validators: { onChange: ntfySchema, onMount: ntfySchema },
     onSubmit: async ({ value }) => {
@@ -34,9 +39,12 @@ export function NtfyChannelSection() {
         const config: NtfyConfig = {
           base_url: value.base_url,
           topic: value.topic,
-          ...(value.auth_token_env?.trim() ? { auth_token_env: value.auth_token_env.trim() } : {}),
+          ...(value.auth_token_value?.trim()
+            ? { auth_token_value: value.auth_token_value.trim() }
+            : {}),
         };
         await update.mutateAsync({ ntfy_config_json: config });
+        form.setFieldValue('auth_token_value', '');
       } catch (err) {
         const detail = err instanceof ApiError ? (err.body as { detail?: string })?.detail : null;
         setErrorMsg(detail ?? (err as Error).message);
@@ -108,25 +116,18 @@ export function NtfyChannelSection() {
         />
 
         <form.Field
-          name="auth_token_env"
+          name="auth_token_value"
           children={(field) => (
-            <div>
-              <label htmlFor="auth_token_env" className="block text-sm font-medium">
-                Auth Token Env (optional)
-              </label>
-              <input
-                id="auth_token_env"
-                type="text"
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                className="mt-1 block w-full rounded border border-input px-3 py-2"
-                placeholder="e.g. YAS_NTFY_AUTH_TOKEN"
-              />
-              <span className="text-xs text-muted-foreground">
-                e.g. YAS_NTFY_AUTH_TOKEN — set this env var in your .env
-              </span>
-            </div>
+            <CredentialField
+              id="auth_token_value"
+              label="Auth Token (optional)"
+              hint="Anonymous if blank and no env var set."
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
+              status={authStatus}
+              errors={field.state.meta.errors.map(formErrorMessage)}
+            />
           )}
         />
 

--- a/frontend/src/components/settings/PushoverChannelSection.test.tsx
+++ b/frontend/src/components/settings/PushoverChannelSection.test.tsx
@@ -38,8 +38,8 @@ describe('PushoverChannelSection', () => {
     render(<PushoverChannelSection />, { wrapper: wrap(makeQc(), baseHh) });
 
     // Verify required fields are present and empty
-    expect((screen.getByLabelText(/User Key Env/i) as HTMLInputElement).value).toBe('');
-    expect((screen.getByLabelText(/App Token Env/i) as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText(/User Key/i) as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText(/App Token/i) as HTMLInputElement).value).toBe('');
 
     // Verify advanced fields have correct defaults
     expect((screen.getByLabelText(/Emergency Retry/i) as HTMLInputElement).value).toBe('60');
@@ -70,8 +70,8 @@ describe('PushoverChannelSection', () => {
     render(<PushoverChannelSection />, { wrapper: wrap(makeQc(), baseHh) });
 
     // Fill required fields
-    await user.type(screen.getByLabelText(/User Key Env/i), 'YAS_PUSHOVER_USER_KEY');
-    await user.type(screen.getByLabelText(/App Token Env/i), 'YAS_PUSHOVER_APP_TOKEN');
+    await user.type(screen.getByLabelText(/User Key/i), 'u-secret-user-key');
+    await user.type(screen.getByLabelText(/App Token/i), 'a-secret-app-token');
 
     // Click save
     await user.click(screen.getByRole('button', { name: /^Save/i }));
@@ -79,8 +79,8 @@ describe('PushoverChannelSection', () => {
     await waitFor(() => {
       expect(captured).not.toBeNull();
       const config = (captured?.pushover_config_json as Record<string, unknown>) || {};
-      expect(config.user_key_env).toBe('YAS_PUSHOVER_USER_KEY');
-      expect(config.app_token_env).toBe('YAS_PUSHOVER_APP_TOKEN');
+      expect(config.user_key_value).toBe('u-secret-user-key');
+      expect(config.app_token_value).toBe('a-secret-app-token');
       expect(config.devices).toBeUndefined(); // omitted when blank
       expect(config.emergency_retry_s).toBe(60);
       expect(config.emergency_expire_s).toBe(3600);
@@ -100,8 +100,8 @@ describe('PushoverChannelSection', () => {
     render(<PushoverChannelSection />, { wrapper: wrap(makeQc(), baseHh) });
 
     // Fill required fields
-    await user.type(screen.getByLabelText(/User Key Env/i), 'YAS_PUSHOVER_USER_KEY');
-    await user.type(screen.getByLabelText(/App Token Env/i), 'YAS_PUSHOVER_APP_TOKEN');
+    await user.type(screen.getByLabelText(/User Key/i), 'u-secret-user-key');
+    await user.type(screen.getByLabelText(/App Token/i), 'a-secret-app-token');
     await user.type(screen.getByLabelText(/Devices/i), 'phone, tablet , watch');
 
     // Click save
@@ -141,14 +141,30 @@ describe('PushoverChannelSection', () => {
     });
   });
 
-  it('missing user_key_env blocks save', async () => {
+  it('save with no credentials succeeds and patch body omits *_value keys', async () => {
+    const user = userEvent.setup();
+    let captured: Record<string, unknown> | null = null;
+    server.use(
+      http.patch('/api/household', async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(baseHh);
+      }),
+    );
+
     render(<PushoverChannelSection />, { wrapper: wrap(makeQc(), baseHh) });
 
-    // Fill only app_token_env
-    await userEvent.type(screen.getByLabelText(/App Token Env/i), 'YAS_PUSHOVER_APP_TOKEN');
+    // Don't fill any credential fields — server falls back to YAS_PUSHOVER_*
+    // env vars. Validation no longer blocks save when these are blank.
+    await user.click(screen.getByRole('button', { name: /^Save/i }));
 
-    // Save button should be disabled with missing user_key_env
-    const saveButton = screen.getByRole('button', { name: /^Save/i }) as HTMLButtonElement;
-    expect(saveButton).toBeDisabled();
+    await waitFor(() => {
+      expect(captured).not.toBeNull();
+      const config = (captured?.pushover_config_json as Record<string, unknown>) || {};
+      expect(config.user_key_value).toBeUndefined();
+      expect(config.app_token_value).toBeUndefined();
+      expect(config.devices).toBeUndefined();
+      expect(config.emergency_retry_s).toBe(60);
+      expect(config.emergency_expire_s).toBe(3600);
+    });
   });
 });

--- a/frontend/src/components/settings/PushoverChannelSection.tsx
+++ b/frontend/src/components/settings/PushoverChannelSection.tsx
@@ -1,18 +1,23 @@
 import { useState } from 'react';
-import { formErrorMessage } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { ErrorBanner } from '@/components/common/ErrorBanner';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { CredentialField } from './CredentialField';
 import { TestSendButton } from './TestSendButton';
 import { useUpdateHousehold } from '@/lib/mutations';
+import { useHousehold } from '@/lib/queries';
 import { ApiError } from '@/lib/api';
+import { formErrorMessage } from '@/lib/formError';
 import type { PushoverConfig } from '@/lib/types';
 
+// Both credential overrides are optional — empty string means "fall back
+// to the conventional env var on the server". We trust the user/UI to
+// keep them blank when env is sufficient.
 const pushoverSchema = z.object({
-  user_key_env: z.string().min(1, 'User key env var is required'),
-  app_token_env: z.string().min(1, 'App token env var is required'),
+  user_key_value: z.string(),
+  app_token_value: z.string(),
   devices: z.string(),
   emergency_retry_s: z.number().int().min(30),
   emergency_expire_s: z.number().int().min(60),
@@ -20,13 +25,17 @@ const pushoverSchema = z.object({
 
 export function PushoverChannelSection() {
   const update = useUpdateHousehold();
+  const household = useHousehold();
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
 
+  const userKeyStatus = household.data?.credential_status?.['pushover_user_key'];
+  const appTokenStatus = household.data?.credential_status?.['pushover_app_token'];
+
   const form = useForm({
     defaultValues: {
-      user_key_env: '',
-      app_token_env: '',
+      user_key_value: '',
+      app_token_value: '',
       devices: '',
       emergency_retry_s: 60,
       emergency_expire_s: 3600,
@@ -41,13 +50,22 @@ export function PushoverChannelSection() {
             .map((s) => s.trim())
             .filter(Boolean) ?? [];
         const config: PushoverConfig = {
-          user_key_env: value.user_key_env,
-          app_token_env: value.app_token_env,
+          // Only send *_value when the user actually typed something —
+          // empty string keeps existing DB value cleared and falls back
+          // to env. Sending undefined (omitted) leaves any prior DB
+          // value alone since the patch endpoint replaces the whole
+          // config blob; we're explicit to avoid that footgun.
+          ...(value.user_key_value ? { user_key_value: value.user_key_value } : {}),
+          ...(value.app_token_value ? { app_token_value: value.app_token_value } : {}),
           ...(devices.length > 0 ? { devices } : {}),
           emergency_retry_s: value.emergency_retry_s,
           emergency_expire_s: value.emergency_expire_s,
         };
         await update.mutateAsync({ pushover_config_json: config });
+        // Reset secret inputs so they don't stay displayed in the DOM
+        // after save. The status badge will refresh from the next query.
+        form.setFieldValue('user_key_value', '');
+        form.setFieldValue('app_token_value', '');
       } catch (err) {
         const detail = err instanceof ApiError ? (err.body as { detail?: string })?.detail : null;
         setErrorMsg(detail ?? (err as Error).message);
@@ -67,60 +85,32 @@ export function PushoverChannelSection() {
         className="space-y-3 max-w-xl"
       >
         <form.Field
-          name="user_key_env"
+          name="user_key_value"
           children={(field) => (
-            <div>
-              <label htmlFor="user_key_env" className="block text-sm font-medium">
-                User Key Env
-              </label>
-              <input
-                id="user_key_env"
-                type="text"
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                aria-invalid={field.state.meta.errors.length > 0}
-                className="mt-1 block w-full rounded border border-input px-3 py-2"
-                placeholder="e.g. YAS_PUSHOVER_USER_KEY"
-              />
-              {field.state.meta.errors.map((err, i) => (
-                <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
-                </p>
-              ))}
-              <span className="text-xs text-muted-foreground">
-                e.g. YAS_PUSHOVER_USER_KEY — set this env var in your .env
-              </span>
-            </div>
+            <CredentialField
+              id="user_key_value"
+              label="User Key"
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
+              status={userKeyStatus}
+              errors={field.state.meta.errors.map(formErrorMessage)}
+            />
           )}
         />
 
         <form.Field
-          name="app_token_env"
+          name="app_token_value"
           children={(field) => (
-            <div>
-              <label htmlFor="app_token_env" className="block text-sm font-medium">
-                App Token Env
-              </label>
-              <input
-                id="app_token_env"
-                type="text"
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                onBlur={field.handleBlur}
-                aria-invalid={field.state.meta.errors.length > 0}
-                className="mt-1 block w-full rounded border border-input px-3 py-2"
-                placeholder="e.g. YAS_PUSHOVER_APP_TOKEN"
-              />
-              {field.state.meta.errors.map((err, i) => (
-                <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
-                </p>
-              ))}
-              <span className="text-xs text-muted-foreground">
-                e.g. YAS_PUSHOVER_APP_TOKEN — set this env var in your .env
-              </span>
-            </div>
+            <CredentialField
+              id="app_token_value"
+              label="App Token"
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
+              status={appTokenStatus}
+              errors={field.state.meta.errors.map(formErrorMessage)}
+            />
           )}
         />
 
@@ -200,7 +190,6 @@ export function PushoverChannelSection() {
           />
         </details>
 
-        {/* Action buttons */}
         <div className="flex items-center gap-3 pt-2">
           <form.Subscribe selector={(state) => state.canSubmit}>
             {(canSubmit) => (

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -236,6 +236,13 @@ export interface AlertRouting {
   enabled: boolean;
 }
 
+export interface CredentialStatus {
+  /** "form" = user pasted a value into Settings (DB); "env" = conventional
+   *  YAS_* env var is set; null = unconfigured. */
+  via: 'form' | 'env' | null;
+  env_var: string;
+}
+
 export interface Household {
   id: number;
   home_location_id: number | null;
@@ -251,6 +258,11 @@ export interface Household {
   email_configured: boolean;
   ntfy_configured: boolean;
   pushover_configured: boolean;
+  /** Per-credential status keyed by Settings field name: smtp_password,
+   *  forwardemail_api_token, ntfy_auth_token, pushover_user_key,
+   *  pushover_app_token. Empty when the channel is unconfigured. May be
+   *  missing on older API responses; consumers default to {}. */
+  credential_status?: Record<string, CredentialStatus>;
 }
 
 // Channel configuration types for Phase 7-1 Settings
@@ -260,14 +272,18 @@ export interface SmtpConfig {
   port: number;
   use_tls: boolean;
   username?: string;
-  password_env?: string;
+  /** Optional password override. When unset/empty, channel falls back
+   *  to the YAS_SMTP_PASSWORD env var. */
+  password_value?: string;
   from_addr: string;
   to_addrs: string[];
 }
 
 export interface ForwardEmailConfig {
   transport: 'forwardemail';
-  api_token_env: string;
+  /** Optional token override. When unset/empty, channel falls back to
+   *  the YAS_FORWARDEMAIL_API_TOKEN env var. */
+  api_token_value?: string;
   from_addr: string;
   to_addrs: string[];
 }
@@ -277,12 +293,15 @@ export type EmailConfig = SmtpConfig | ForwardEmailConfig;
 export interface NtfyConfig {
   base_url: string;
   topic: string;
-  auth_token_env?: string;
+  /** Optional override; falls back to YAS_NTFY_AUTH_TOKEN. */
+  auth_token_value?: string;
 }
 
 export interface PushoverConfig {
-  user_key_env: string;
-  app_token_env: string;
+  /** Optional override; falls back to YAS_PUSHOVER_USER_KEY. */
+  user_key_value?: string;
+  /** Optional override; falls back to YAS_PUSHOVER_APP_TOKEN. */
+  app_token_value?: string;
   devices?: string[];
   emergency_retry_s?: number;
   emergency_expire_s?: number;


### PR DESCRIPTION
Companion to #50. Replaces the env-var-NAME inputs in the Settings page with masked password inputs + a status badge that tells the user where each credential is currently resolving from.

## What changed

Each credential field is a new \`<CredentialField>\` that combines:
- Masked password input (\`type=\"password\"\`, \`autocomplete=\"off\"\`, mono font).
- Status badge: \`✓ env\` (resolves from YAS_*) / \`✓ form\` (DB-stored override) / \`✗ not set\`.
- Placeholder \`•••••• (set via YAS_PUSHOVER_USER_KEY)\` when env is in use, so the user knows leaving it blank is fine.
- After save the secret input is wiped (\`form.setFieldValue('')\`) so it doesn't linger in the DOM.

Field rename map:
- Pushover: \`user_key_env\`/\`app_token_env\` → \`user_key_value\`/\`app_token_value\`
- Ntfy: \`auth_token_env\` → \`auth_token_value\`
- Email/SMTP: \`password_env\` → \`password_value\`
- Email/ForwardEmail: \`api_token_env\` → \`api_token_value\`

The ForwardEmail token used to be required-on-save (the form refused to submit without an env name). It's now optional — empty means \"fall back to the YAS_FORWARDEMAIL_API_TOKEN env var,\" matching how the other channels behave.

## Why

Two real bugs from the prior design (caught while configuring channels with @owine):
1. The env-var-NAME indirection was the wrong abstraction — users typed an env name into the form, and separately set the env var to the value. They forgot the form half because the form looked optional.
2. \`String(err)\` rendering was masking helpful Zod errors as \`[object Object]\` (fixed in #49). Once that was fixed, users still had to know to type \`YAS_PUSHOVER_USER_KEY\` into the box.

PR #50 made the backend resolve credentials in the order \`config.*_value\` → \`Settings.*\` → fail. This PR exposes that order in the UI: type a value to override, leave blank to use env, see at a glance where the credential is coming from.

## Master §10 terminal criteria delta

None. UX/refactor.

## Test plan

- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [x] uv run pytest -q (668; backend unchanged from #50)
- [ ] CI passes
- [ ] Manual smoke after merge: open Settings; verify each channel field shows the correct status badge based on which YAS_* env vars are set; paste a value and save → status flips to \"form\"; clear and save → status flips back to \"env\" if YAS_* is set, or \"not set\" otherwise