### PR TITLE
ci: pin actions to patch tags so Renovate emits accurate comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6 # Renovate will pin to SHA on first scan
+      - uses: pnpm/action-setup@v6.0.8
         with:
           package_json_file: frontend/package.json
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -97,7 +97,7 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6 # Renovate will pin to SHA on first scan
+      - uses: pnpm/action-setup@v6.0.8
         with:
           package_json_file: frontend/package.json
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -212,7 +212,7 @@ jobs:
 
       - name: Compute OCI metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6
+        uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ steps.image.outputs.name }}
           labels: |
@@ -301,7 +301,7 @@ jobs:
 
       - name: Compute OCI annotations for manifest
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6
+        uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ steps.image.outputs.name }}
           labels: |


### PR DESCRIPTION
## Summary
Reverts `pnpm/action-setup` (2 lines) and `docker/metadata-action` (2 lines) from `@<sha> # vN` to patch tags (`@v6.0.8`, `@v6.0.0`) so Renovate re-pins to SHA with accurate `# vX.Y.Z` comments.

## Test plan
- [ ] Renovate's next scan re-pins to SHA with accurate patch comments