### PR TITLE
chore: approve msw build script for pnpm v11

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,5 +66,8 @@
     "typescript-eslint": "8.59.2",
     "vite": "8.0.12",
     "vitest": "4.1.6"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["msw"]
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,8 @@
     "vitest": "4.1.6"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["msw"]
+    "onlyBuiltDependencies": [
+      "msw"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `pnpm.onlyBuiltDependencies: ["msw"]` to `frontend/package.json` so msw's postinstall script is explicitly approved
- pnpm v11 promotes ignored build scripts from a warning to a hard install error (`ERR_PNPM_IGNORED_BUILDS`), which is currently blocking #84

## Why
PR #84 (pnpm v10 → v11) is red on `frontend-check`, `e2e`, and both `docker-build` jobs with:

\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: msw@2.14.6
\`\`\`

This config change unblocks the toolchain bump and is a no-op on pnpm v10, so landing it on main lets Renovate rebase #84 and go green.

## Test plan
- [ ] CI passes locally-equivalent install on pnpm v10 (verified: `pnpm install --frozen-lockfile` succeeds)
- [ ] After merge, rebase #84 and confirm `frontend-check` / `e2e` / `docker-build` go green