### PR TITLE
chore(renovate): drop platformAutomerge + carve anthropic into own group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,11 +31,10 @@
   },
   "packageRules": [
     {
-      "description": "Default: bundle every non-major update into a single weekly PR; auto-merge once CI passes (any time of day, even though branches only land Mondays)",
+      "description": "Default: bundle every non-major update into a single weekly PR; Renovate auto-merges in its own polling cycle once CI passes. We don't use GitHub's native (platform) auto-merge — it would require branch protection with required status checks, which the single-maintainer flow doesn't otherwise need.",
       "matchUpdateTypes": ["patch", "minor", "pin", "digest", "lockFileMaintenance"],
       "groupName": "all non-major dependencies",
       "automerge": true,
-      "platformAutomerge": true,
       "automergeSchedule": ["at any time"]
     },
     {
@@ -103,8 +102,9 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Anthropic SDK — review manually; do not auto-merge",
+      "description": "Anthropic SDK — review manually; do not auto-merge. Carved into its own group so it doesn't poison the 'all non-major dependencies' bundle's automerge.",
       "matchPackageNames": ["anthropic"],
+      "groupName": "anthropic-sdk",
       "automerge": false,
       "labels": ["dependencies", "review-required"]
     },


### PR DESCRIPTION
Two coupled changes that fix grouped Renovate PRs not auto-merging.

## 1. Drop \`platformAutomerge: true\`

GitHub's native auto-merge requires branch protection with required status checks. Setting that up on \`main\` is overhead the single-maintainer flow doesn't otherwise need (and we'd just turned it on briefly only to find this anthropic-grouping issue underneath).

Renovate's own polling-based automerge handles patch/minor/pin/digest/lockfile updates fine. The trade-off: instead of merging the instant CI goes green, PRs merge on Renovate's next polling cycle (~hourly). For dep updates that's fine.

## 2. Move \`anthropic\` into its own \`groupName\`

The previous Anthropic-no-automerge rule poisoned the entire 'all non-major dependencies' bundle: any week that included an anthropic bump turned the whole weekly PR into manual-merge. We hit this exact case on PR #71.

\`\`\`diff
 {
   "matchPackageNames": ["anthropic"],
+  "groupName": "anthropic-sdk",
   "automerge": false,
   ...
 }
\`\`\`

Anthropic now gets its own dedicated PR (manual review preserved). The rest of the weekly non-major bundle is eligible for automerge again.

## Master §10 terminal criteria delta

None.

## Test plan

- [x] \`jq -e .\` validates renovate.json syntax
- [x] Branch protection on \`main\` removed (was added briefly to debug; not needed with Renovate-controlled automerge)
- [ ] CI passes
- [ ] Next Renovate PR with no anthropic content automerges in its polling cycle (verify by waiting + observing)

## Summary by Sourcery

Adjust Renovate configuration to rely on Renovate-managed automerge and isolate Anthropic updates into their own group for manual review.

Enhancements:
- Disable platform-level automerge in favor of Renovate's own polling-based automerge for non-major dependency updates.
- Move Anthropic dependency updates into a dedicated, non-automerge Renovate group so they no longer block automerge for other grouped dependencies.