### PR TITLE
chore(ci): skip docker-build on PRs that don't affect the image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,35 @@ on:
     branches: [main]
   pull_request:
 jobs:
+  # Detect which areas of the codebase changed so docker-build can skip
+  # on PRs that don't touch image inputs (docs-only, spec-only, etc.).
+  # On push-to-main we still build unconditionally — every published
+  # image gets multi-arch verification.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.filter.outputs.image }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        id: filter
+        with:
+          filters: |
+            image:
+              - 'Dockerfile'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'src/**'
+              - 'alembic/**'
+              - 'frontend/package.json'
+              - 'frontend/package-lock.json'
+              - 'frontend/vite.config.ts'
+              - 'frontend/tsconfig*.json'
+              - 'frontend/src/**'
+              - 'frontend/index.html'
+              - 'frontend/public/**'
+              - '.github/workflows/ci.yml'
+
   check:
     runs-on: ubuntu-latest
     env:
@@ -134,6 +163,13 @@ jobs:
     # On push-to-main, also pushes each arch by-digest to GHCR. The
     # docker-publish job then assembles a multi-arch manifest. PRs only
     # build (no push), preserving the security boundary.
+    #
+    # Conditional: on PRs, only run when files that affect the image
+    # actually changed (Dockerfile, src/**, frontend/**, deps, ci.yml).
+    # Pure docs/spec PRs skip the build entirely. On push-to-main we
+    # always run — every published image gets multi-arch verification.
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.image == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Adds a \`changes\` job using \`dorny/paths-filter@v3.0.2\` that emits an \`image\` boolean. The \`docker-build\` matrix job gates on it for PRs only — push-to-main always builds.

## What counts as \"affects the image\"

- \`Dockerfile\`
- \`pyproject.toml\` / \`uv.lock\`
- \`src/**\` (Python source baked into the runtime)
- \`alembic/**\` (migrations baked in)
- \`frontend/{package.json,package-lock.json,vite.config.ts,tsconfig*.json,index.html,public/**,src/**}\`
- \`.github/workflows/ci.yml\` itself (so we always test workflow edits)

## What's skipped

Pure docs / spec / README-only / .env.example PRs no longer trigger \`docker-build\`. Recent examples that paid the cost for nothing: #36 (README env var docs), #41 (roadmap cleanup), #43 (Pushover/Gotify split), #56 (CI warnings cleanup, edited ci.yml so this would still trigger).

## Why this is safe

- **Push-to-main always builds.** \`if: github.event_name == 'push' || needs.changes.outputs.image == 'true'\` — the push branch always evaluates true. Every image published to GHCR still gets multi-arch verification before \`docker-publish\` stitches the manifest.
- **Workflow self-coverage.** \`.github/workflows/ci.yml\` is in the filter, so any CI change re-triggers the build.
- **No state confusion for \`docker-publish\`.** That job has \`needs: docker-build\` and only runs on push-to-main, where docker-build always runs. PR-side skip doesn't break the dep graph because docker-publish is gated separately.

## This PR will exercise the new path

This PR touches \`.github/workflows/ci.yml\` → docker-build SHOULD run. That validates the filter actually triggers when expected. A docs-only follow-up will validate the skip path.

## Master §10 terminal criteria delta

None. CI cost / latency optimization.

## Test plan

- [x] YAML syntax-valid
- [ ] CI: this PR (touches ci.yml) triggers docker-build
- [ ] After merge: a docs-only PR skips docker-build entirely (visible as 'docker-build (linux/amd64): skipped' in checks)