### PR TITLE
fix(ui): preserve last-channel checkbox state via onClick.preventDefault

### DIFF
--- a/frontend/src/components/settings/AlertRoutingSection.tsx
+++ b/frontend/src/components/settings/AlertRoutingSection.tsx
@@ -87,6 +87,15 @@ export function AlertRoutingSection() {
                         aria-label={`${row.type} ${ch}`}
                         checked={isChecked}
                         disabled={!isConfigured}
+                        // The last-remaining-channel guard cannot live in
+                        // onChange alone: by then the browser has already
+                        // toggled .checked, and since handleChannelToggle
+                        // short-circuits without state change, React never
+                        // re-renders to sync the DOM back. Suppress the
+                        // default toggle at the click stage.
+                        onClick={(e) => {
+                          if (isLastChannel) e.preventDefault();
+                        }}
                         onChange={() => handleChannelToggle(row, ch)}
                         title={
                           !isConfigured


### PR DESCRIPTION
The \`AlertRoutingSection\` last-remaining-channel guard lived only in \`onChange\`, which fires **after** the browser has already toggled the checkbox's \`.checked\` property. \`handleChannelToggle\` then short-circuits with no state change, so React never re-renders to sync the DOM back to the controlled prop — the visual state drifts.

This was a latent race that happened to pass on main but failed deterministically on PR #66 (lockfile maintenance). Some lib bump in there (most likely \`@mswjs/interceptors 0.41.6 → 0.41.8\` shifting microtask timing) exposed it. None of the test infrastructure (\`react\`, \`react-dom\`, \`@testing-library/*\`, \`vitest\`, \`jsdom\`, \`user-event\`) actually changed versions; it's a microtask ordering tipping point.

## Fix

Add \`onClick\` handler that calls \`e.preventDefault()\` when the guard fires. Click events run **before** the default toggle, so this actually suppresses the DOM mutation rather than racing to undo it. \`onChange\`'s short-circuit stays as belt-and-suspenders.

\`\`\`tsx
onClick={(e) => { if (isLastChannel) e.preventDefault(); }}
onChange={() => handleChannelToggle(row, ch)}
\`\`\`

## Why this matters

Without the fix, PR #66 (lockfile maintenance) is blocked. After this lands, rebasing #66 should turn it green.

## Master §10 terminal criteria delta

None. UX bugfix.

## Test plan

- [x] Reproduced the failure on PR #66's branch deterministically (3/3 runs)
- [x] After fix on main's lockfile: AlertRoutingSection.test.tsx 6/6 passing on 3 consecutive runs
- [x] Full frontend suite 302 passing
- [ ] CI passes
- [ ] After merge: rebase PR #66; expect green