### PR TITLE
fix: move pnpm allowBuilds to pnpm-workspace.yaml

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,10 +66,5 @@
     "typescript-eslint": "8.59.2",
     "vite": "8.0.12",
     "vitest": "4.1.6"
-  },
-  "pnpm": {
-    "allowBuilds": [
-      "msw"
-    ]
   }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  msw: true


### PR DESCRIPTION
## Summary
- Removes the `pnpm.allowBuilds` block from `frontend/package.json` (added in #89)
- Creates `frontend/pnpm-workspace.yaml` with the v11-correct shape:
  ```yaml
  allowBuilds:
    msw: true
  ```

## Why
Per [pnpm settings docs](https://pnpm.io/settings), `allowBuilds` in v11 lives in `pnpm-workspace.yaml` and is an object mapping package matchers to booleans — not an array under `pnpm` in `package.json`. The wrong shape/location was silently ignored, so PR #84 (pnpm v11 bump) is still failing with `ERR_PNPM_IGNORED_BUILDS: msw@2.14.6`.

## Test plan
- [ ] Local `pnpm install --frozen-lockfile` on v10 still succeeds
- [ ] After merge + rebase of #84, `frontend-check` / `e2e` / `docker-build` go green