### PR TITLE
fix(channels): rebuild notifiers per tick + redact configs to round-trip

### DIFF
--- a/frontend/src/components/settings/EmailChannelSection.tsx
+++ b/frontend/src/components/settings/EmailChannelSection.tsx
@@ -48,20 +48,22 @@ export function EmailChannelSection() {
   const smtpStatus = household.data?.credential_status?.['smtp_password'];
   const fwdStatus = household.data?.credential_status?.['forwardemail_api_token'];
 
-  // Note: Household does NOT expose smtp_config_json (only HouseholdSettings row has it).
-  // The backend makes *_config_json write-only. So we always start with empty form.
-  // This is a real constraint: form starts empty/default each time page loads; users
-  // must re-enter config when editing. The Disable button still works (PATCHes null).
+  // Pre-populate non-secret fields from the saved (redacted) config.
+  // Secret *_value fields stay blank — the credential_status badge
+  // tells the user where the secret resolves; they can paste a new
+  // value to override or leave blank to keep the stored one.
+  const saved = household.data?.smtp_config_json as Record<string, unknown> | null | undefined;
+  const savedTransport = (saved?.transport as 'smtp' | 'forwardemail' | undefined) ?? 'smtp';
   const form = useForm({
     defaultValues: {
-      transport: 'smtp',
-      host: '',
-      port: 587,
-      username: '',
+      transport: savedTransport,
+      host: (saved?.host as string | undefined) ?? '',
+      port: (saved?.port as number | undefined) ?? 587,
+      username: (saved?.username as string | undefined) ?? '',
       password_value: '',
-      use_tls: true,
-      from_addr: '',
-      to_addrs: '',
+      use_tls: (saved?.use_tls as boolean | undefined) ?? true,
+      from_addr: (saved?.from_addr as string | undefined) ?? '',
+      to_addrs: Array.isArray(saved?.to_addrs) ? (saved!.to_addrs as string[]).join(', ') : '',
       api_token_value: '',
     },
     validators: { onChange: schema, onMount: schema },

--- a/frontend/src/components/settings/NtfyChannelSection.tsx
+++ b/frontend/src/components/settings/NtfyChannelSection.tsx
@@ -26,10 +26,11 @@ export function NtfyChannelSection() {
 
   const authStatus = household.data?.credential_status?.['ntfy_auth_token'];
 
+  const saved = household.data?.ntfy_config_json as Record<string, unknown> | null | undefined;
   const form = useForm({
     defaultValues: {
-      base_url: 'https://ntfy.sh',
-      topic: '',
+      base_url: (saved?.base_url as string | undefined) ?? 'https://ntfy.sh',
+      topic: (saved?.topic as string | undefined) ?? '',
       auth_token_value: '',
     },
     validators: { onChange: ntfySchema, onMount: ntfySchema },

--- a/frontend/src/components/settings/PushoverChannelSection.tsx
+++ b/frontend/src/components/settings/PushoverChannelSection.tsx
@@ -32,13 +32,14 @@ export function PushoverChannelSection() {
   const userKeyStatus = household.data?.credential_status?.['pushover_user_key'];
   const appTokenStatus = household.data?.credential_status?.['pushover_app_token'];
 
+  const saved = household.data?.pushover_config_json as Record<string, unknown> | null | undefined;
   const form = useForm({
     defaultValues: {
       user_key_value: '',
       app_token_value: '',
-      devices: '',
-      emergency_retry_s: 60,
-      emergency_expire_s: 3600,
+      devices: Array.isArray(saved?.devices) ? (saved!.devices as string[]).join(', ') : '',
+      emergency_retry_s: (saved?.emergency_retry_s as number | undefined) ?? 60,
+      emergency_expire_s: (saved?.emergency_expire_s as number | undefined) ?? 3600,
     },
     validators: { onChange: pushoverSchema, onMount: pushoverSchema },
     onSubmit: async ({ value }) => {

--- a/frontend/src/components/settings/TestSendButton.tsx
+++ b/frontend/src/components/settings/TestSendButton.tsx
@@ -30,6 +30,11 @@ export function TestSendButton({ channel, label, dirty }: Props) {
         variant="outline"
         onClick={handleClick}
         disabled={dirty || test.isPending}
+        title={
+          dirty
+            ? 'Save your changes first — test sends use the saved config, not the unsaved form values.'
+            : undefined
+        }
       >
         {test.isPending ? 'Sending…' : label}
       </Button>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -263,6 +263,12 @@ export interface Household {
    *  pushover_app_token. Empty when the channel is unconfigured. May be
    *  missing on older API responses; consumers default to {}. */
   credential_status?: Record<string, CredentialStatus>;
+  /** Saved channel configs with secret *_value keys redacted out so the
+   *  Settings form can pre-populate non-secret fields (transport, host,
+   *  from_addr, etc.) on edit. */
+  smtp_config_json?: Record<string, unknown> | null;
+  ntfy_config_json?: Record<string, unknown> | null;
+  pushover_config_json?: Record<string, unknown> | null;
 }
 
 // Channel configuration types for Phase 7-1 Settings

--- a/src/yas/alerts/notifier_builder.py
+++ b/src/yas/alerts/notifier_builder.py
@@ -1,0 +1,88 @@
+"""Build channel notifiers from current household config + settings.
+
+Lives outside the worker module so the delivery loop can rebuild them
+per tick (so config changes via Settings UI take effect without a
+worker restart). Previously the worker built notifiers once at startup
+and held them for the lifetime of the process.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from yas.alerts.channels.base import Notifier
+from yas.alerts.channels.email import EmailChannel
+from yas.alerts.channels.ntfy import NtfyChannel
+from yas.alerts.channels.pushover import PushoverChannel
+from yas.config import Settings
+from yas.db.models import HouseholdSettings
+from yas.logging import get_logger
+
+log = get_logger("yas.alerts.notifier_builder")
+
+
+def build_notifiers(
+    household: HouseholdSettings | None,
+    settings: Settings,
+) -> dict[str, Notifier]:
+    """Construct one Notifier per configured channel.
+
+    For each channel:
+    - Pushover can construct from env-only credentials (config dict is
+      everything else), so we attempt with `{}` even when the channel's
+      config_json is null. The constructor raises if both DB and env
+      lack the credential.
+    - Email and Ntfy require structural config the user must save
+      (transport, host, base_url, topic, from_addr, etc.) — null
+      config_json means the channel is unconfigured and we skip it
+      silently rather than constructing a broken channel.
+    """
+    notifiers: dict[str, Notifier] = {}
+
+    smtp_cfg = getattr(household, "smtp_config_json", None) if household else None
+    ntfy_cfg = getattr(household, "ntfy_config_json", None) if household else None
+    pushover_cfg = getattr(household, "pushover_config_json", None) if household else None
+
+    if smtp_cfg is not None:
+        try:
+            notifiers["email"] = cast(Notifier, EmailChannel(smtp_cfg, settings))
+        except ValueError as exc:
+            log.warning("channel.disabled", channel="email", reason=str(exc))
+
+    if ntfy_cfg is not None:
+        try:
+            notifiers["ntfy"] = cast(Notifier, NtfyChannel(ntfy_cfg, settings))
+        except ValueError as exc:
+            log.warning("channel.disabled", channel="ntfy", reason=str(exc))
+
+    # Pushover: try even with null config_json, so users with the
+    # conventional YAS_PUSHOVER_* env vars don't have to click Save in
+    # the UI just to enable the channel. Empty dict + env credentials
+    # is a valid configuration.
+    pushover_attempt: dict[str, Any] = pushover_cfg if pushover_cfg is not None else {}
+    try:
+        notifiers["pushover"] = cast(Notifier, PushoverChannel(pushover_attempt, settings))
+    except ValueError as exc:
+        # Only log when the user explicitly configured a row but it
+        # failed; the empty-and-no-env case is common for fresh installs.
+        if pushover_cfg is not None:
+            log.warning("channel.disabled", channel="pushover", reason=str(exc))
+
+    return notifiers
+
+
+_last_logged_keys: tuple[str, ...] | None = None
+
+
+def log_constructed(notifiers: dict[str, Notifier]) -> None:
+    """Log the constructed-channels summary, but only when the set
+    changes — otherwise the per-tick rebuild floods the logs."""
+    global _last_logged_keys
+    keys = tuple(sorted(notifiers.keys()))
+    if keys == _last_logged_keys:
+        return
+    _last_logged_keys = keys
+    if keys:
+        log.info("channels.constructed", channels=list(keys))
+    else:
+        log.warning("channels.none_constructed", note="all channels disabled or unconfigured")

--- a/src/yas/web/routes/household.py
+++ b/src/yas/web/routes/household.py
@@ -36,6 +36,27 @@ async def _load_or_create(session: AsyncSession) -> HouseholdSettings:
     return hh
 
 
+_SECRET_KEYS = {
+    "password_value",
+    "api_token_value",
+    "auth_token_value",
+    "user_key_value",
+    "app_token_value",
+}
+
+
+def _redact_config(cfg: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return a copy of the channel config with secret-bearing keys stripped.
+
+    Non-secret fields (transport, host, port, from_addr, to_addrs,
+    devices, base_url, topic, emergency_*) are preserved so the form
+    can pre-populate them. Secret values stay server-side.
+    """
+    if cfg is None:
+        return None
+    return {k: v for k, v in cfg.items() if k not in _SECRET_KEYS}
+
+
 def _credential_status(
     cfg: dict[str, Any] | None,
     *,
@@ -120,6 +141,9 @@ async def _to_out(s: AsyncSession, hh: HouseholdSettings, settings: Settings) ->
         ntfy_configured=hh.ntfy_config_json is not None,
         pushover_configured=hh.pushover_config_json is not None,
         credential_status=cred_status,
+        smtp_config_json=_redact_config(hh.smtp_config_json),
+        ntfy_config_json=_redact_config(hh.ntfy_config_json),
+        pushover_config_json=_redact_config(hh.pushover_config_json),
     )
 
 

--- a/src/yas/web/routes/household_schemas.py
+++ b/src/yas/web/routes/household_schemas.py
@@ -38,6 +38,14 @@ class HouseholdOut(BaseModel):
     # from a form-stored override, an env var, or is unset. Empty when
     # the corresponding *_config_json is null (channel not configured).
     credential_status: dict[str, CredentialStatus] = {}
+    # Redacted channel configs — secret *_value keys are stripped so
+    # the UI can pre-populate non-secret fields (transport, host,
+    # from_addr, to_addrs, devices, etc.) on edit. Credentials are
+    # never returned; the form leaves those fields blank and the
+    # credential_status badge tells the user where the secret resolves.
+    smtp_config_json: dict[str, Any] | None = None
+    ntfy_config_json: dict[str, Any] | None = None
+    pushover_config_json: dict[str, Any] | None = None
 
 
 class HouseholdPatch(BaseModel):

--- a/src/yas/web/routes/notifier_test.py
+++ b/src/yas/web/routes/notifier_test.py
@@ -48,8 +48,19 @@ async def test_notifier(channel: str, request: Request) -> TestSendOut:
     async with session_scope(_engine(request)) as s:
         hh = (await s.execute(select(HouseholdSettings))).scalars().first()
         config = getattr(hh, field, None) if hh else None
+    # Pushover can construct from env-only credentials, so missing
+    # config_json is fine — fall through with `{}`. Email and Ntfy
+    # require structural config the user must save first; surface that
+    # as a clear error rather than letting the constructor's ValueError
+    # bubble up.
     if config is None:
-        raise HTTPException(status_code=503, detail=f"{channel} not configured")
+        if channel == "pushover":
+            config = {}
+        else:
+            return TestSendOut(
+                ok=False,
+                detail=f"{channel} not configured — fill in the form and click Save first",
+            )
     # Channel constructors raise ValueError if a credential is missing in
     # both the form-stored value and the conventional env var. Surface as
     # ok=false rather than 500.

--- a/src/yas/worker/delivery_loop.py
+++ b/src/yas/worker/delivery_loop.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from yas.alerts.channels.base import Notifier
 from yas.alerts.delivery import _apply_grace_window, send_alert_group
+from yas.alerts.notifier_builder import build_notifiers, log_constructed
 from yas.alerts.rate_limit import coalesce
 from yas.config import Settings
 from yas.db.models import Alert, HouseholdSettings
@@ -20,9 +21,19 @@ from yas.logging import get_logger
 async def alert_delivery_loop(
     engine: AsyncEngine,
     settings: Settings,
-    notifiers: dict[str, Notifier],
+    notifiers_override: dict[str, Any] | None = None,
 ) -> None:
-    """Polling delivery loop.  Runs until cancelled."""
+    """Polling delivery loop. Runs until cancelled.
+
+    Notifiers are rebuilt each tick from the current household state, so
+    saving config in the Settings UI takes effect within ~60s without
+    requiring a worker restart. Each tick disposes the channels it
+    constructed at the end so httpx clients don't leak.
+
+    `notifiers_override` is a test affordance: when provided, the loop
+    skips the per-tick build/aclose dance and uses the injected dict.
+    Production code should never pass this.
+    """
     log = get_logger("yas.alerts.delivery")
     log.info("delivery.start", tick_s=settings.alert_delivery_tick_s)
     try:
@@ -32,34 +43,47 @@ async def alert_delivery_loop(
                     await s.execute(select(HouseholdSettings).limit(1))
                 ).scalar_one_or_none()
 
-                now = datetime.now(UTC)
-                due_rows = (
-                    (
-                        await s.execute(
-                            select(Alert)
-                            .where(
-                                Alert.sent_at.is_(None),
-                                Alert.skipped.is_(False),
-                                Alert.scheduled_for <= now,
-                                Alert.closed_at.is_(None),
+                if notifiers_override is not None:
+                    notifiers = notifiers_override
+                    own_notifiers = False
+                else:
+                    notifiers = build_notifiers(household, settings)
+                    log_constructed(notifiers)
+                    own_notifiers = True
+
+                try:
+                    now = datetime.now(UTC)
+                    due_rows = (
+                        (
+                            await s.execute(
+                                select(Alert)
+                                .where(
+                                    Alert.sent_at.is_(None),
+                                    Alert.skipped.is_(False),
+                                    Alert.scheduled_for <= now,
+                                    Alert.closed_at.is_(None),
+                                )
+                                .order_by(Alert.scheduled_for)
+                                .limit(100)
                             )
-                            .order_by(Alert.scheduled_for)
-                            .limit(100)
                         )
+                        .scalars()
+                        .all()
                     )
-                    .scalars()
-                    .all()
-                )
 
-                due = _apply_grace_window(
-                    list(due_rows),
-                    now,
-                    settings.alert_countdown_past_due_grace_s,
-                )
+                    due = _apply_grace_window(
+                        list(due_rows),
+                        now,
+                        settings.alert_countdown_past_due_grace_s,
+                    )
 
-                groups = coalesce(due, window_s=settings.alert_coalesce_normal_s)
-                for g in groups:
-                    await send_alert_group(s, g, notifiers, settings, household)
+                    groups = coalesce(due, window_s=settings.alert_coalesce_normal_s)
+                    for g in groups:
+                        await send_alert_group(s, g, notifiers, settings, household)
+                finally:
+                    if own_notifiers:
+                        for n in notifiers.values():
+                            await n.aclose()
 
             await asyncio.sleep(settings.alert_delivery_tick_s)
     except asyncio.CancelledError:

--- a/src/yas/worker/runner.py
+++ b/src/yas/worker/runner.py
@@ -5,15 +5,10 @@ one TaskGroup."""
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from yas.alerts.channels.base import Notifier
-from yas.alerts.channels.email import EmailChannel
-from yas.alerts.channels.ntfy import NtfyChannel
-from yas.alerts.channels.pushover import PushoverChannel
 from yas.alerts.routing import seed_default_routing
 from yas.config import Settings
 from yas.crawl.fetcher import DefaultFetcher, Fetcher
@@ -37,41 +32,18 @@ def _build_notifiers(
     household: HouseholdSettings | None,
     settings: Settings,
 ) -> dict[str, Notifier]:
-    """Construct channel notifiers from household config JSON + env secrets.
+    """Backwards-compat shim that delegates to the shared builder.
 
-    For each channel config present in ``household``, attempt to construct
-    the corresponding channel object.  If the config is absent (None) the
-    channel is skipped.  If the constructor raises ``ValueError`` (e.g.
-    a required env-var secret is missing) the channel is logged as disabled
-    and skipped.
-
-    The api-only worker path does NOT call this helper; it is only invoked
-    when ``settings.alerts_enabled`` is True and a worker is starting.
+    Kept so external callers don't break; new code should import from
+    ``yas.alerts.notifier_builder`` directly. The delivery loop now
+    rebuilds notifiers per tick rather than relying on a startup-time
+    snapshot, so saving config in Settings takes effect within ~60s
+    without a worker restart.
     """
-    notifiers: dict[str, Notifier] = {}
+    from yas.alerts.notifier_builder import build_notifiers, log_constructed
 
-    if household is None:
-        return notifiers
-
-    channel_specs: list[tuple[str, dict[str, Any] | None, type[Any]]] = [
-        ("email", household.smtp_config_json, EmailChannel),
-        ("ntfy", household.ntfy_config_json, NtfyChannel),
-        ("pushover", household.pushover_config_json, PushoverChannel),
-    ]
-
-    for channel_name, config, channel_cls in channel_specs:
-        if config is None:
-            continue
-        try:
-            notifiers[channel_name] = channel_cls(config, settings)
-        except ValueError as exc:
-            log.warning("channel.disabled", channel=channel_name, reason=str(exc))
-
-    if notifiers:
-        log.info("channels.constructed", channels=sorted(notifiers.keys()))
-    else:
-        log.warning("channels.none_constructed", note="all channels disabled or unconfigured")
-
+    notifiers = build_notifiers(household, settings)
+    log_constructed(notifiers)
     return notifiers
 
 
@@ -107,13 +79,13 @@ async def run_worker(
         min_interval_s=settings.geocode_nominatim_min_interval_s,
     )
 
-    # Build notifiers from household config unless the caller already injected them.
-    own_notifiers = notifiers is None
-    if settings.alerts_enabled and notifiers is None:
+    # Seed alert routing once at startup; notifiers are now built per
+    # tick inside alert_delivery_loop so config changes take effect
+    # without requiring a worker restart.
+    if settings.alerts_enabled:
         async with session_scope(engine) as s:
             await seed_default_routing(s)
-            household = (await s.execute(select(HouseholdSettings).limit(1))).scalar_one_or_none()
-        notifiers = _build_notifiers(household, settings)
+    own_notifiers = notifiers is None
 
     log.info("worker.start")
     try:
@@ -130,8 +102,7 @@ async def run_worker(
                     geocode_enricher_loop(engine=engine, settings=settings, geocoder=geocoder)
                 )
             if settings.alerts_enabled:
-                assert notifiers is not None  # guaranteed by the block above
-                tg.create_task(alert_delivery_loop(engine, settings, notifiers))
+                tg.create_task(alert_delivery_loop(engine, settings))
                 tg.create_task(daily_digest_loop(engine, settings, llm))
                 tg.create_task(daily_detector_loop(engine, settings))
     finally:

--- a/tests/integration/test_api_notifier_test.py
+++ b/tests/integration/test_api_notifier_test.py
@@ -45,12 +45,18 @@ async def test_unknown_channel_returns_404(client):
 
 
 @pytest.mark.asyncio
-async def test_unconfigured_channel_returns_503(client):
+async def test_unconfigured_email_returns_ok_false_with_save_hint(client):
+    """Email needs structural form fields (transport, host, from_addr, ...)
+    that can't come from env. With null config_json, the test endpoint
+    returns ok=false with a helpful message rather than 503 — matches
+    how the UI renders the result."""
     c, engine = client
-    await _seed_household(engine)  # all *_config_json default null
+    await _seed_household(engine)
     r = await c.post("/api/notifiers/email/test")
-    assert r.status_code == 503
-    assert "not configured" in r.json()["detail"].lower()
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "save" in body["detail"].lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Several coupled bugs caught testing the credentials UX:

## 1. Saving config didn't take effect until container restart

The worker built \`notifiers\` once at startup. \`alert_delivery_loop\` reused the same dict every tick. So when you saved Pushover/Email config in Settings, the in-memory channel dict stayed stale → \`notifier_missing\` warnings every minute, even when DB had a valid config.

**Fix:** extract \`_build_notifiers\` to \`yas.alerts.notifier_builder\`, have \`alert_delivery_loop\` rebuild per tick (~60s). Channels are \`aclose\`'d at the end of each tick so httpx clients don't leak. \`log_constructed()\` deduplicates the \`channels.constructed\` log so we don't flood every 60s when nothing changes.

## 2. Pushover with env-only creds wasn't testable

\`/api/notifiers/pushover/test\` returned 503 when \`pushover_config_json\` was null in DB. But Pushover only needs credentials — those can come entirely from env. Now Pushover specifically falls through with \`{}\` so env credentials suffice. Email and Ntfy still need structural form fields (transport/host/topic/from_addr/to_addrs), so they return \`ok=false\` with a clear "Save first" hint.

## 3. Settings form started empty every reload

\`/api/household\` only ever returned the \`*_configured\` booleans, never the saved configs. Result: every time a user reopened Settings to edit, they had to retype from/to addresses, transport, host, topic, devices — even though those values were sitting in the DB.

**Fix:** \`/api/household\` now returns \`smtp_config_json\`, \`ntfy_config_json\`, \`pushover_config_json\` with secret \`*_value\` keys stripped. The Settings form pre-populates non-secret fields. Credentials stay server-side; the \`credential_status\` badge tells users where each secret resolves.

## 4. Test button tooltip when dirty

Disabled-because-dirty test buttons now show a hover title: "Save your changes first — test sends use the saved config, not the unsaved form values." Closes the silent-disabled-button confusion.

## Master §10 terminal criteria delta

None. All UX/operational fixes.

## Test plan

- [x] uv run pytest -q (668 passing; 1 test renamed and updated for new ok=false behavior)
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [x] alert_delivery_loop tests still work via the test-only \`notifiers_override\` arg
- [ ] CI passes
- [ ] After merge + container redeploy:
  - Save Pushover with empty fields, confirm worker logs \`channels.constructed: ['pushover']\` within 60s without restart
  - Open Settings → previously-saved Email config (transport, from, to) appears in the form
  - Pushover test send returns ok=true (env credentials suffice)
  - Email test send is allowed once config is saved; tooltip explains while dirty