### PR TITLE
fix(ui): credential_status always returned + touched-only error rendering

### DIFF
--- a/frontend/src/components/kids/KidForm.tsx
+++ b/frontend/src/components/kids/KidForm.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@tanstack/react-form';
-import { uniqueFormErrors } from '@/lib/formError';
+import { touchedFormErrors } from '@/lib/formError';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { kidSchema, type KidFormValues } from './kidSchema';
@@ -146,7 +146,7 @@ export function KidForm({ mode, id }: KidFormProps) {
               aria-invalid={field.state.meta.errors.length > 0}
               className="mt-1 block w-full rounded border border-input px-3 py-2"
             />
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>
@@ -171,7 +171,7 @@ export function KidForm({ mode, id }: KidFormProps) {
               aria-invalid={field.state.meta.errors.length > 0}
               className="mt-1 block w-full rounded border border-input px-3 py-2"
             />
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>
@@ -215,7 +215,7 @@ export function KidForm({ mode, id }: KidFormProps) {
                 </label>
               ))}
             </div>
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>
@@ -259,7 +259,7 @@ export function KidForm({ mode, id }: KidFormProps) {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -316,7 +316,7 @@ export function KidForm({ mode, id }: KidFormProps) {
                 No limit
               </label>
             </div>
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>
@@ -362,7 +362,7 @@ export function KidForm({ mode, id }: KidFormProps) {
                 Use distance instead
               </label>
             </div>
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>
@@ -391,7 +391,7 @@ export function KidForm({ mode, id }: KidFormProps) {
               onChange={(e) => field.handleChange(parseFloat(e.target.value))}
               className="mt-2 w-full"
             />
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>
@@ -423,7 +423,7 @@ export function KidForm({ mode, id }: KidFormProps) {
               rows={4}
               className="mt-1 block w-full rounded border border-input px-3 py-2"
             />
-            {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+            {touchedFormErrors(field.state.meta).map((m, i) => (
               <p key={i} className="mt-1 text-xs text-destructive">
                 {m}
               </p>

--- a/frontend/src/components/settings/EmailChannelSection.tsx
+++ b/frontend/src/components/settings/EmailChannelSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { uniqueFormErrors } from '@/lib/formError';
+import { touchedFormErrors } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -166,7 +166,7 @@ export function EmailChannelSection() {
                           className="mt-1 block w-full rounded border border-input px-3 py-2"
                           placeholder="smtp.example.com"
                         />
-                        {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                        {touchedFormErrors(field.state.meta).map((m, i) => (
                           <p key={i} className="mt-1 text-xs text-destructive">
                             {m}
                           </p>
@@ -193,7 +193,7 @@ export function EmailChannelSection() {
                           min="1"
                           max="65535"
                         />
-                        {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                        {touchedFormErrors(field.state.meta).map((m, i) => (
                           <p key={i} className="mt-1 text-xs text-destructive">
                             {m}
                           </p>
@@ -233,7 +233,7 @@ export function EmailChannelSection() {
                         onChange={field.handleChange}
                         onBlur={field.handleBlur}
                         status={smtpStatus}
-                        errors={uniqueFormErrors(field.state.meta.errors)}
+                        errors={touchedFormErrors(field.state.meta)}
                       />
                     )}
                   />
@@ -264,7 +264,7 @@ export function EmailChannelSection() {
                       onChange={field.handleChange}
                       onBlur={field.handleBlur}
                       status={fwdStatus}
-                      errors={uniqueFormErrors(field.state.meta.errors)}
+                      errors={touchedFormErrors(field.state.meta)}
                     />
                   )}
                 />
@@ -291,7 +291,7 @@ export function EmailChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="noreply@example.com"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -317,7 +317,7 @@ export function EmailChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="admin@example.com, support@example.com"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>

--- a/frontend/src/components/settings/HouseholdSection.tsx
+++ b/frontend/src/components/settings/HouseholdSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { uniqueFormErrors } from '@/lib/formError';
+import { touchedFormErrors } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -122,7 +122,7 @@ export function HouseholdSection() {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -148,7 +148,7 @@ export function HouseholdSection() {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -179,7 +179,7 @@ export function HouseholdSection() {
                   min="0"
                   step="0.1"
                 />
-                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                {touchedFormErrors(field.state.meta).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
                     {m}
                   </p>
@@ -225,7 +225,7 @@ export function HouseholdSection() {
                 aria-invalid={field.state.meta.errors.length > 0}
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -251,7 +251,7 @@ export function HouseholdSection() {
                   aria-invalid={field.state.meta.errors.length > 0}
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                 />
-                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                {touchedFormErrors(field.state.meta).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
                     {m}
                   </p>
@@ -276,7 +276,7 @@ export function HouseholdSection() {
                   aria-invalid={field.state.meta.errors.length > 0}
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                 />
-                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                {touchedFormErrors(field.state.meta).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
                     {m}
                   </p>
@@ -307,7 +307,7 @@ export function HouseholdSection() {
                   step="0.5"
                 />
               </div>
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>

--- a/frontend/src/components/settings/NtfyChannelSection.tsx
+++ b/frontend/src/components/settings/NtfyChannelSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { uniqueFormErrors } from '@/lib/formError';
+import { touchedFormErrors } from '@/lib/formError';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -80,7 +80,7 @@ export function NtfyChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="https://ntfy.sh"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -106,7 +106,7 @@ export function NtfyChannelSection() {
                 className="mt-1 block w-full rounded border border-input px-3 py-2"
                 placeholder="my-alerts"
               />
-              {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+              {touchedFormErrors(field.state.meta).map((m, i) => (
                 <p key={i} className="mt-1 text-xs text-destructive">
                   {m}
                 </p>
@@ -126,7 +126,7 @@ export function NtfyChannelSection() {
               onChange={field.handleChange}
               onBlur={field.handleBlur}
               status={authStatus}
-              errors={uniqueFormErrors(field.state.meta.errors)}
+              errors={touchedFormErrors(field.state.meta)}
             />
           )}
         />

--- a/frontend/src/components/settings/PushoverChannelSection.tsx
+++ b/frontend/src/components/settings/PushoverChannelSection.tsx
@@ -9,7 +9,7 @@ import { TestSendButton } from './TestSendButton';
 import { useUpdateHousehold } from '@/lib/mutations';
 import { useHousehold } from '@/lib/queries';
 import { ApiError } from '@/lib/api';
-import { uniqueFormErrors } from '@/lib/formError';
+import { touchedFormErrors } from '@/lib/formError';
 import type { PushoverConfig } from '@/lib/types';
 
 // Both credential overrides are optional — empty string means "fall back
@@ -94,7 +94,7 @@ export function PushoverChannelSection() {
               onChange={field.handleChange}
               onBlur={field.handleBlur}
               status={userKeyStatus}
-              errors={uniqueFormErrors(field.state.meta.errors)}
+              errors={touchedFormErrors(field.state.meta)}
             />
           )}
         />
@@ -109,7 +109,7 @@ export function PushoverChannelSection() {
               onChange={field.handleChange}
               onBlur={field.handleBlur}
               status={appTokenStatus}
-              errors={uniqueFormErrors(field.state.meta.errors)}
+              errors={touchedFormErrors(field.state.meta)}
             />
           )}
         />
@@ -154,7 +154,7 @@ export function PushoverChannelSection() {
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                   min="30"
                 />
-                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                {touchedFormErrors(field.state.meta).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
                     {m}
                   </p>
@@ -180,7 +180,7 @@ export function PushoverChannelSection() {
                   className="mt-1 block w-full rounded border border-input px-3 py-2"
                   min="60"
                 />
-                {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                {touchedFormErrors(field.state.meta).map((m, i) => (
                   <p key={i} className="mt-1 text-xs text-destructive">
                     {m}
                   </p>

--- a/frontend/src/components/watchlist/WatchlistEntrySheet.tsx
+++ b/frontend/src/components/watchlist/WatchlistEntrySheet.tsx
@@ -1,5 +1,5 @@
 import { useForm } from '@tanstack/react-form';
-import { uniqueFormErrors } from '@/lib/formError';
+import { touchedFormErrors } from '@/lib/formError';
 import { useState } from 'react';
 import { z } from 'zod';
 import { useCreateWatchlistEntry, useUpdateWatchlistEntry } from '@/lib/mutations';
@@ -152,7 +152,7 @@ export function WatchlistEntrySheet({
                     aria-invalid={field.state.meta.errors.length > 0}
                     className="mt-1 block w-full rounded border border-input px-3 py-2"
                   />
-                  {uniqueFormErrors(field.state.meta.errors).map((m, i) => (
+                  {touchedFormErrors(field.state.meta).map((m, i) => (
                     <p key={i} className="mt-1 text-xs text-destructive">
                       {m}
                     </p>

--- a/frontend/src/lib/formError.ts
+++ b/frontend/src/lib/formError.ts
@@ -1,4 +1,20 @@
 /**
+ * Visible-when-touched + deduped errors for a TanStack Form field.
+ * Returns [] until the user has interacted with the field, so a fresh
+ * form doesn't shout "required" at every empty input on first paint.
+ *
+ * Pass the field's meta object (or the parts that matter):
+ *   {field.state.meta}
+ */
+export function touchedFormErrors(meta: {
+  errors: readonly unknown[];
+  isTouched?: boolean;
+}): string[] {
+  if (!meta.isTouched) return [];
+  return uniqueFormErrors(meta.errors);
+}
+
+/**
  * Dedupe a list of TanStack Form errors by their rendered message.
  * onMount + onChange validators on the same schema both populate
  * `meta.errors`, producing visually-identical duplicates. We collapse

--- a/src/yas/web/routes/household.py
+++ b/src/yas/web/routes/household.py
@@ -66,42 +66,43 @@ async def _to_out(s: AsyncSession, hh: HouseholdSettings, settings: Settings) ->
         loc = (
             await s.execute(select(Location).where(Location.id == hh.home_location_id))
         ).scalar_one_or_none()
-    cred_status: dict[str, CredentialStatus] = {}
+    # Always return all five credential statuses, regardless of whether
+    # the user has saved a *_config_json row yet. Otherwise the badge
+    # never appears on a fresh form even when env vars are set, leaving
+    # users unsure whether they need to paste a value.
     smtp = hh.smtp_config_json
-    if smtp is not None and smtp.get("transport") == "smtp":
-        cred_status["smtp_password"] = _credential_status(
-            smtp,
+    cred_status: dict[str, CredentialStatus] = {
+        "smtp_password": _credential_status(
+            smtp if smtp and smtp.get("transport") == "smtp" else None,
             value_key="password_value",
             env_var_name="YAS_SMTP_PASSWORD",
             settings_value=settings.smtp_password,
-        )
-    if smtp is not None and smtp.get("transport") == "forwardemail":
-        cred_status["forwardemail_api_token"] = _credential_status(
-            smtp,
+        ),
+        "forwardemail_api_token": _credential_status(
+            smtp if smtp and smtp.get("transport") == "forwardemail" else None,
             value_key="api_token_value",
             env_var_name="YAS_FORWARDEMAIL_API_TOKEN",
             settings_value=settings.forwardemail_api_token,
-        )
-    if hh.ntfy_config_json is not None:
-        cred_status["ntfy_auth_token"] = _credential_status(
+        ),
+        "ntfy_auth_token": _credential_status(
             hh.ntfy_config_json,
             value_key="auth_token_value",
             env_var_name="YAS_NTFY_AUTH_TOKEN",
             settings_value=settings.ntfy_auth_token,
-        )
-    if hh.pushover_config_json is not None:
-        cred_status["pushover_user_key"] = _credential_status(
+        ),
+        "pushover_user_key": _credential_status(
             hh.pushover_config_json,
             value_key="user_key_value",
             env_var_name="YAS_PUSHOVER_USER_KEY",
             settings_value=settings.pushover_user_key,
-        )
-        cred_status["pushover_app_token"] = _credential_status(
+        ),
+        "pushover_app_token": _credential_status(
             hh.pushover_config_json,
             value_key="app_token_value",
             env_var_name="YAS_PUSHOVER_APP_TOKEN",
             settings_value=settings.pushover_app_token,
-        )
+        ),
+    }
 
     return HouseholdOut(
         id=hh.id,


### PR DESCRIPTION
Two more UX bugs caught in real-usage screenshots after the credentials refactor:

## 1. Backend: \`credential_status\` was gated on saved config

The previous \`_to_out\` only added \`credential_status\` entries when the corresponding \`*_config_json\` was non-null. Result: a fresh form (no save yet) got no badge — the UI couldn't tell users whether \`YAS_*\` env vars were already in effect, leaving them unsure if they needed to paste a value or not.

Fix: always return all 5 credential statuses (\`smtp_password\`, \`forwardemail_api_token\`, \`ntfy_auth_token\`, \`pushover_user_key\`, \`pushover_app_token\`). The form-value path collapses to \`via=null\` when there's no saved row, but env resolution stays accurate from day one.

## 2. Frontend: errors rendered on untouched fields

\`onMount: schema\` is needed for the \`canSubmit\` gating (so Save stays disabled on a blank form). But it also means \`field.state.meta.errors\` is populated on first paint — yielding \"Valid email required\" red text under fields the user hasn't touched yet.

Fix: new \`touchedFormErrors(meta)\` helper returns \`[]\` until \`isTouched === true\`. Sweep replaces \`uniqueFormErrors(field.state.meta.errors)\` across 6 files (4 channel sections + KidForm + WatchlistEntrySheet). \`canSubmit\` gating still works because the form's overall \`isValid\` flag is independent of per-field rendering.

## Master §10 terminal criteria delta

None. UX bugfixes.

## Test plan

- [x] uv run pytest -q (668 passing)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [x] Existing household + form tests pass — no assertions about per-field error rendering on initial paint, so no test changes needed
- [ ] CI passes
- [ ] After merge + container redeploy: fresh Settings page shows ✓ env / ✓ form / ✗ not set badges based on env-set status; no red errors until user types or tabs out