### PR TITLE
feat(matching): drive-time in scoring + Max Drive Time filter

### DIFF
--- a/frontend/src/components/offerings/MoreFiltersPanel.tsx
+++ b/frontend/src/components/offerings/MoreFiltersPanel.tsx
@@ -25,6 +25,8 @@ function countActiveFilters(value: FilterState): number {
   if (value.timeOfDayMin !== null || value.timeOfDayMax !== null) count++;
   // maxDistanceMi !== null → +1
   if (value.maxDistanceMi !== null) count++;
+  // maxDriveMinutes !== null → +1
+  if (value.maxDriveMinutes !== null) count++;
   // ageMin !== null || ageMax !== null → +1
   if (value.ageMin !== null || value.ageMax !== null) count++;
   // watchlistOnly → +1
@@ -45,6 +47,7 @@ export function MoreFiltersPanel({ value, onChange, programTypeOptions, isOpen, 
       timeOfDayMin: null,
       timeOfDayMax: null,
       maxDistanceMi: null,
+      maxDriveMinutes: null,
       ageMin: null,
       ageMax: null,
       watchlistOnly: false,
@@ -199,6 +202,40 @@ export function MoreFiltersPanel({ value, onChange, programTypeOptions, isOpen, 
                 <button
                   type="button"
                   onClick={() => onChange({ ...value, maxDistanceMi: null })}
+                  className="rounded border border-input bg-background px-3 py-1.5 text-sm hover:bg-accent"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* 6b. Drive time */}
+          <div>
+            <label className="block text-sm font-medium mb-2">Drive time</label>
+            <p className="text-xs text-muted-foreground mb-2">
+              Routed driving minutes. Offerings without a drive estimate (e.g. unroutable
+              destinations) pass through.
+            </p>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={value.maxDriveMinutes ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value ? parseInt(e.target.value, 10) : null;
+                    onChange({ ...value, maxDriveMinutes: val });
+                  }}
+                  placeholder="Max minutes"
+                  className="w-full rounded border border-input bg-background px-2 py-1.5 text-sm"
+                />
+              </div>
+              {value.maxDriveMinutes !== null && (
+                <button
+                  type="button"
+                  onClick={() => onChange({ ...value, maxDriveMinutes: null })}
                   className="rounded border border-input bg-background px-3 py-1.5 text-sm hover:bg-accent"
                 >
                   Clear

--- a/frontend/src/lib/offeringsFilters.ts
+++ b/frontend/src/lib/offeringsFilters.ts
@@ -25,6 +25,7 @@ export function defaultFilterState(allKidIds: number[]): FilterState {
     timeOfDayMin: null,
     timeOfDayMax: null,
     maxDistanceMi: null,
+    maxDriveMinutes: null,
     ageMin: null,
     ageMax: null,
     watchlistOnly: false,
@@ -89,7 +90,7 @@ export function applyFilters(
         if (f.regTiming === 'open_now' && !isOpen) return false;
         if (f.regTiming === 'closed' && !isClosed) return false;
       }
-      // distance
+      // distance (great-circle miles)
       if (
         f.maxDistanceMi !== null &&
         household?.home_lat != null &&
@@ -104,6 +105,19 @@ export function applyFilters(
           o.location_lon,
         );
         if (miles > f.maxDistanceMi) return false;
+      }
+      // drive time (routed minutes from Match.reasons.drive_minutes)
+      // Offerings without drive_minutes (no provider result, unroutable
+      // destination, feature off) pass through — same as the matcher's
+      // gate behavior of "unknown = let it through."
+      if (f.maxDriveMinutes !== null) {
+        const driveValues = row.matches
+          .map((m) => (m.reasons as { drive_minutes?: unknown }).drive_minutes)
+          .filter((v): v is number => typeof v === 'number');
+        if (driveValues.length > 0) {
+          const min = Math.min(...driveValues);
+          if (min > f.maxDriveMinutes) return false;
+        }
       }
       // age range overlap
       if (f.ageMin !== null && o.age_max !== null && o.age_max < f.ageMin) return false;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -80,6 +80,11 @@ export interface FilterState {
   timeOfDayMin: string | null; // 'HH:MM'
   timeOfDayMax: string | null;
   maxDistanceMi: number | null;
+  /** Drive-time cap (minutes). When set, filters offerings whose
+   *  drive_minutes (from `Match.reasons`) exceeds the cap. Offerings
+   *  without drive_minutes (no provider result, e.g. unroutable
+   *  destinations) pass through — same as the matcher's gate behavior. */
+  maxDriveMinutes: number | null;
   ageMin: number | null;
   ageMax: number | null;
   watchlistOnly: boolean;

--- a/src/yas/matching/matcher.py
+++ b/src/yas/matching/matcher.py
@@ -274,6 +274,7 @@ async def _evaluate_pair(
         distance_mi=distance_mi,
         household_max_distance_mi=default_max_distance,
         today=today,
+        drive_minutes=drive_minutes,
     )
     include = watchlist is not None or _gates_passed(gates)
     reasons = _reasons_payload(gates, breakdown, watchlist)

--- a/src/yas/matching/scoring.py
+++ b/src/yas/matching/scoring.py
@@ -45,9 +45,20 @@ def compute_score(
     distance_mi: float | None,
     household_max_distance_mi: float | None,
     today: date,
+    drive_minutes: float | None = None,
 ) -> tuple[float, dict[str, Any]]:
+    """Compute the score for one (kid, offering) pair.
+
+    When `drive_minutes` is provided AND the kid has `max_drive_minutes`
+    set, the distance component uses routed-driving time instead of
+    great-circle miles. Otherwise falls back to miles. The breakdown
+    field is named `distance` in both cases — it's a normalized
+    "how far is this" signal regardless of the underlying unit.
+    """
     availability = _availability_signal(kid, offering)
-    distance = _distance_signal(kid, offering, distance_mi, household_max_distance_mi)
+    distance = _distance_signal(
+        kid, offering, distance_mi, household_max_distance_mi, drive_minutes
+    )
     price = _price_signal(kid, offering)
     registration = _registration_signal(offering, today=today)
     freshness = _freshness_signal(offering, today=today)
@@ -85,7 +96,26 @@ def _distance_signal(
     offering: Any,
     distance_mi: float | None,
     household_default: float | None,
+    drive_minutes: float | None = None,
 ) -> float:
+    """Normalized 0..1 closeness signal.
+
+    Prefers drive-time when both (a) the kid has `max_drive_minutes` set
+    AND (b) `drive_minutes` is computable. Falls back to great-circle
+    miles (`distance_mi` against `kid.max_distance_mi` or household
+    default) otherwise. Same shape: 1.0 at ≤30% of cap, linear decay to
+    0.0 at the cap.
+    """
+    drive_cap_raw = getattr(kid, "max_drive_minutes", None)
+    if drive_cap_raw is not None and drive_minutes is not None and drive_cap_raw > 0:
+        drive_cap = float(drive_cap_raw)
+        threshold = drive_cap * 0.3
+        if drive_minutes <= threshold:
+            return 1.0
+        if drive_minutes >= drive_cap:
+            return 0.0
+        return max(0.0, 1.0 - (drive_minutes - threshold) / (drive_cap - threshold))
+
     cap = kid.max_distance_mi if kid.max_distance_mi is not None else household_default
     if distance_mi is None or cap is None or cap <= 0:
         return 0.5
@@ -94,7 +124,6 @@ def _distance_signal(
         return 1.0
     if distance_mi >= cap:
         return 0.0
-    # linear decay from 1.0 at threshold to 0.0 at cap
     return max(0.0, 1.0 - (distance_mi - threshold) / (cap - threshold))
 
 

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -10,6 +10,7 @@ from yas.matching.scoring import ScoreBreakdown, compute_score
 class _Kid:
     availability: dict = field(default_factory=dict)
     max_distance_mi: float | None = None
+    max_drive_minutes: int | None = None
 
 
 @dataclass
@@ -100,6 +101,70 @@ def test_distance_zero_at_cap():
         household_max_distance_mi=None,
         today=TODAY,
     )
+    assert reasons["distance"] == pytest.approx(0.0)
+
+
+def test_distance_uses_drive_time_when_kid_has_drive_cap():
+    """When kid has max_drive_minutes set AND drive_minutes is provided,
+    the distance signal is computed from drive-time, not miles."""
+    kid = _Kid(max_distance_mi=5.0, max_drive_minutes=30)
+    offering = _Offering()
+    # 9 min drive: well under the 30% threshold (=9 min) → full credit
+    # despite distance_mi=50 (which would be 0.0 on miles path).
+    _score, reasons = compute_score(
+        kid,
+        offering,
+        distance_mi=50.0,
+        household_max_distance_mi=None,
+        today=TODAY,
+        drive_minutes=9.0,
+    )
+    assert reasons["distance"] == pytest.approx(1.0)
+
+
+def test_distance_drive_time_decays_to_zero_at_drive_cap():
+    kid = _Kid(max_drive_minutes=30)
+    offering = _Offering()
+    _score, reasons = compute_score(
+        kid,
+        offering,
+        distance_mi=None,
+        household_max_distance_mi=None,
+        today=TODAY,
+        drive_minutes=30.0,
+    )
+    assert reasons["distance"] == pytest.approx(0.0)
+
+
+def test_distance_falls_back_to_miles_when_drive_minutes_missing():
+    """Provider failed → drive_minutes=None → use miles path."""
+    kid = _Kid(max_distance_mi=10.0, max_drive_minutes=30)
+    offering = _Offering()
+    _score, reasons = compute_score(
+        kid,
+        offering,
+        distance_mi=2.0,
+        household_max_distance_mi=None,
+        today=TODAY,
+        drive_minutes=None,
+    )
+    # Falls through to miles signal: 2mi < 30% of 10 → 1.0
+    assert reasons["distance"] == pytest.approx(1.0)
+
+
+def test_distance_ignores_drive_minutes_when_no_drive_cap():
+    """drive_minutes provided but kid.max_drive_minutes is None → use miles."""
+    kid = _Kid(max_distance_mi=10.0, max_drive_minutes=None)
+    offering = _Offering()
+    _score, reasons = compute_score(
+        kid,
+        offering,
+        distance_mi=10.0,
+        household_max_distance_mi=None,
+        today=TODAY,
+        drive_minutes=5.0,
+    )
+    # Miles path: at cap → 0.0 (drive value ignored)
     assert reasons["distance"] == pytest.approx(0.0)
 
 


### PR DESCRIPTION
Two changes that make drive-time data actually shape what the user sees, not just decorate the chip.

## 1. Drive time in scoring

\`compute_score\` accepts an optional \`drive_minutes\` and prefers it over miles when **both** \`kid.max_drive_minutes\` is set AND \`drive_minutes\` is computable. Same scoring shape (\`1.0\` at ≤30% of cap, linear decay to \`0.0\` at the cap), different unit. Falls back to great-circle miles when:
- the kid has no drive cap configured
- drive_minutes is None (provider failed, feature off, etc.)

This means a kid with \`max_drive_minutes=30\` will now rank a 9-min drive higher than a 25-min drive even if great-circle miles tells a different story (e.g., highway access).

## 2. Max Drive Time filter

New filter in the **More Filters** panel alongside Distance. Reads each row's smallest \`match.reasons.drive_minutes\` and excludes when it exceeds the cap. Offerings without a drive estimate (no provider result, unroutable destination, feature off) pass through — matches the matcher's gate behavior of \"unknown = let it through.\"

The active-filter count and \"reset secondary filters\" both account for the new field.

## Master §10 terminal criteria delta

None. Quality-of-match improvement.

## Test plan

- [x] uv run pytest -q (674 passing, +4 in test_scoring)
  - drive-time path takes priority when both inputs available
  - falls back to miles when drive_minutes None
  - decays to 0.0 at drive cap
  - ignores drive_minutes when no kid cap configured
- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [ ] CI passes
- [ ] After merge + redeploy + rematch:
  - Set Max Drive Time = 30 in More Filters → routable offerings >30 min away disappear
  - Australian tennis offerings (no drive estimate) still appear (unknown = pass)
  - Score breakdown's \"distance\" component reflects drive minutes for kids with the cap set