### PR TITLE
fix(ui): label the Interests field on KidForm

### DIFF
--- a/frontend/src/components/kids/InterestsField.test.tsx
+++ b/frontend/src/components/kids/InterestsField.test.tsx
@@ -15,14 +15,14 @@ describe('InterestsField', () => {
   it('renders input placeholder', () => {
     render(<InterestsField value={[]} onChange={vi.fn()} />);
     expect(
-      screen.getByPlaceholderText('Type and press Enter (e.g., baseball)'),
+      screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)'),
     ).toBeInTheDocument();
   });
 
   it('typing + Enter adds a chip and clears input', async () => {
     const onChange = vi.fn();
     render(<InterestsField value={[]} onChange={onChange} />);
-    const input = screen.getByPlaceholderText('Type and press Enter (e.g., baseball)');
+    const input = screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)');
     await userEvent.type(input, 'Tennis');
     await userEvent.keyboard('{Enter}');
     expect(onChange).toHaveBeenCalledWith(['Tennis']);
@@ -32,7 +32,7 @@ describe('InterestsField', () => {
   it('typing + comma adds a chip and clears input', async () => {
     const onChange = vi.fn();
     render(<InterestsField value={[]} onChange={onChange} />);
-    const input = screen.getByPlaceholderText('Type and press Enter (e.g., baseball)');
+    const input = screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)');
     await userEvent.type(input, 'Basketball,');
     expect(onChange).toHaveBeenCalledWith(['Basketball']);
     expect(input).toHaveValue('');
@@ -41,7 +41,7 @@ describe('InterestsField', () => {
   it('blur on non-empty input adds chip', async () => {
     const onChange = vi.fn();
     render(<InterestsField value={[]} onChange={onChange} />);
-    const input = screen.getByPlaceholderText('Type and press Enter (e.g., baseball)');
+    const input = screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)');
     await userEvent.type(input, 'Volleyball');
     await userEvent.click(document.body);
     expect(onChange).toHaveBeenCalledWith(['Volleyball']);
@@ -50,7 +50,7 @@ describe('InterestsField', () => {
   it('empty trimmed input does not add chip', async () => {
     const onChange = vi.fn();
     render(<InterestsField value={[]} onChange={onChange} />);
-    const input = screen.getByPlaceholderText('Type and press Enter (e.g., baseball)');
+    const input = screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)');
     await userEvent.type(input, '   ');
     await userEvent.keyboard('{Enter}');
     expect(onChange).not.toHaveBeenCalled();
@@ -59,7 +59,7 @@ describe('InterestsField', () => {
   it('duplicate (case-insensitive) does not add', async () => {
     const onChange = vi.fn();
     render(<InterestsField value={['Baseball']} onChange={onChange} />);
-    const input = screen.getByPlaceholderText('Type and press Enter (e.g., baseball)');
+    const input = screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)');
     await userEvent.type(input, 'baseball');
     await userEvent.keyboard('{Enter}');
     expect(onChange).not.toHaveBeenCalled();
@@ -79,7 +79,7 @@ describe('InterestsField', () => {
 
   it('sets aria-invalid on input when error is present', () => {
     render(<InterestsField value={[]} onChange={vi.fn()} error="This field is required" />);
-    const input = screen.getByPlaceholderText('Type and press Enter (e.g., baseball)');
+    const input = screen.getByPlaceholderText('Type an interest and press Enter (e.g. tennis)');
     expect(input).toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/frontend/src/components/kids/InterestsField.tsx
+++ b/frontend/src/components/kids/InterestsField.tsx
@@ -21,20 +21,30 @@ export function InterestsField({ value, onChange, error }: Props) {
 
   return (
     <div className="space-y-1">
-      <div className="flex flex-wrap gap-1">
-        {value.map((v, i) => (
-          <span
-            key={`${v}-${i}`}
-            className="inline-flex items-center gap-1 rounded-md bg-accent px-2 py-1 text-xs"
-          >
-            {v}
-            <button type="button" aria-label={`Remove ${v}`} onClick={() => remove(i)}>
-              ×
-            </button>
-          </span>
-        ))}
-      </div>
+      <label htmlFor="interests-input" className="block text-sm font-medium">
+        Interests
+      </label>
+      <p className="text-xs text-muted-foreground">
+        Add at least one — without interests, no offerings will match this kid. Examples: soccer,
+        tennis, baseball, swim, gymnastics, art, music, multisport.
+      </p>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1 pt-1">
+          {value.map((v, i) => (
+            <span
+              key={`${v}-${i}`}
+              className="inline-flex items-center gap-1 rounded-md bg-accent px-2 py-1 text-xs"
+            >
+              {v}
+              <button type="button" aria-label={`Remove ${v}`} onClick={() => remove(i)}>
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
       <input
+        id="interests-input"
         type="text"
         value={input}
         onChange={(e) => setInput(e.target.value)}
@@ -45,8 +55,9 @@ export function InterestsField({ value, onChange, error }: Props) {
           }
         }}
         onBlur={() => add(input)}
-        placeholder="Type and press Enter (e.g., baseball)"
+        placeholder="Type an interest and press Enter (e.g. tennis)"
         aria-invalid={error ? 'true' : undefined}
+        className="mt-1 block w-full rounded border border-input px-3 py-2"
       />
       {error && <p className="text-xs text-destructive">{error}</p>}
     </div>


### PR DESCRIPTION
Caught from real-usage feedback ("There is nowhere in the ui to add interests"). The \`InterestsField\` was actually rendering in the Edit Kid form all along — but it had **no \`<label>\`**, no header, just chips above an unlabeled \`<input>\` with placeholder \"Type and press Enter\". Trivially easy to scroll past in a form full of properly-labeled fields.

## What this looked like in production

A kid with \`interests=[]\` causes the matcher's interests gate to fail every offering:

\`\`\`python
if not kid.interests:
    return GateResult(False, "no_kid_interests", "kid has no interests configured")
\`\`\`

Real session: user had 141 offerings extracted from crawls, 0 matches across 1 kid. Diagnosis (via DB query): \`Ari (id=1, interests=[], ...): 0 matches of 141 offerings\`. Root cause: form field invisible.

## Fix

- Add \`<label htmlFor="interests-input">Interests</label>\` so the field has a header.
- Add a one-line hint: *\"Add at least one — without interests, no offerings will match this kid. Examples: soccer, tennis, baseball, swim, gymnastics, art, music, multisport.\"*
- Hide the chip row when empty (no orphan whitespace pretending to be a control).
- Style the input to match the other form inputs (\`mt-1 block w-full rounded border border-input px-3 py-2\`).
- Update the test to match the new placeholder.

## Master §10 terminal criteria delta

None. UX bugfix.

## Test plan

- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [x] Read existing InterestsField.test.tsx — only the placeholder string assertion needed updating
- [ ] CI passes
- [ ] After merge + redeploy + add interests to Ari + rematch: offerings + matches populate