### PR TITLE
fix(ui): disable last-channel checkbox (replaces click-suppression from #67)

### DIFF
--- a/frontend/src/components/settings/AlertRoutingSection.tsx
+++ b/frontend/src/components/settings/AlertRoutingSection.tsx
@@ -79,6 +79,12 @@ export function AlertRoutingSection() {
                   const isConfigured = configuredChannels[ch as keyof typeof configuredChannels];
                   const isChecked = row.channels.includes(ch);
                   const isLastChannel = row.enabled && row.channels.length === 1 && isChecked;
+                  // Disable when not configured OR when removing this channel
+                  // would orphan the row (enabled with no destinations). The
+                  // user disables a row entirely via the Enabled toggle.
+                  // (Earlier attempt with onClick.preventDefault was racey
+                  // under some library timings; disabled is bulletproof.)
+                  const disabled = !isConfigured || isLastChannel;
 
                   return (
                     <td key={`${row.type}-${ch}`} className="border border-border px-4 py-2">
@@ -86,16 +92,7 @@ export function AlertRoutingSection() {
                         type="checkbox"
                         aria-label={`${row.type} ${ch}`}
                         checked={isChecked}
-                        disabled={!isConfigured}
-                        // The last-remaining-channel guard cannot live in
-                        // onChange alone: by then the browser has already
-                        // toggled .checked, and since handleChannelToggle
-                        // short-circuits without state change, React never
-                        // re-renders to sync the DOM back. Suppress the
-                        // default toggle at the click stage.
-                        onClick={(e) => {
-                          if (isLastChannel) e.preventDefault();
-                        }}
+                        disabled={disabled}
                         onChange={() => handleChannelToggle(row, ch)}
                         title={
                           !isConfigured
@@ -104,7 +101,7 @@ export function AlertRoutingSection() {
                               ? 'Use Enabled toggle to disable this alert type entirely'
                               : undefined
                         }
-                        className={isConfigured ? 'cursor-pointer' : 'cursor-not-allowed'}
+                        className={disabled ? 'cursor-not-allowed' : 'cursor-pointer'}
                       />
                     </td>
                   );


### PR DESCRIPTION
PR #67 attempted to fix the last-remaining-channel race via \`onClick.preventDefault()\`. It worked on main's current lockfile but **failed deterministically once #66 (lockfile maintenance) bumped libraries**. Either user-event v14 or one of the interceptor libs in the test stack now processes events such that the prevented-default doesn't suppress the change reliably.

## New approach

Disable the checkbox when it would be the last remaining channel. user-event no-ops on disabled inputs (no race), the visual state stays correct (controlled \`checked\` prop never gets contested), and the existing tooltip already explains *"Use Enabled toggle to disable this alert type entirely."*

\`\`\`tsx
const disabled = !isConfigured || isLastChannel;

<input
  type="checkbox"
  checked={isChecked}
  disabled={disabled}
  onChange={() => handleChannelToggle(row, ch)}
  ...
/>
\`\`\`

The \`handleChannelToggle\` short-circuit stays as belt-and-suspenders.

## Why this is robust

\`disabled\` is enforced by the browser/jsdom at the click level — no event handler runs, no state to race. The previous pattern (controlled \`checked\` + \`onChange\` short-circuit) relied on React re-rendering to sync the DOM back; without a state change, no re-render, and the DOM drifted.

## Master §10 terminal criteria delta

None.

## Test plan

- [x] cd frontend && npm run typecheck / lint / format:check / test all clean (302)
- [x] AlertRoutingSection.test.tsx — 6/6 passing
- [x] Reproduced PR #66's failure locally (preventDefault approach failed); patched the disable approach; PR 66's env now passes
- [ ] CI passes
- [ ] After merge: rebase #66 and watch it go green