### PR TITLE
fix: copy pnpm-workspace.yaml into Docker frontend build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /build
 RUN corepack enable
 # Cache deps separately. .npmrc enforces minimum-release-age soak so a
 # compromised version can't slip into the image build.
-COPY frontend/package.json frontend/pnpm-lock.yaml frontend/.npmrc ./
+COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml frontend/.npmrc ./
 RUN pnpm install --frozen-lockfile
 # Build
 COPY frontend/ ./


### PR DESCRIPTION
## Summary
- Add `frontend/pnpm-workspace.yaml` to the `COPY` line in the frontend-build stage

## Why
After #95 moved pnpm `allowBuilds` into `pnpm-workspace.yaml`, the Dockerfile still only copies `package.json`/`pnpm-lock.yaml`/`.npmrc`, so the build container can't see the build approval. PR #84 (pnpm v11) is still red on both docker-build jobs with `ERR_PNPM_IGNORED_BUILDS`. Frontend-check and e2e (which run on the host) already pass.

## Test plan
- [ ] After merge + rebase of #84, both `docker-build` jobs go green