### PR TITLE
fix: use pnpm v11 allowBuilds key for msw

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "vitest": "4.1.6"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
+    "allowBuilds": [
       "msw"
     ]
   }


### PR DESCRIPTION
## Summary
- Renames `pnpm.onlyBuiltDependencies` to `pnpm.allowBuilds` (the pnpm v11 replacement)
- Follow-up to #88, which used the legacy v10 key

## Why
pnpm v11 consolidated `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, `ignoredBuiltDependencies`, and `ignoreDepScripts` into a single `allowBuilds` option. The legacy keys are no-ops on v11, so #84 would have hit `ERR_PNPM_IGNORED_BUILDS` again once it merged.

On pnpm v10 (current main) the new key is also a no-op but v10 only warns on unrun msw scripts, so this is safe to land ahead of #84.

## Test plan
- [ ] Local `pnpm install --frozen-lockfile` on v10 still succeeds
- [ ] After this merges and #84 rebases, `frontend-check` / `e2e` / `docker-build` go green on v11