### PR TITLE
fix(ui): dedupe form errors + dark-mode AlertRouting + honest CredentialField

### DIFF
--- a/frontend/src/components/kids/KidForm.tsx
+++ b/frontend/src/components/kids/KidForm.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@tanstack/react-form';
-import { formErrorMessage } from '@/lib/formError';
+import { uniqueFormErrors } from '@/lib/formError';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { kidSchema, type KidFormValues } from './kidSchema';
@@ -146,9 +146,9 @@ export function KidForm({ mode, id }: KidFormProps) {
               aria-invalid={field.state.meta.errors.length > 0}
               className="mt-1 block w-full rounded border border-input px-3 py-2"
             />
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>
@@ -171,9 +171,9 @@ export function KidForm({ mode, id }: KidFormProps) {
               aria-invalid={field.state.meta.errors.length > 0}
               className="mt-1 block w-full rounded border border-input px-3 py-2"
             />
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>
@@ -215,9 +215,9 @@ export function KidForm({ mode, id }: KidFormProps) {
                 </label>
               ))}
             </div>
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>
@@ -259,9 +259,9 @@ export function KidForm({ mode, id }: KidFormProps) {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>
@@ -316,9 +316,9 @@ export function KidForm({ mode, id }: KidFormProps) {
                 No limit
               </label>
             </div>
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>
@@ -362,9 +362,9 @@ export function KidForm({ mode, id }: KidFormProps) {
                 Use distance instead
               </label>
             </div>
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>
@@ -391,9 +391,9 @@ export function KidForm({ mode, id }: KidFormProps) {
               onChange={(e) => field.handleChange(parseFloat(e.target.value))}
               className="mt-2 w-full"
             />
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>
@@ -423,9 +423,9 @@ export function KidForm({ mode, id }: KidFormProps) {
               rows={4}
               className="mt-1 block w-full rounded border border-input px-3 py-2"
             />
-            {field.state.meta.errors.map((err, i) => (
+            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
-                {formErrorMessage(err)}
+                {m}
               </p>
             ))}
           </div>

--- a/frontend/src/components/settings/AlertRoutingSection.tsx
+++ b/frontend/src/components/settings/AlertRoutingSection.tsx
@@ -50,15 +50,13 @@ export function AlertRoutingSection() {
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">Alert Routing</h2>
       <div className="overflow-x-auto">
-        <table className="border-collapse border border-gray-200 w-full">
+        <table className="border-collapse border border-border w-full">
           <thead>
-            <tr className="bg-gray-50">
-              <th className="border border-gray-200 px-4 py-2 text-left font-semibold">
-                Alert Type
-              </th>
-              <th className="border border-gray-200 px-4 py-2 text-left font-semibold">Enabled</th>
+            <tr className="bg-muted">
+              <th className="border border-border px-4 py-2 text-left font-semibold">Alert Type</th>
+              <th className="border border-border px-4 py-2 text-left font-semibold">Enabled</th>
               {channels.map((ch) => (
-                <th key={ch} className="border border-gray-200 px-4 py-2 text-left font-semibold">
+                <th key={ch} className="border border-border px-4 py-2 text-left font-semibold">
                   {ch}
                 </th>
               ))}
@@ -66,9 +64,9 @@ export function AlertRoutingSection() {
           </thead>
           <tbody>
             {routing.data.map((row) => (
-              <tr key={row.type} className="hover:bg-gray-50">
-                <td className="border border-gray-200 px-4 py-2">{row.type}</td>
-                <td className="border border-gray-200 px-4 py-2">
+              <tr key={row.type} className="hover:bg-muted">
+                <td className="border border-border px-4 py-2">{row.type}</td>
+                <td className="border border-border px-4 py-2">
                   <input
                     type="checkbox"
                     aria-label={`${row.type} enabled`}
@@ -83,7 +81,7 @@ export function AlertRoutingSection() {
                   const isLastChannel = row.enabled && row.channels.length === 1 && isChecked;
 
                   return (
-                    <td key={`${row.type}-${ch}`} className="border border-gray-200 px-4 py-2">
+                    <td key={`${row.type}-${ch}`} className="border border-border px-4 py-2">
                       <input
                         type="checkbox"
                         aria-label={`${row.type} ${ch}`}

--- a/frontend/src/components/settings/CredentialField.tsx
+++ b/frontend/src/components/settings/CredentialField.tsx
@@ -37,6 +37,13 @@ export function CredentialField({
   errors,
   hint,
 }: Props) {
+  // Three states:
+  //   - status === undefined → backend didn't return credential_status (older
+  //     API or channel not yet saved). We don't actually know if it's set;
+  //     render no badge rather than claiming "not set."
+  //   - status.via === 'env' / 'form' → credential resolves; green/blue badge.
+  //   - status.via === null → backend confirmed no env, no form value. Amber.
+  const known = status !== undefined;
   const via = status?.via ?? null;
   const envVar = status?.env_var;
 
@@ -49,29 +56,28 @@ export function CredentialField({
           ? `Paste value, or set ${envVar} env var`
           : 'Paste value';
 
-  const badge =
-    via === 'env' ? (
-      <span
-        className="inline-flex items-center rounded bg-emerald-100 px-1.5 py-0.5 text-xs text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200"
-        title={`Resolves from ${envVar}`}
-      >
-        ✓ env
-      </span>
-    ) : via === 'form' ? (
-      <span
-        className="inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-900 dark:bg-blue-900/30 dark:text-blue-200"
-        title="Stored in DB; overrides any env var"
-      >
-        ✓ form
-      </span>
-    ) : (
-      <span
-        className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-200"
-        title={envVar ? `Set ${envVar} or paste a value above` : 'Unconfigured'}
-      >
-        ✗ not set
-      </span>
-    );
+  const badge = !known ? null : via === 'env' ? (
+    <span
+      className="inline-flex items-center rounded bg-emerald-100 px-1.5 py-0.5 text-xs text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200"
+      title={`Resolves from ${envVar}`}
+    >
+      ✓ env
+    </span>
+  ) : via === 'form' ? (
+    <span
+      className="inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-900 dark:bg-blue-900/30 dark:text-blue-200"
+      title="Stored in DB; overrides any env var"
+    >
+      ✓ form
+    </span>
+  ) : (
+    <span
+      className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-200"
+      title={envVar ? `Set ${envVar} or paste a value above` : 'Unconfigured'}
+    >
+      ✗ not set
+    </span>
+  );
 
   return (
     <div>

--- a/frontend/src/components/settings/EmailChannelSection.tsx
+++ b/frontend/src/components/settings/EmailChannelSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { formErrorMessage } from '@/lib/formError';
+import { uniqueFormErrors } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -166,9 +166,9 @@ export function EmailChannelSection() {
                           className="mt-1 block w-full rounded border border-input px-3 py-2"
                           placeholder="smtp.example.com"
                         />
-                        {field.state.meta.errors.map((err, i) => (
+                        {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                           <p key={i} className="mt-1 text-xs text-destructive">
-                            {formErrorMessage(err)}
+                            {m}
                           </p>
                         ))}
                       </div>
@@ -193,9 +193,9 @@ export function EmailChannelSection() {
                           min="1"
                           max="65535"
                         />
-                        {field.state.meta.errors.map((err, i) => (
+                        {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                           <p key={i} className="mt-1 text-xs text-destructive">
-                            {formErrorMessage(err)}
+                            {m}
                           </p>
                         ))}
                       </div>
@@ -233,7 +233,7 @@ export function EmailChannelSection() {
                         onChange={field.handleChange}
                         onBlur={field.handleBlur}
                         status={smtpStatus}
-                        errors={field.state.meta.errors.map(formErrorMessage)}
+                        errors={uniqueFormErrors(field.state.meta.errors)}
                       />
                     )}
                   />
@@ -264,7 +264,7 @@ export function EmailChannelSection() {
                       onChange={field.handleChange}
                       onBlur={field.handleBlur}
                       status={fwdStatus}
-                      errors={field.state.meta.errors.map(formErrorMessage)}
+                      errors={uniqueFormErrors(field.state.meta.errors)}
                     />
                   )}
                 />
@@ -291,9 +291,9 @@ export function EmailChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="noreply@example.com"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>
@@ -317,9 +317,9 @@ export function EmailChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="admin@example.com, support@example.com"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>

--- a/frontend/src/components/settings/HouseholdSection.tsx
+++ b/frontend/src/components/settings/HouseholdSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { formErrorMessage } from '@/lib/formError';
+import { uniqueFormErrors } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -122,9 +122,9 @@ export function HouseholdSection() {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
               {geocodePill && <div className="mt-2">{geocodePill}</div>}
@@ -148,9 +148,9 @@ export function HouseholdSection() {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>
@@ -179,9 +179,9 @@ export function HouseholdSection() {
                   min="0"
                   step="0.1"
                 />
-                {field.state.meta.errors.map((err, i) => (
+                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {formErrorMessage(err)}
+                    {m}
                   </p>
                 ))}
               </div>
@@ -225,9 +225,9 @@ export function HouseholdSection() {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>
@@ -251,9 +251,9 @@ export function HouseholdSection() {
                   aria-invalid={field.state.meta.errors.length > 0}
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                 />
-                {field.state.meta.errors.map((err, i) => (
+                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {formErrorMessage(err)}
+                    {m}
                   </p>
                 ))}
               </div>
@@ -276,9 +276,9 @@ export function HouseholdSection() {
                   aria-invalid={field.state.meta.errors.length > 0}
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                 />
-                {field.state.meta.errors.map((err, i) => (
+                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {formErrorMessage(err)}
+                    {m}
                   </p>
                 ))}
               </div>
@@ -307,9 +307,9 @@ export function HouseholdSection() {
                   step="0.5"
                 />
               </div>
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>

--- a/frontend/src/components/settings/NtfyChannelSection.tsx
+++ b/frontend/src/components/settings/NtfyChannelSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { formErrorMessage } from '@/lib/formError';
+import { uniqueFormErrors } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -80,9 +80,9 @@ export function NtfyChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="https://ntfy.sh"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>
@@ -106,9 +106,9 @@ export function NtfyChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="my-alerts"
               />
-              {field.state.meta.errors.map((err, i) => (
+              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
-                  {formErrorMessage(err)}
+                  {m}
                 </p>
               ))}
             </div>
@@ -126,7 +126,7 @@ export function NtfyChannelSection() {
               onChange={field.handleChange}
               onBlur={field.handleBlur}
               status={authStatus}
-              errors={field.state.meta.errors.map(formErrorMessage)}
+              errors={uniqueFormErrors(field.state.meta.errors)}
             />
           )}
         />

--- a/frontend/src/components/settings/PushoverChannelSection.tsx
+++ b/frontend/src/components/settings/PushoverChannelSection.tsx
@@ -9,7 +9,7 @@ import { TestSendButton } from './TestSendButton';
 import { useUpdateHousehold } from '@/lib/mutations';
 import { useHousehold } from '@/lib/queries';
 import { ApiError } from '@/lib/api';
-import { formErrorMessage } from '@/lib/formError';
+import { uniqueFormErrors } from '@/lib/formError';
 import type { PushoverConfig } from '@/lib/types';
 
 // Both credential overrides are optional — empty string means "fall back
@@ -94,7 +94,7 @@ export function PushoverChannelSection() {
               onChange={field.handleChange}
               onBlur={field.handleBlur}
               status={userKeyStatus}
-              errors={field.state.meta.errors.map(formErrorMessage)}
+              errors={uniqueFormErrors(field.state.meta.errors)}
             />
           )}
         />
@@ -109,7 +109,7 @@ export function PushoverChannelSection() {
               onChange={field.handleChange}
               onBlur={field.handleBlur}
               status={appTokenStatus}
-              errors={field.state.meta.errors.map(formErrorMessage)}
+              errors={uniqueFormErrors(field.state.meta.errors)}
             />
           )}
         />
@@ -154,9 +154,9 @@ export function PushoverChannelSection() {
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                   min="30"
                 />
-                {field.state.meta.errors.map((err, i) => (
+                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {formErrorMessage(err)}
+                    {m}
                   </p>
                 ))}
               </div>
@@ -180,9 +180,9 @@ export function PushoverChannelSection() {
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                   min="60"
                 />
-                {field.state.meta.errors.map((err, i) => (
+                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
-                    {formErrorMessage(err)}
+                    {m}
                   </p>
                 ))}
               </div>

--- a/frontend/src/components/watchlist/WatchlistEntrySheet.tsx
+++ b/frontend/src/components/watchlist/WatchlistEntrySheet.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@tanstack/react-form';
-import { formErrorMessage } from '@/lib/formError';
+import { uniqueFormErrors } from '@/lib/formError';
 import { useState } from 'react';
 import { z } from 'zod';
 import { useCreateWatchlistEntry, useUpdateWatchlistEntry } from '@/lib/mutations';
@@ -152,9 +152,9 @@ export function WatchlistEntrySheet({
                     aria-invalid={field.state.meta.errors.length > 0}
                     className="mt-1 block w-full rounded border border-input px-3 py-2"
                   />
-                  {field.state.meta.errors.map((err, i) => (
+                  {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
                     <p key={i} className="mt-1 text-xs text-destructive">
-                      {formErrorMessage(err)}
+                      {m}
                     </p>
                   ))}
                 </div>

--- a/frontend/src/lib/formError.ts
+++ b/frontend/src/lib/formError.ts
@@ -1,4 +1,23 @@
 /**
+ * Dedupe a list of TanStack Form errors by their rendered message.
+ * onMount + onChange validators on the same schema both populate
+ * `meta.errors`, producing visually-identical duplicates. We collapse
+ * by message string so the user sees each problem once.
+ */
+export function uniqueFormErrors(errors: readonly unknown[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const err of errors) {
+    const m = formErrorMessage(err);
+    if (m && !seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  return out;
+}
+
+/**
  * Extract a renderable string from a TanStack Form error entry.
  *
  * `field.state.meta.errors` is `Array<unknown>` — what's in there depends


### PR DESCRIPTION
Three small UI bugs caught in real-usage screenshots:

## 1. Duplicate validation errors

Each form does \`validators: { onChange, onMount }\` against the same Zod schema. Both validators fire and both populate \`field.state.meta.errors\` with identical entries — visible after #49 fixed \`String(err)\` rendering (before that, all entries rendered as the same \`[object Object]\` string and visually collapsed). 

Fix: new \`uniqueFormErrors(errors)\` helper in \`lib/formError.ts\` dedupes by message string at render time. Sweeps the existing \`field.state.meta.errors.map(formErrorMessage)\` pattern in 6 files.

## 2. AlertRouting table unreadable in dark mode

\`<thead>\` row used \`bg-gray-50\` (light gray = white in practice) and tbody rows had \`hover:bg-gray-50\` — both produced white-on-white text in dark theme. Switched to design-system \`bg-muted\` + \`border-border\` tokens that flip with theme.

## 3. CredentialField was lying when status unknown

The previous version rendered \"✗ not set\" whenever \`status\` was undefined. But undefined just means the backend didn't include \`credential_status\` in the response (older API, or a yet-unsaved channel) — not that the credential isn't set. Fix: render no badge in the unknown case; only show ✓ env / ✓ form / ✗ not set when the backend has actually told us.

This is what surfaced in the screenshot — your conventional \`YAS_PUSHOVER_USER_KEY\` / \`YAS_FORWARDEMAIL_API_TOKEN\` env vars ARE set, but the running container is from before #50 merged so its \`/api/household\` doesn't yet return \`credential_status\`. Once you pull the latest image and restart, the green \`✓ env\` badge will appear.

## Master §10 terminal criteria delta

None. UX bugfixes.

## Test plan

- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [x] Reviewed all 6 sites of the dedupe sweep
- [ ] CI passes
- [ ] After merge + container redeploy:
  - Open Settings → AlertRouting table is readable in dark mode (no white-on-white headers)
  - Each From/To error message appears once, not twice
  - Pushover/Email channels show ✓ env (not ✗ not set) given the conventional YAS_* env vars are present in your container