### PR TITLE
Group digest New Matches by site → program type (+ fix missing site names)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-digest-site-program-grouping.md
+++ b/docs/superpowers/plans/2026-05-20-digest-site-program-grouping.md
@@ -1,0 +1,579 @@
+# Digest Site → Program Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group the daily digest's "New Matches" section by site → program type → activities, and fix the latent bug where the digest never resolved site names.
+
+**Architecture:** `gather_digest_payload` resolves site names (one batch `Site` query — fixing the empty-site bug), adds `program_type` to each offering dict, and stores a derived `new_match_groups` structure (built by a pure `_group_matches_by_site` helper from the already-score-sorted flat list). The digest templates' New Matches section iterates `new_match_groups`; the `offering_row_*` macros gain an optional `show_site` flag so grouped rows don't repeat the site that's already in the header.
+
+**Tech Stack:** Python 3.14, SQLAlchemy 2.x async, Jinja2 (StrictUndefined env), pytest/pytest-asyncio.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-digest-site-program-grouping-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/yas/email/payloads.py` — add `new_match_groups` field to `DigestPayload`
+- `src/yas/email/builders.py` — add `program_type` to `_offering_to_dict`; add `_group_matches_by_site` + `_program_label` helpers; resolve site names + populate `new_match_groups` in `gather_digest_payload`
+- `src/yas/email/templates/macros.j2` — add `show_site=true` param to `offering_row_html` / `offering_row_text`
+- `src/yas/email/templates/digest.html.j2` — grouped New Matches section
+- `src/yas/email/templates/digest.txt.j2` — grouped New Matches section (adopts `offering_row_text`)
+- `tests/unit/test_email_builders.py` — site-name regression + `new_match_groups` shape tests
+- `tests/unit/test_email_render_pair.py` — `show_site` flag test
+- `tests/unit/test_digest_golden.py` — build `new_match_groups` in fixtures; add multi-site case
+
+**Create:**
+- `tests/unit/test_email_grouping.py` — pure `_group_matches_by_site` / `_program_label` unit tests
+- `tests/golden/digest/multi_site.txt`, `tests/golden/digest/multi_site.html` — new golden snapshot
+- (re-baselined) `tests/golden/digest/with_matches.txt`, `tests/golden/digest/with_matches.html`
+
+## Conventions
+
+- Run a single test: `uv run pytest tests/unit/test_X.py::test_Y -v --no-cov`
+- Full check before commit: `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src && uv run pytest tests/unit tests/integration -q --no-cov`
+  - **Note:** `ruff format --check` is a *separate* CI gate from `ruff check`. Run both. (A prior PR failed CI on format-only.)
+- TDD per @superpowers:test-driven-development. @superpowers:verification-before-completion before claiming done.
+- Conventional commits: `feat(email):` / `test:` / `refactor(email):`.
+
+---
+
+## Task 1: Grouping helper + program label (pure, no DB)
+
+The core grouping logic, fully testable without a database.
+
+**Files:**
+- Modify: `src/yas/email/builders.py` (add `_program_label`, `_group_matches_by_site`)
+- Create: `tests/unit/test_email_grouping.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/unit/test_email_grouping.py
+"""Pure unit tests for the digest site->program grouping helper."""
+from __future__ import annotations
+
+from yas.email.builders import _group_matches_by_site, _program_label
+
+
+def _m(site_id, site_name, program_type, name, score):
+    return {
+        "offering_id": hash((site_id, name)) & 0xFFFF,
+        "offering_name": name,
+        "site_id": site_id,
+        "site_name": site_name,
+        "program_type": program_type,
+        "score": score,
+        "start_date": None,
+        "price_cents": None,
+        "registration_opens_at": None,
+        "registration_url": None,
+    }
+
+
+def test_program_label_titlecases_and_maps_unknown():
+    assert _program_label("soccer") == "Soccer"
+    assert _program_label("martial_arts") == "Martial Arts"
+    assert _program_label("unknown") == "Other"
+
+
+def test_groups_by_site_then_program():
+    # Flat list, already score-sorted desc (as gather_digest_payload produces).
+    matches = [
+        _m(1, "Park District", "soccer", "Soccer Camp", 0.91),
+        _m(1, "Park District", "swim", "Summer Swim", 0.80),
+        _m(1, "Park District", "soccer", "Lil Kickers", 0.74),
+        _m(2, "YMCA", "dance", "Ballet I", 0.66),
+    ]
+    groups = _group_matches_by_site(matches)
+
+    # Two sites, ordered by best score desc: Park District (0.91) then YMCA (0.66).
+    assert [g["site_name"] for g in groups] == ["Park District", "YMCA"]
+
+    park = groups[0]
+    # Programs ordered by their best offering's score: soccer (0.91) before swim (0.80).
+    assert [p["program_type"] for p in park["programs"]] == ["soccer", "swim"]
+    assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swimming" if False else "Swim"]
+    # Offerings within soccer ordered by score desc.
+    soccer = park["programs"][0]
+    assert [o["offering_name"] for o in soccer["offerings"]] == ["Soccer Camp", "Lil Kickers"]
+
+    ymca = groups[1]
+    assert ymca["site_id"] == 2
+    assert [p["program_type"] for p in ymca["programs"]] == ["dance"]
+
+
+def test_empty_list_returns_empty():
+    assert _group_matches_by_site([]) == []
+
+
+def test_missing_site_name_groups_under_blank():
+    groups = _group_matches_by_site([_m(5, "", "art", "Painting", 0.5)])
+    assert groups[0]["site_id"] == 5
+    assert groups[0]["site_name"] == ""
+```
+
+Note: fix the `program_label` assertion line — `_program_label("swim")` returns `"Swim"`. Write it as `assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swim"]`.
+
+- [ ] **Step 2: Run, expect failure (ImportError)**
+
+`uv run pytest tests/unit/test_email_grouping.py -v --no-cov`
+Expected: FAIL — `_group_matches_by_site` / `_program_label` not importable.
+
+- [ ] **Step 3: Implement the helpers in `src/yas/email/builders.py`**
+
+Add near the top (after `_offering_to_dict`):
+
+```python
+def _program_label(program_type: str) -> str:
+    """Human display label for a ProgramType value. `unknown` -> 'Other'."""
+    if program_type == "unknown":
+        return "Other"
+    return program_type.replace("_", " ").title()
+    # Note: acronyms like 'stem' render as 'Stem'. Acceptable; do not special-case.
+
+
+def _group_matches_by_site(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group a score-sorted flat match list into site -> program -> offerings.
+
+    Pure reorganization of the same dicts (no DB). Ordering:
+      - sites by their best (max) offering score, descending
+      - programs within a site by their best offering score, descending
+      - offerings within a program preserve the input order (score desc)
+
+    `matches` is expected pre-sorted by score desc (as gather_digest_payload
+    produces). Offerings without a 'score' key sort last within their bucket.
+    """
+
+    def _score(o: dict[str, Any]) -> float:
+        s = o.get("score")
+        return s if isinstance(s, (int, float)) else float("-inf")
+
+    # Preserve first-seen order while bucketing so we can sort buckets by max score.
+    sites: dict[int, dict[str, Any]] = {}
+    for m in matches:
+        site_id = m["site_id"]
+        site = sites.setdefault(
+            site_id,
+            {"site_id": site_id, "site_name": m.get("site_name", ""), "_programs": {}},
+        )
+        pt = m.get("program_type", "unknown")
+        prog = site["_programs"].setdefault(
+            pt, {"program_type": pt, "program_label": _program_label(pt), "offerings": []}
+        )
+        prog["offerings"].append(m)
+
+    result: list[dict[str, Any]] = []
+    for site in sites.values():
+        programs = list(site["_programs"].values())
+        # offerings already score-sorted from input; sort programs by their best score.
+        programs.sort(key=lambda p: max(_score(o) for o in p["offerings"]), reverse=True)
+        result.append(
+            {
+                "site_id": site["site_id"],
+                "site_name": site["site_name"],
+                "programs": programs,
+            }
+        )
+    # sites by their best offering score across all programs.
+    result.sort(
+        key=lambda s: max(_score(o) for p in s["programs"] for o in p["offerings"]),
+        reverse=True,
+    )
+    return result
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+`uv run pytest tests/unit/test_email_grouping.py -v --no-cov`
+
+- [ ] **Step 5: Lint/format/types**
+
+`uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/yas/email/builders.py tests/unit/test_email_grouping.py
+git commit -m "feat(email): add site->program grouping helper for the digest
+
+Pure _group_matches_by_site reorganizes the score-sorted flat match list
+into site -> program-type -> offerings, ordering sites and programs by
+their best offering score. _program_label maps ProgramType values to
+display labels (unknown -> Other). No DB access; fully unit-tested."
+```
+
+---
+
+## Task 2: Add `program_type` to the offering dict + populate the payload
+
+Wire site-name resolution (the bug fix), `program_type`, and `new_match_groups` into `gather_digest_payload`.
+
+**Files:**
+- Modify: `src/yas/email/payloads.py` (add `new_match_groups` field)
+- Modify: `src/yas/email/builders.py` (`_offering_to_dict` + `gather_digest_payload`)
+- Modify: `tests/unit/test_email_builders.py` (regression + shape tests)
+
+- [ ] **Step 1: Add the field to `DigestPayload`**
+
+In `src/yas/email/payloads.py`, add to `DigestPayload` (after `new_matches`):
+
+```python
+    new_match_groups: list[dict[str, Any]] = field(default_factory=list)
+```
+
+- [ ] **Step 2: Write failing builder tests**
+
+Add to `tests/unit/test_email_builders.py` (it already has DB-backed digest tests; reuse the existing engine/seed helpers in that file — check their names first, e.g. `_make_engine`, and the Site/Page/Kid/Offering/Match factories):
+
+```python
+@pytest.mark.asyncio
+async def test_gather_digest_populates_site_name_and_groups(tmp_path: Any) -> None:
+    """Regression: site_name is resolved (was always ''); new_match_groups nests by site->program."""
+    eng = await _make_engine(tmp_path)
+    async with session_scope(eng) as s:
+        site_a = Site(name="Park District", base_url="https://a.example.com", active=True)
+        site_b = Site(name="YMCA", base_url="https://b.example.com", active=True)
+        s.add_all([site_a, site_b]); await s.flush()
+        page_a = Page(site_id=site_a.id, url="https://a.example.com/s", kind=PageKind.schedule)
+        page_b = Page(site_id=site_b.id, url="https://b.example.com/s", kind=PageKind.schedule)
+        s.add_all([page_a, page_b]); await s.flush()
+        kid = Kid(name="Ada", dob=date(2017, 1, 1), created_at=NOW - timedelta(days=30))
+        s.add(kid); await s.flush()
+        # Two offerings at site A (soccer + swim), one at site B (dance).
+        o1 = Offering(site_id=site_a.id, page_id=page_a.id, name="Soccer Camp",
+                      normalized_name="soccer camp", program_type="soccer",
+                      start_date=date(2026, 6, 1), price_cents=15000,
+                      registration_url="https://a.example.com/r/1")
+        o2 = Offering(site_id=site_a.id, page_id=page_a.id, name="Summer Swim",
+                      normalized_name="summer swim", program_type="swim",
+                      start_date=date(2026, 6, 15), price_cents=14000)
+        o3 = Offering(site_id=site_b.id, page_id=page_b.id, name="Ballet I",
+                      normalized_name="ballet i", program_type="dance",
+                      start_date=date(2026, 6, 3), price_cents=12000)
+        s.add_all([o1, o2, o3]); await s.flush()
+        # Matches inside the window, scores set so ordering is deterministic.
+        s.add_all([
+            Match(kid_id=kid.id, offering_id=o1.id, score=0.91, computed_at=NOW),
+            Match(kid_id=kid.id, offering_id=o2.id, score=0.80, computed_at=NOW),
+            Match(kid_id=kid.id, offering_id=o3.id, score=0.66, computed_at=NOW),
+        ]); await s.flush()
+
+        payload = await gather_digest_payload(
+            s, kid,
+            window_start=NOW - timedelta(days=1), window_end=NOW + timedelta(hours=1),
+            alert_no_matches_kid_days=7, now=NOW,
+        )
+
+    # Bug fix: site_name is populated on the flat list (previously always "").
+    assert all(m["site_name"] for m in payload.new_matches)
+    # program_type present on every offering dict.
+    assert all("program_type" in m for m in payload.new_matches)
+    # Grouped: Park District (best 0.91) before YMCA (0.66).
+    assert [g["site_name"] for g in payload.new_match_groups] == ["Park District", "YMCA"]
+    park = payload.new_match_groups[0]
+    assert [p["program_type"] for p in park["programs"]] == ["soccer", "swim"]
+```
+
+(Adjust imports/seed-helper names to match what already exists at the top of `test_email_builders.py`. `NOW`, `date`, `timedelta` are already imported there from the Task-5 work; verify.)
+
+- [ ] **Step 3: Run, expect failure**
+
+`uv run pytest tests/unit/test_email_builders.py::test_gather_digest_populates_site_name_and_groups -v --no-cov`
+Expected: FAIL — `new_match_groups` empty / `site_name` blank / `program_type` missing.
+
+- [ ] **Step 4: Add `program_type` to `_offering_to_dict`**
+
+In `src/yas/email/builders.py::_offering_to_dict`, add to the dict literal:
+
+```python
+        "program_type": offering.program_type,
+```
+
+(Always present — the column defaults to `unknown`.)
+
+- [ ] **Step 5: Resolve site names + build groups in `gather_digest_payload`**
+
+After the `new_matches` list is built (the loop over `match_rows`), insert:
+
+```python
+    # Resolve site names for the new-match offerings (one batch query) and
+    # populate site_name on each dict. Without this the digest showed no site
+    # (site_name defaulted to "" and the macro guard dropped it).
+    if new_matches:
+        site_ids = {m["site_id"] for m in new_matches}
+        site_names = dict(
+            (
+                await session.execute(
+                    select(Site.id, Site.name).where(Site.id.in_(site_ids))
+                )
+            ).all()
+        )
+        for m in new_matches:
+            m["site_name"] = site_names.get(m["site_id"], "")
+
+    new_match_groups = _group_matches_by_site(new_matches)
+```
+
+Ensure `Site` is imported in `builders.py` (the `new_match` builder already imports it — confirm it's module-level).
+
+Then add `new_match_groups=new_match_groups,` to the `DigestPayload(...)` constructor call at the end of the function.
+
+- [ ] **Step 6: Run the new test + the full builder/digest suite**
+
+```bash
+uv run pytest tests/unit/test_email_builders.py tests/unit/test_email_digest_builder.py -v --no-cov
+```
+Expected: PASS. (The existing `test_email_digest_builder.py` `gather_digest_payload` tests should still pass; if any asserted `site_name == ""`, update them to the resolved name — but they likely don't assert site_name at all.)
+
+- [ ] **Step 7: Lint/format/types + full suite**
+
+`uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src && uv run pytest tests/unit tests/integration -q --no-cov`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/yas/email/payloads.py src/yas/email/builders.py tests/unit/test_email_builders.py
+git commit -m "feat(email): resolve digest site names + build new_match_groups
+
+gather_digest_payload now batch-resolves site_id->name for the new-match
+offerings (fixing the long-standing empty-site bug where site_name
+defaulted to '' and the row macro silently dropped it) and adds
+program_type to each offering dict. The derived new_match_groups field on
+DigestPayload nests the score-sorted matches by site -> program type via
+_group_matches_by_site. The flat new_matches list is unchanged (still used
+for the header count, empty-day skip, and LLM top-line)."
+```
+
+---
+
+## Task 3: `show_site` flag on the offering-row macros
+
+So grouped rows don't repeat the site that's in the group header. Default preserves all existing callers.
+
+**Files:**
+- Modify: `src/yas/email/templates/macros.j2`
+- Modify: `tests/unit/test_email_render_pair.py`
+
+- [ ] **Step 1: Write failing macro tests**
+
+Add to `tests/unit/test_email_render_pair.py` (it already renders macros via `env.from_string`; mirror the existing `_offering` helper there):
+
+```python
+@pytest.mark.parametrize("variant", ["html", "text"])
+def test_offering_row_show_site_false_omits_site(variant: str) -> None:
+    macro = f"offering_row_{variant}"
+    tpl = env.from_string(
+        f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m, show_site=false) }}}}'
+    )
+    out = tpl.render(m=_offering(site_name="Park District", score=0.9))
+    assert "Park District" not in out
+
+
+@pytest.mark.parametrize("variant", ["html", "text"])
+def test_offering_row_default_includes_site(variant: str) -> None:
+    macro = f"offering_row_{variant}"
+    tpl = env.from_string(
+        f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m) }}}}'
+    )
+    out = tpl.render(m=_offering(site_name="Park District", score=0.9))
+    assert "Park District" in out
+```
+
+(Confirm the `_offering` helper in that file accepts `site_name`; it builds a base dict — add `site_name` to its base or pass via overrides.)
+
+- [ ] **Step 2: Run, expect failure**
+
+`uv run pytest tests/unit/test_email_render_pair.py -k show_site -v --no-cov`
+Expected: FAIL — `show_site=false` still renders the site (param ignored / unknown).
+
+- [ ] **Step 3: Add the `show_site` parameter to both macros**
+
+In `src/yas/email/templates/macros.j2`, change the macro signatures and the site guard:
+
+```jinja
+{% macro offering_row_html(m, show_site=true) %}
+<li>
+  <strong>{{ m.offering_name }}</strong>
+  {% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}
+  ...
+```
+
+```jinja
+{% macro offering_row_text(m, show_site=true) -%}
+  - {{ m.offering_name }}{% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}...
+```
+
+(Only the site-name guard changes — every other fragment is untouched.)
+
+- [ ] **Step 4: Run macro tests + the full render-pair file**
+
+`uv run pytest tests/unit/test_email_render_pair.py -v --no-cov`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Confirm no golden drift from existing callers**
+
+`uv run pytest tests/unit/test_email_render_golden.py -v --no-cov`
+Expected: PASS unchanged — `new_match`/others call the macro with no `show_site` arg, so default `true` preserves output byte-for-byte.
+
+- [ ] **Step 6: Lint/format/types**
+
+`uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/yas/email/templates/macros.j2 tests/unit/test_email_render_pair.py
+git commit -m "feat(email): optional show_site flag on offering-row macros
+
+offering_row_html/_text gain show_site=true (default unchanged). The
+grouped digest section will pass show_site=false so rows don't repeat the
+site already shown in the group header. All existing callers omit the arg
+and render identically."
+```
+
+---
+
+## Task 4: Grouped New Matches templates + golden re-baseline
+
+Render the grouping, and re-baseline the digest goldens (the change *is* the golden diff).
+
+**Files:**
+- Modify: `src/yas/email/templates/digest.html.j2`
+- Modify: `src/yas/email/templates/digest.txt.j2`
+- Modify: `tests/unit/test_digest_golden.py` (build `new_match_groups` in fixtures + multi-site case)
+- Re-baseline: `tests/golden/digest/with_matches.{txt,html}`
+- Create: `tests/golden/digest/multi_site.{txt,html}`
+
+**Content note (intentional):** the text digest's New Matches rows currently use an inline format with NO registration URL. This task switches them to `offering_row_text(m, show_site=false)`, which DRYs the template and **adds a per-row registration link to text digests** — a small, deliberate content improvement within the New Matches section. Call it out in the commit.
+
+- [ ] **Step 1: Update `test_digest_golden.py` fixtures to build groups**
+
+The golden fixtures construct `DigestPayload` directly (bypassing the builder), so they must populate `new_match_groups` via the helper, exactly as the builder does.
+
+In `tests/unit/test_digest_golden.py`:
+- Import the helper: `from yas.email.builders import _group_matches_by_site`.
+- In `_payload_with_matches()`, ensure each match dict has a `program_type` key (e.g. `"program_type": "soccer"`), and set `new_match_groups=_group_matches_by_site(new_matches)` on the returned payload. (The match dict already has `site_name="Park District"`.)
+- Add a `_payload_multi_site()` factory: two sites (e.g. "Park District" with soccer + swim, "YMCA" with dance), three matches, scores 0.91/0.80/0.66, each dict with `site_name`, `site_id`, `program_type`, `score`, `start_date`, `price_cents`, `registration_url`. Build `new_match_groups` via the helper. Add it to the `_CASES` list with top_line `"Ada — 3 new matches"`.
+
+- [ ] **Step 2: Update the HTML template New Matches section**
+
+In `src/yas/email/templates/digest.html.j2`, replace the New Matches block:
+
+```jinja
+{% if payload.new_matches %}
+<h1 style="font-size: 1em; border-bottom: 1px solid #ccc;">New Matches ({{ payload.new_matches|length }})</h1>
+{% for site in payload.new_match_groups %}
+<h2 style="font-size: 0.95em; margin: 12px 0 4px;">{{ site.site_name or "Unknown site" }}</h2>
+{% for prog in site.programs %}
+<h3 style="font-size: 0.85em; color: #555; margin: 6px 0 2px;">{{ prog.program_label }}</h3>
+<ul style="margin-top: 0;">
+  {% for m in prog.offerings %}
+  {{ offering_row_html(m, show_site=false) }}
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endfor %}
+{% endif %}
+```
+
+- [ ] **Step 3: Update the text template New Matches section**
+
+In `src/yas/email/templates/digest.txt.j2`, add the macro import at the top (after `{% extends %}`):
+
+```jinja
+{% from "macros.j2" import offering_row_text %}
+```
+
+Replace the NEW MATCHES block:
+
+```jinja
+{% if payload.new_matches -%}
+NEW MATCHES ({{ payload.new_matches|length }}):
+{% for site in payload.new_match_groups -%}
+{{ site.site_name or "Unknown site" }}:
+{% for prog in site.programs -%}
+  {{ prog.program_label }}:
+{% for m in prog.offerings -%}
+  {{ offering_row_text(m, show_site=false) }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
+{%- endif %}
+```
+
+(Watch indentation/whitespace — the env uses `trim_blocks` + `lstrip_blocks`. The exact rendered shape is locked by the golden in the next step; iterate the template until the golden looks right, then capture it.)
+
+- [ ] **Step 4: Run the golden test — expect FAIL (old goldens), inspect, re-baseline**
+
+`uv run pytest tests/unit/test_digest_golden.py -v --no-cov`
+Expected: FAIL for `with_matches` (layout changed) and `multi_site` (no golden yet).
+
+Re-capture goldens with a one-shot script (mirrors how the digest goldens were originally captured):
+
+```bash
+uv run python -c "
+from tests.unit.test_digest_golden import _payload_with_matches, _payload_multi_site
+from yas.email import render_digest_payload
+from pathlib import Path
+out = Path('tests/golden/digest')
+for name, payload, top in [
+    ('with_matches', _payload_with_matches(), 'Ada — 1 new match'),
+    ('multi_site', _payload_multi_site(), 'Ada — 3 new matches'),
+]:
+    r = render_digest_payload(payload, top)
+    (out / f'{name}.txt').write_text(r.body_plain)
+    (out / f'{name}.html').write_text(r.body_html)
+print('captured')
+"
+```
+
+(Use the actual `top_line` values that `_CASES` uses for each case so the golden matches the test. If `_payload_with_matches`'s case in `_CASES` uses a specific top_line, reuse it verbatim.)
+
+- [ ] **Step 5: Manually inspect the re-baselined goldens**
+
+```bash
+sed -n '1,40p' tests/golden/digest/multi_site.txt
+```
+Confirm: New Matches header with total count, then per-site headers, per-program sub-headers, activity rows beneath, no per-row site repetition, and (text) the registration URL now present on rows. Open `multi_site.html` in a browser to confirm the nesting reads cleanly.
+
+- [ ] **Step 6: Run golden test, expect PASS**
+
+`uv run pytest tests/unit/test_digest_golden.py -v --no-cov`
+
+- [ ] **Step 7: Full verification**
+
+`uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src && uv run pytest tests/unit tests/integration -q --no-cov`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/yas/email/templates/digest.html.j2 src/yas/email/templates/digest.txt.j2 tests/unit/test_digest_golden.py tests/golden/digest/
+git commit -m "feat(email): group digest New Matches by site -> program type
+
+The New Matches section now renders site headers, program-type
+sub-headers, and the activities beneath each, replacing the flat
+site-less list. Uses offering_row_*(show_site=false) so rows don't repeat
+the site in the header. The text digest rows adopt offering_row_text,
+which also adds a per-row registration link to text digests (small
+intentional content improvement). Re-baselines the with_matches digest
+golden and adds a multi_site golden exercising two sites x program types."
+```
+
+---
+
+## Final verification
+
+- [ ] `uv run pytest tests/unit tests/integration -q --no-cov` green.
+- [ ] `uv run ruff check src tests` and `uv run ruff format --check src tests` clean.
+- [ ] `uv run mypy src` clean.
+- [ ] Manual: open `tests/golden/digest/multi_site.html` and `with_matches.html` in a browser — site → program → activity nesting reads cleanly; no "@ Site" repetition under a site header.
+- [ ] Confirm other digest sections (Starting Soon, Registration Opens, Delivery Issues) and the empty/under-threshold states are visually unchanged in the goldens.
+
+## Notes
+
+- **Scope discipline:** only the New Matches section changes. Starting Soon / Registration Opens / Delivery Issues / empty states are untouched — verify their golden output is byte-identical except where the New Matches block sits.
+- **One source of truth:** `new_match_groups` is derived from `new_matches` via the pure helper. Both the builder (real path) and the golden fixtures (test path) call `_group_matches_by_site` — never hand-build the nested structure.
+- @superpowers:test-driven-development — failing test first for Tasks 1–3. Task 4 is template+golden; the golden re-baseline is the verification.

--- a/docs/superpowers/plans/2026-05-20-digest-site-program-grouping.md
+++ b/docs/superpowers/plans/2026-05-20-digest-site-program-grouping.md
@@ -94,7 +94,7 @@ def test_groups_by_site_then_program():
     park = groups[0]
     # Programs ordered by their best offering's score: soccer (0.91) before swim (0.80).
     assert [p["program_type"] for p in park["programs"]] == ["soccer", "swim"]
-    assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swimming" if False else "Swim"]
+    assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swim"]
     # Offerings within soccer ordered by score desc.
     soccer = park["programs"][0]
     assert [o["offering_name"] for o in soccer["offerings"]] == ["Soccer Camp", "Lil Kickers"]
@@ -113,8 +113,6 @@ def test_missing_site_name_groups_under_blank():
     assert groups[0]["site_id"] == 5
     assert groups[0]["site_name"] == ""
 ```
-
-Note: fix the `program_label` assertion line — `_program_label("swim")` returns `"Swim"`. Write it as `assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swim"]`.
 
 - [ ] **Step 2: Run, expect failure (ImportError)**
 

--- a/docs/superpowers/specs/2026-05-20-digest-site-program-grouping-design.md
+++ b/docs/superpowers/specs/2026-05-20-digest-site-program-grouping-design.md
@@ -1,0 +1,136 @@
+# Digest Site → Program Grouping — Design
+
+**Date:** 2026-05-20
+**Status:** Draft (spec review pending)
+**Scope:** Backend digest rendering (`src/yas/email/`). No API or frontend changes.
+
+## Problem
+
+The daily digest's "New Matches" section is a flat, score-sorted list of activities with no indication of **which site/organization** each activity came from. Worse, the site name is missing entirely: `gather_digest_payload` builds each match dict via `_offering_to_dict(o, m.score)` without passing a `site_name`, so it defaults to `""`, and the `offering_row_*` macro's `{% if m.site_name %}` guard silently drops it. A parent reading the digest sees activity names with no source attribution.
+
+The request: show what site/program each activity was detected from, grouping the activities under each site and, within a site, under each program type.
+
+## Goals
+
+1. Group the digest's **New Matches** section by **site → program type → activities**.
+2. Fix the latent empty-site bug so site names are actually resolved and shown (this is a prerequisite for grouping).
+3. Preserve the existing "highest-signal first" ordering: a parent should still see the strongest match near the top.
+4. Keep the change isolated to the New Matches section and the digest builder — no churn in other sections, other email kinds, or the immediate-alert path.
+
+## Non-goals
+
+- Grouping the "Starting Soon" or "Registration Opens" sections. Those are deliberately time-ordered (by start date / open date); grouping by site would fight that ordering. They stay flat.
+- Any change to the immediate-alert renderers (`new_match`, `reg_opens_*`, etc.). They already resolve site names and render single offerings or short lists; grouping is a digest concern.
+- A new `program`/category data model. `Offering.program_type` (an existing enum) is the inner grouping key as-is.
+- Frontend or API changes. The digest-preview endpoint renders the same payload, so it inherits the new layout for free.
+
+## Data model context
+
+`Site (org/website) → Page (where detected) → Offering (the activity)`. `Offering` carries `site_id` and `program_type: ProgramType` (a `StrEnum`: `soccer`, `dance`, `swim`, …, default `unknown`). The digest already joins `Match → Offering`; it does not currently join `Site`.
+
+## Design
+
+### Payload shape
+
+`DigestPayload` keeps its existing flat `new_matches: list[dict]` (still used for the header count, the empty-day skip check in `yas.worker.digest_loop`, and the LLM top-line generator). It gains one derived field:
+
+```python
+new_match_groups: list[dict[str, Any]] = field(default_factory=list)
+# Each entry is one site:
+#   {
+#     "site_id": int,
+#     "site_name": str,            # "" only if the Site row is somehow missing
+#     "programs": [
+#       {
+#         "program_type": str,     # raw enum value, e.g. "soccer"
+#         "program_label": str,    # display form, e.g. "Soccer"; "unknown" -> "Other"
+#         "offerings": list[dict], # the existing offering-row dicts, score desc
+#       },
+#       ...                        # programs ordered by their best offering's score desc
+#     ],
+#   },
+#   ...                            # sites ordered by their best offering's score desc
+```
+
+`new_match_groups` is a pure reorganization of `new_matches` — same dicts, regrouped. It is not a second query.
+
+### Builder changes (`gather_digest_payload`)
+
+1. **Resolve site names** (fixes the bug): after building `new_matches`, collect the distinct `site_id`s, run one `select(Site).where(Site.id.in_(site_ids))`, build a `{site_id: name}` map, and populate `site_name` on each new-match dict. This mirrors the batch-resolve `build_new_match` already does. (Only the `new_matches` list needs this for now; `starting_soon`/`registration_calendar` are unchanged and out of scope.)
+2. **Add `program_type`** to `_offering_to_dict` output so the inner grouping key is present on every offering dict. The key is always set (`Offering.program_type` defaults to `unknown`). Adding a key to this dict is backward-compatible: existing templates ignore unknown keys, and the immediate-alert offering rows simply don't read it.
+3. **Group:** call a new pure helper `_group_matches_by_site(new_matches) -> list[dict]` and store the result as `new_match_groups`.
+
+### Grouping helper (`_group_matches_by_site`)
+
+Pure function over the already-score-sorted flat list — no DB, no I/O:
+
+- Bucket offerings by `site_id` (carrying `site_name`), then within each site bucket by `program_type`.
+- Order: sites by their best (max) offering score descending; programs within a site by their best offering score descending; offerings within a program by score descending (already sorted, preserved as a stable sub-order).
+- `program_label`: `"Other"` for `unknown`, otherwise `program_type.replace("_", " ").title()` (e.g. `martial_arts` → "Martial Arts"). Acronym imperfections (e.g. "Stem") are acceptable; not worth special-casing.
+- Offerings missing a score (shouldn't happen for digest matches, which always have a `Match.score`) sort last within their program.
+
+### Template changes
+
+Only the **New Matches** block of `digest.html.j2` and `digest.txt.j2` changes. It iterates `payload.new_match_groups`: each site is a sub-header, each program a nested heading, each activity a row rendered by the existing `offering_row_*` macro.
+
+The header count stays total activities: `New Matches ({{ payload.new_matches|length }})`.
+
+**Per-row site omission:** inside a grouped view, repeating "@ Park District" on every row under a "Park District" header is noise. `offering_row_html` / `offering_row_text` gain an optional `show_site=true` parameter (default preserves current behavior for `new_match` and all other callers). The grouped digest section calls the macros with `show_site=false`.
+
+Rendered shape (HTML, illustrative):
+
+```
+New Matches (4)
+─────────────────
+Park District
+  Soccer
+    • Soccer Camp · Jun 1 · $150.00 · score 0.91 · Register
+    • Lil Kickers · Jun 8 · $90.00 · score 0.74 · Register
+  Swimming
+    • Summer Swim · Jun 15 · $140.00 · score 0.80 · Register
+YMCA
+  Dance
+    • Ballet I · Jun 3 · $120.00 · score 0.66 · Register
+```
+
+The text template mirrors this with indentation. Other sections (Starting Soon, Registration Opens, Delivery Issues) and all empty/under-threshold states are untouched.
+
+## Error handling
+
+- **Missing Site row:** `site_name` falls back to `""`; the offering still groups under its `site_id`. The grouping helper never raises — it buckets and sorts dicts.
+- **`program_type`:** always present (enum default `unknown` → label "Other"), so the inner key is never missing.
+- **StrictUndefined:** the grouped template reads only fields the builder always populates (`site_name`, `program_label`, offering-dict keys), so no new undefined-field exposure.
+
+## Testing
+
+- **Unit — `_group_matches_by_site`** (no DB): a flat list spanning two sites and multiple program types asserts site order (best score), program order within site (best score), offering order within program (score desc), and `program_label` mapping (`unknown` → "Other", underscore/titlecase).
+- **Unit — `gather_digest_payload`** (extend the existing digest builder test): assert `site_name` is now populated on `new_matches` (regression guard for the bug) and that `new_match_groups` nests correctly for a seeded two-site scenario.
+- **Macro — `test_email_render_pair.py`**: assert `offering_row_*(m, show_site=false)` omits the site fragment while the default still includes it.
+- **Golden — digest**: update the existing `with_matches` golden (currently a flat, site-less row) to the grouped layout, and add a **multi-site** golden scenario (two sites, ≥2 program types) so grouping is exercised in a rendered snapshot. Both `.txt` and `.html`.
+
+## Migration & rollout
+
+Internal-only; no flags. Single feature branch:
+
+1. Add `program_type` to `_offering_to_dict`; add `_group_matches_by_site` + unit test.
+2. Resolve site names in `gather_digest_payload`; populate `new_match_groups`; extend builder test (asserts the bug fix).
+3. Add `show_site` param to the macros + macro test.
+4. Update digest templates' New Matches section.
+5. Re-baseline the `with_matches` digest golden; add the multi-site golden scenario + seeder.
+
+Each step keeps the suite green. The digest goldens change deliberately (grouping is the point); the change is reviewed as a golden diff.
+
+## YAGNI
+
+- No grouping of Starting Soon / Registration Opens.
+- No collapsing/threshold ("show first N per site") — render all matches grouped; revisit only if real digests get unwieldy.
+- No per-site links or site-level metadata beyond the name.
+- No typed dataclasses for the group structure — nested dicts match the existing `DigestPayload` section style and keep the template StrictUndefined-friendly.
+
+## Open questions
+
+None blocking. Decisions taken during brainstorming:
+- Grouping key: site → program type. ✅
+- Sections: New Matches only. ✅
+- Ordering: sites by best match score; programs by best score within site; activities by score. ✅
+- Per-row site omitted inside groups (it's in the header). ✅

--- a/docs/superpowers/specs/2026-05-20-digest-site-program-grouping-design.md
+++ b/docs/superpowers/specs/2026-05-20-digest-site-program-grouping-design.md
@@ -115,8 +115,7 @@ Internal-only; no flags. Single feature branch:
 1. Add `program_type` to `_offering_to_dict`; add `_group_matches_by_site` + unit test.
 2. Resolve site names in `gather_digest_payload`; populate `new_match_groups`; extend builder test (asserts the bug fix).
 3. Add `show_site` param to the macros + macro test.
-4. Update digest templates' New Matches section.
-5. Re-baseline the `with_matches` digest golden; add the multi-site golden scenario + seeder.
+4. Update digest templates' New Matches section **and** re-baseline goldens in one reviewable unit: the template change *is* what produces the golden diff, so updating the `with_matches` golden and adding the multi-site golden scenario + seeder happen in the same step/commit as the template edit.
 
 Each step keeps the suite green. The digest goldens change deliberately (grouping is the point); the change is reviewed as a golden diff.
 

--- a/src/yas/email/builders.py
+++ b/src/yas/email/builders.py
@@ -47,6 +47,7 @@ def _offering_to_dict(
     d: dict[str, Any] = {
         "offering_id": offering.id,
         "offering_name": offering.name,
+        "program_type": offering.program_type,
         "site_id": offering.site_id,
         "start_date": offering.start_date,
         "price_cents": offering.price_cents,
@@ -164,6 +165,20 @@ async def gather_digest_payload(
     for m, o in match_rows:
         d = _offering_to_dict(o, m.score)
         new_matches.append(d)
+
+    # Resolve site names for the new-match offerings (one batch query) and
+    # populate site_name on each dict. Without this the digest showed no site
+    # (site_name defaulted to "" and the row macro guard dropped it).
+    if new_matches:
+        site_ids = {m["site_id"] for m in new_matches}
+        name_rows = (
+            await session.execute(select(Site.id, Site.name).where(Site.id.in_(site_ids)))
+        ).all()
+        site_names = {row.id: row.name for row in name_rows}
+        for m in new_matches:
+            m["site_name"] = site_names.get(m["site_id"], "")
+
+    new_match_groups = _group_matches_by_site(new_matches)
 
     # ------------------------------------------------------------------
     # 2. starting_soon -- any matched offering starting in (today, today+14d]
@@ -292,6 +307,7 @@ async def gather_digest_payload(
         kid_name=kid.name,
         for_date=today,
         new_matches=new_matches,
+        new_match_groups=new_match_groups,
         starting_soon=starting_soon,
         registration_calendar=registration_calendar,
         delivery_failures=delivery_failures,

--- a/src/yas/email/builders.py
+++ b/src/yas/email/builders.py
@@ -93,7 +93,10 @@ def _group_matches_by_site(matches: list[dict[str, Any]]) -> list[dict[str, Any]
             site_id,
             {"site_id": site_id, "site_name": m.get("site_name", ""), "_programs": {}},
         )
-        pt = m.get("program_type", "unknown")
+        # Coerce missing / None / empty program_type to "unknown" so the label
+        # mapping never sees None (offerings always carry a value in practice
+        # since the column defaults to "unknown", but be defensive).
+        pt = m.get("program_type") or "unknown"
         prog = site["_programs"].setdefault(
             pt, {"program_type": pt, "program_label": _program_label(pt), "offerings": []}
         )

--- a/src/yas/email/builders.py
+++ b/src/yas/email/builders.py
@@ -60,6 +60,64 @@ def _offering_to_dict(
     return d
 
 
+def _program_label(program_type: str) -> str:
+    """Human display label for a ProgramType value. `unknown` -> 'Other'."""
+    if program_type == "unknown":
+        return "Other"
+    return program_type.replace("_", " ").title()
+    # Note: acronyms like 'stem' render as 'Stem'. Acceptable; do not special-case.
+
+
+def _group_matches_by_site(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group a score-sorted flat match list into site -> program -> offerings.
+
+    Pure reorganization of the same dicts (no DB). Ordering:
+      - sites by their best (max) offering score, descending
+      - programs within a site by their best offering score, descending
+      - offerings within a program preserve the input order (score desc)
+
+    `matches` is expected pre-sorted by score desc (as gather_digest_payload
+    produces). Offerings without a 'score' key sort last within their bucket.
+    """
+
+    def _score(o: dict[str, Any]) -> float:
+        s = o.get("score")
+        return s if isinstance(s, (int, float)) else float("-inf")
+
+    # Preserve first-seen order while bucketing so we can sort buckets by max score.
+    sites: dict[int, dict[str, Any]] = {}
+    for m in matches:
+        site_id = m["site_id"]
+        site = sites.setdefault(
+            site_id,
+            {"site_id": site_id, "site_name": m.get("site_name", ""), "_programs": {}},
+        )
+        pt = m.get("program_type", "unknown")
+        prog = site["_programs"].setdefault(
+            pt, {"program_type": pt, "program_label": _program_label(pt), "offerings": []}
+        )
+        prog["offerings"].append(m)
+
+    result: list[dict[str, Any]] = []
+    for site in sites.values():
+        programs = list(site["_programs"].values())
+        # offerings already score-sorted from input; sort programs by their best score.
+        programs.sort(key=lambda p: max(_score(o) for o in p["offerings"]), reverse=True)
+        result.append(
+            {
+                "site_id": site["site_id"],
+                "site_name": site["site_name"],
+                "programs": programs,
+            }
+        )
+    # sites by their best offering score across all programs.
+    result.sort(
+        key=lambda s: max(_score(o) for p in s["programs"] for o in p["offerings"]),
+        reverse=True,
+    )
+    return result
+
+
 async def gather_digest_payload(
     session: AsyncSession,
     kid: Kid,

--- a/src/yas/email/payloads.py
+++ b/src/yas/email/payloads.py
@@ -15,6 +15,7 @@ class DigestPayload:
     kid_name: str
     for_date: date
     new_matches: list[dict[str, Any]] = field(default_factory=list)
+    new_match_groups: list[dict[str, Any]] = field(default_factory=list)
     starting_soon: list[dict[str, Any]] = field(default_factory=list)
     registration_calendar: list[dict[str, Any]] = field(default_factory=list)
     delivery_failures: list[dict[str, Any]] = field(default_factory=list)

--- a/src/yas/email/templates/digest.html.j2
+++ b/src/yas/email/templates/digest.html.j2
@@ -12,11 +12,17 @@ We're still scanning sites and will be in touch as soon as we find something. Ba
 
 {% if payload.new_matches %}
 <h1 style="font-size: 1em; border-bottom: 1px solid #ccc;">New Matches ({{ payload.new_matches|length }})</h1>
-<ul>
-  {% for m in payload.new_matches %}
-  {{ offering_row_html(m) }}
+{% for site in payload.new_match_groups %}
+<h2 style="font-size: 0.95em; margin: 12px 0 4px;">{{ site.site_name or "Unknown site" }}</h2>
+{% for prog in site.programs %}
+<h3 style="font-size: 0.85em; color: #555; margin: 6px 0 2px;">{{ prog.program_label }}</h3>
+<ul style="margin-top: 0;">
+  {% for m in prog.offerings %}
+  {{ offering_row_html(m, show_site=false) }}
   {% endfor %}
 </ul>
+{% endfor %}
+{% endfor %}
 {% endif %}
 
 {% if payload.starting_soon %}

--- a/src/yas/email/templates/digest.txt.j2
+++ b/src/yas/email/templates/digest.txt.j2
@@ -1,4 +1,5 @@
 {% extends "base.txt.j2" %}
+{% from "macros.j2" import offering_row_text %}
 {% block subject %}{{ top_line }}{% endblock %}
 {% block body %}
 {% if payload.under_no_matches_threshold -%}
@@ -6,9 +7,13 @@ We haven't found any activities matching {{ payload.kid_name }} yet. We're still
 {%- else -%}
 {% if payload.new_matches -%}
 NEW MATCHES ({{ payload.new_matches|length }}):
-{% for m in payload.new_matches -%}
-  - {{ m.offering_name }} @ {{ m.site_name }} · {{ m.start_date|rel_date }} · {{ m.price_cents|price }} · score {{ "%.2f"|format(m.score) }}
-{% endfor %}
+{% for site in payload.new_match_groups -%}
+{{ site.site_name or "Unknown site" }}:
+{% for prog in site.programs %}  {{ prog.program_label }}:
+{% for m in prog.offerings %}    {{ offering_row_text(m, show_site=false) }}
+{% endfor -%}
+{% endfor -%}
+{% endfor -%}
 {%- endif %}
 {% if payload.starting_soon -%}
 STARTING SOON:

--- a/src/yas/email/templates/digest.txt.j2
+++ b/src/yas/email/templates/digest.txt.j2
@@ -7,6 +7,12 @@ We haven't found any activities matching {{ payload.kid_name }} yet. We're still
 {%- else -%}
 {% if payload.new_matches -%}
 NEW MATCHES ({{ payload.new_matches|length }}):
+{# Whitespace: the env uses trim_blocks + lstrip_blocks, which strips leading
+   whitespace BEFORE a block tag. The 2-space (program) and 4-space (row)
+   indents below therefore ride on the SAME line as their {% for %} tag, after
+   the %}, so they survive. Do NOT move the {% for %} onto its own line to
+   "tidy" this — the indentation will silently vanish. Re-baseline the digest
+   goldens if you change this block. #}
 {% for site in payload.new_match_groups -%}
 {{ site.site_name or "Unknown site" }}:
 {% for prog in site.programs %}  {{ prog.program_label }}:

--- a/src/yas/email/templates/macros.j2
+++ b/src/yas/email/templates/macros.j2
@@ -14,10 +14,10 @@
      score field; the macros tolerate omission, not None.
 #}
 
-{% macro offering_row_html(m) %}
+{% macro offering_row_html(m, show_site=true) %}
 <li>
   <strong>{{ m.offering_name }}</strong>
-  {% if m.site_name %} @ {{ m.site_name }}{% endif %}
+  {% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}
   {% if m.start_date %}&middot; {{ m.start_date | rel_date }}{% endif %}
   {% if m.price_cents is not none %}&middot; {{ m.price_cents | price }}{% endif %}
   {% if m.score is defined and m.score is not none %}&middot; score {{ "%.2f" | format(m.score) }}{% endif %}
@@ -25,8 +25,8 @@
 </li>
 {% endmacro %}
 
-{% macro offering_row_text(m) -%}
-  - {{ m.offering_name }}{% if m.site_name %} @ {{ m.site_name }}{% endif %}{% if m.start_date %} · {{ m.start_date | rel_date }}{% endif %}{% if m.price_cents is not none %} · {{ m.price_cents | price }}{% endif %}{% if m.score is defined and m.score is not none %} · score {{ "%.2f" | format(m.score) }}{% endif %}{% if m.registration_url %} · {{ m.registration_url }}{% endif %}
+{% macro offering_row_text(m, show_site=true) -%}
+  - {{ m.offering_name }}{% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}{% if m.start_date %} · {{ m.start_date | rel_date }}{% endif %}{% if m.price_cents is not none %} · {{ m.price_cents | price }}{% endif %}{% if m.score is defined and m.score is not none %} · score {{ "%.2f" | format(m.score) }}{% endif %}{% if m.registration_url %} · {{ m.registration_url }}{% endif %}
 {%- endmacro %}
 
 {% macro reg_countdown_html(opens_at, label) %}

--- a/tests/golden/digest/multi_site.html
+++ b/tests/golden/digest/multi_site.html
@@ -9,16 +9,31 @@
   <strong style="font-size: 1.05em;">Daily digest — Ada</strong>
 </header>
 
-<p style="font-size: 1.1em; font-weight: bold;">Ada — 1 new match</p>
+<p style="font-size: 1.1em; font-weight: bold;">Ada — 3 new matches</p>
 
 
-<h1 style="font-size: 1em; border-bottom: 1px solid #ccc;">New Matches (1)</h1>
+<h1 style="font-size: 1em; border-bottom: 1px solid #ccc;">New Matches (3)</h1>
 <h2 style="font-size: 0.95em; margin: 12px 0 4px;">Park District</h2>
 <h3 style="font-size: 0.85em; color: #555; margin: 6px 0 2px;">Soccer</h3>
 <ul style="margin-top: 0;">
   <li>
   <strong>Soccer Camp</strong>
 &middot; Mon, Jun 1&middot; $150.00&middot; score 0.91&middot; <a href="https://example.com/reg/10">Register</a></li>
+
+</ul>
+<h3 style="font-size: 0.85em; color: #555; margin: 6px 0 2px;">Swim</h3>
+<ul style="margin-top: 0;">
+  <li>
+  <strong>Summer Swim</strong>
+&middot; Mon, Jun 15&middot; $140.00&middot; score 0.80&middot; <a href="https://example.com/reg/11">Register</a></li>
+
+</ul>
+<h2 style="font-size: 0.95em; margin: 12px 0 4px;">YMCA</h2>
+<h3 style="font-size: 0.85em; color: #555; margin: 6px 0 2px;">Dance</h3>
+<ul style="margin-top: 0;">
+  <li>
+  <strong>Ballet I</strong>
+&middot; Wed, Jun 3&middot; $120.00&middot; score 0.66&middot; <a href="https://example.com/reg/12">Register</a></li>
 
 </ul>
 

--- a/tests/golden/digest/multi_site.txt
+++ b/tests/golden/digest/multi_site.txt
@@ -1,0 +1,13 @@
+Ada — 3 new matches
+NEW MATCHES (3):
+Park District:
+  Soccer:
+    - Soccer Camp · Mon, Jun 1 · $150.00 · score 0.91 · https://example.com/reg/10
+  Swim:
+    - Summer Swim · Mon, Jun 15 · $140.00 · score 0.80 · https://example.com/reg/11
+YMCA:
+  Dance:
+    - Ballet I · Wed, Jun 3 · $120.00 · score 0.66 · https://example.com/reg/12
+
+---
+Youth Activity Scheduler

--- a/tests/golden/digest/with_matches.txt
+++ b/tests/golden/digest/with_matches.txt
@@ -1,6 +1,8 @@
 Ada — 1 new match
 NEW MATCHES (1):
-- Soccer Camp @ Park District · Mon, Jun 1 · $150.00 · score 0.91
+Park District:
+  Soccer:
+    - Soccer Camp · Mon, Jun 1 · $150.00 · score 0.91 · https://example.com/reg/10
 
 ---
 Youth Activity Scheduler

--- a/tests/unit/test_digest_golden.py
+++ b/tests/unit/test_digest_golden.py
@@ -138,3 +138,36 @@ def test_digest_golden(name: str, factory, top_line: str) -> None:
     expected_html = (_GOLDEN_DIR / f"{name}.html").read_text()
     assert txt == expected_txt, f"text diverges for {name}"
     assert html == expected_html, f"html diverges for {name}"
+
+
+def test_unknown_program_type_renders_as_other_header() -> None:
+    """A match with program_type 'unknown' renders under an 'Other' program
+    header in both formats (validates the label mapping in rendered output,
+    not just in the helper unit test). Kept off the goldens to avoid churn."""
+    new_matches = [
+        {
+            "offering_id": 99,
+            "offering_name": "Mystery Program",
+            "score": 0.5,
+            "site_id": 9,
+            "site_name": "Some Site",
+            "program_type": "unknown",
+            "start_date": date(2026, 7, 1),
+            "price_cents": 5000,
+            "registration_opens_at": None,
+            "registration_url": "https://example.com/reg/99",
+        }
+    ]
+    payload = DigestPayload(
+        kid_id=1,
+        kid_name="Ada",
+        for_date=date(2026, 5, 19),
+        new_matches=new_matches,
+        new_match_groups=_group_matches_by_site(new_matches),
+    )
+    txt, html = render_digest(payload, "Ada — 1 new match")
+    assert "Other" in txt
+    assert "Other" in html
+    # And not the raw enum value.
+    assert "unknown" not in txt
+    assert "unknown" not in html

--- a/tests/unit/test_digest_golden.py
+++ b/tests/unit/test_digest_golden.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from yas.email import render_digest_payload
+from yas.email.builders import _group_matches_by_site
 from yas.email.payloads import DigestPayload
 
 
@@ -26,23 +27,80 @@ _GOLDEN_DIR = Path(__file__).parent.parent / "golden" / "digest"
 
 
 def _payload_with_matches() -> DigestPayload:
+    new_matches = [
+        {
+            "offering_id": 10,
+            "offering_name": "Soccer Camp",
+            "score": 0.91,
+            "site_id": 1,
+            "site_name": "Park District",
+            "program_type": "soccer",
+            "start_date": date(2026, 6, 1),
+            "price_cents": 15000,
+            "registration_opens_at": datetime(2026, 5, 25, 9, 0, tzinfo=UTC),
+            "registration_url": "https://example.com/reg/10",
+        }
+    ]
     return DigestPayload(
         kid_id=1,
         kid_name="Ada",
         for_date=date(2026, 5, 19),
-        new_matches=[
-            {
-                "offering_id": 10,
-                "offering_name": "Soccer Camp",
-                "score": 0.91,
-                "site_id": 1,
-                "site_name": "Park District",
-                "start_date": date(2026, 6, 1),
-                "price_cents": 15000,
-                "registration_opens_at": datetime(2026, 5, 25, 9, 0, tzinfo=UTC),
-                "registration_url": "https://example.com/reg/10",
-            }
-        ],
+        new_matches=new_matches,
+        new_match_groups=_group_matches_by_site(new_matches),
+        starting_soon=[],
+        registration_calendar=[],
+        delivery_failures=[],
+        site_stagnant_ids=[],
+        silent_schedule_posts=[],
+        under_no_matches_threshold=False,
+    )
+
+
+def _payload_multi_site() -> DigestPayload:
+    new_matches = [
+        {
+            "offering_id": 10,
+            "offering_name": "Soccer Camp",
+            "score": 0.91,
+            "site_id": 1,
+            "site_name": "Park District",
+            "program_type": "soccer",
+            "start_date": date(2026, 6, 1),
+            "price_cents": 15000,
+            "registration_opens_at": None,
+            "registration_url": "https://example.com/reg/10",
+        },
+        {
+            "offering_id": 11,
+            "offering_name": "Summer Swim",
+            "score": 0.80,
+            "site_id": 1,
+            "site_name": "Park District",
+            "program_type": "swim",
+            "start_date": date(2026, 6, 15),
+            "price_cents": 14000,
+            "registration_opens_at": None,
+            "registration_url": "https://example.com/reg/11",
+        },
+        {
+            "offering_id": 12,
+            "offering_name": "Ballet I",
+            "score": 0.66,
+            "site_id": 2,
+            "site_name": "YMCA",
+            "program_type": "dance",
+            "start_date": date(2026, 6, 3),
+            "price_cents": 12000,
+            "registration_opens_at": None,
+            "registration_url": "https://example.com/reg/12",
+        },
+    ]
+    return DigestPayload(
+        kid_id=1,
+        kid_name="Ada",
+        for_date=date(2026, 5, 19),
+        new_matches=new_matches,
+        new_match_groups=_group_matches_by_site(new_matches),
         starting_soon=[],
         registration_calendar=[],
         delivery_failures=[],
@@ -67,6 +125,7 @@ def _payload_under_threshold() -> DigestPayload:
 
 _CASES = [
     ("with_matches", _payload_with_matches, "Ada — 1 new match"),
+    ("multi_site", _payload_multi_site, "Ada — 3 new matches"),
     ("empty", _payload_empty, "Bo — quiet day"),
     ("under_threshold", _payload_under_threshold, "Cy — still searching"),
 ]

--- a/tests/unit/test_email_builders.py
+++ b/tests/unit/test_email_builders.py
@@ -1115,3 +1115,11 @@ async def test_gather_digest_populates_site_name_and_groups(tmp_path: Any) -> No
     assert [g["site_name"] for g in payload.new_match_groups] == ["Park District", "YMCA"]
     park = payload.new_match_groups[0]
     assert [p["program_type"] for p in park["programs"]] == ["soccer", "swim"]
+    # Program labels are wired through (templates render these).
+    assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swim"]
+    # The actual offerings land under the right program, not just the type list.
+    assert [o["offering_name"] for o in park["programs"][0]["offerings"]] == ["Soccer Camp"]
+    assert [o["offering_name"] for o in park["programs"][1]["offerings"]] == ["Summer Swim"]
+    ymca = payload.new_match_groups[1]
+    assert [p["program_label"] for p in ymca["programs"]] == ["Dance"]
+    assert [o["offering_name"] for o in ymca["programs"][0]["offerings"]] == ["Ballet I"]

--- a/tests/unit/test_email_builders.py
+++ b/tests/unit/test_email_builders.py
@@ -25,6 +25,7 @@ from yas.email.builders import (
     build_site_stagnant,
     build_test_send,
     build_watchlist_hit,
+    gather_digest_payload,
 )
 from yas.email.payloads import (
     CrawlFailedPayload,
@@ -1040,3 +1041,77 @@ async def test_build_test_send_explicit_channel(tmp_path: Any) -> None:
         payload = await build_test_send(s, a, [a])
 
     assert payload.channel == "ntfy"
+
+
+@pytest.mark.asyncio
+async def test_gather_digest_populates_site_name_and_groups(tmp_path: Any) -> None:
+    """Regression: site_name is resolved (was always ''); new_match_groups nests by site->program."""
+    eng = await _engine(tmp_path)
+    async with session_scope(eng) as s:
+        site_a = Site(name="Park District", base_url="https://a.example.com", active=True)
+        site_b = Site(name="YMCA", base_url="https://b.example.com", active=True)
+        s.add_all([site_a, site_b])
+        await s.flush()
+        page_a = Page(site_id=site_a.id, url="https://a.example.com/s", kind=PageKind.schedule)
+        page_b = Page(site_id=site_b.id, url="https://b.example.com/s", kind=PageKind.schedule)
+        s.add_all([page_a, page_b])
+        await s.flush()
+        kid = Kid(name="Ada", dob=date(2017, 1, 1), created_at=NOW - timedelta(days=30))
+        s.add(kid)
+        await s.flush()
+        o1 = Offering(
+            site_id=site_a.id,
+            page_id=page_a.id,
+            name="Soccer Camp",
+            normalized_name="soccer camp",
+            program_type="soccer",
+            start_date=date(2026, 6, 1),
+            price_cents=15000,
+            registration_url="https://a.example.com/r/1",
+        )
+        o2 = Offering(
+            site_id=site_a.id,
+            page_id=page_a.id,
+            name="Summer Swim",
+            normalized_name="summer swim",
+            program_type="swim",
+            start_date=date(2026, 6, 15),
+            price_cents=14000,
+        )
+        o3 = Offering(
+            site_id=site_b.id,
+            page_id=page_b.id,
+            name="Ballet I",
+            normalized_name="ballet i",
+            program_type="dance",
+            start_date=date(2026, 6, 3),
+            price_cents=12000,
+        )
+        s.add_all([o1, o2, o3])
+        await s.flush()
+        s.add_all(
+            [
+                Match(kid_id=kid.id, offering_id=o1.id, score=0.91, computed_at=NOW),
+                Match(kid_id=kid.id, offering_id=o2.id, score=0.80, computed_at=NOW),
+                Match(kid_id=kid.id, offering_id=o3.id, score=0.66, computed_at=NOW),
+            ]
+        )
+        await s.flush()
+
+        payload = await gather_digest_payload(
+            s,
+            kid,
+            window_start=NOW - timedelta(days=1),
+            window_end=NOW + timedelta(hours=1),
+            alert_no_matches_kid_days=7,
+            now=NOW,
+        )
+
+    # Bug fix: site_name is populated on the flat list (previously always "").
+    assert all(m["site_name"] for m in payload.new_matches)
+    # program_type present on every offering dict.
+    assert all("program_type" in m for m in payload.new_matches)
+    # Grouped: Park District (best 0.91) before YMCA (0.66).
+    assert [g["site_name"] for g in payload.new_match_groups] == ["Park District", "YMCA"]
+    park = payload.new_match_groups[0]
+    assert [p["program_type"] for p in park["programs"]] == ["soccer", "swim"]

--- a/tests/unit/test_email_digest_builder.py
+++ b/tests/unit/test_email_digest_builder.py
@@ -16,7 +16,7 @@ from yas.db.models import Alert, Kid, Match, Offering, Page, Site
 from yas.db.models._types import AlertType, PageKind
 from yas.db.session import create_engine_for, session_scope
 from yas.email import render_digest_payload
-from yas.email.builders import gather_digest_payload
+from yas.email.builders import _group_matches_by_site, gather_digest_payload
 from yas.email.payloads import DigestPayload
 
 
@@ -427,22 +427,26 @@ def _empty_payload() -> DigestPayload:
 
 
 def _payload_with_matches() -> DigestPayload:
+    new_matches = [
+        {
+            "offering_id": 10,
+            "offering_name": "Soccer Camp",
+            "score": 0.92,
+            "site_id": 1,
+            "site_name": "City Rec",
+            "program_type": "soccer",
+            "start_date": TODAY + timedelta(days=5),
+            "price_cents": 15000,
+            "registration_opens_at": None,
+            "registration_url": "https://example.com/register",
+        }
+    ]
     return DigestPayload(
         kid_id=1,
         kid_name="Alice",
         for_date=TODAY,
-        new_matches=[
-            {
-                "offering_id": 10,
-                "offering_name": "Soccer Camp",
-                "score": 0.92,
-                "site_name": "City Rec",
-                "start_date": TODAY + timedelta(days=5),
-                "price_cents": 15000,
-                "registration_opens_at": None,
-                "registration_url": "https://example.com/register",
-            }
-        ],
+        new_matches=new_matches,
+        new_match_groups=_group_matches_by_site(new_matches),
     )
 
 

--- a/tests/unit/test_email_grouping.py
+++ b/tests/unit/test_email_grouping.py
@@ -60,3 +60,41 @@ def test_missing_site_name_groups_under_blank():
     groups = _group_matches_by_site([_m(5, "", "art", "Painting", 0.5)])
     assert groups[0]["site_id"] == 5
     assert groups[0]["site_name"] == ""
+
+
+def test_none_program_type_buckets_as_unknown():
+    """An explicit None program_type coerces to 'unknown' / 'Other' (not a crash)."""
+    groups = _group_matches_by_site([_m(1, "Park", None, "Mystery Camp", 0.5)])
+    prog = groups[0]["programs"][0]
+    assert prog["program_type"] == "unknown"
+    assert prog["program_label"] == "Other"
+
+
+def test_absent_program_type_buckets_as_unknown():
+    """A match dict with no program_type key at all also buckets as 'unknown'."""
+    m = {"site_id": 1, "site_name": "Park", "offering_name": "Mystery", "score": 0.5}
+    groups = _group_matches_by_site([m])
+    prog = groups[0]["programs"][0]
+    assert prog["program_type"] == "unknown"
+    assert prog["program_label"] == "Other"
+
+
+def test_offerings_preserve_input_order_within_program():
+    """The helper does NOT re-sort offerings within a program; it preserves the
+    input order (callers pass a score-desc list). This documents the contract."""
+    first = _m(1, "Park", "soccer", "First In", 0.4)
+    second = _m(1, "Park", "soccer", "Second In", 0.9)
+    groups = _group_matches_by_site([first, second])
+    offerings = groups[0]["programs"][0]["offerings"]
+    assert [o["offering_name"] for o in offerings] == ["First In", "Second In"]
+
+
+def test_scoreless_only_program_sorts_after_scored_program():
+    """_score's -inf default sends a program whose offerings all lack scores to
+    the end of the program ordering, without crashing."""
+    scoreless = _m(1, "Park", "art", "Open Studio", 0.0)
+    del scoreless["score"]
+    scored = _m(1, "Park", "soccer", "Soccer Camp", 0.9)
+    # Scoreless program listed first in input to prove the program sort reorders.
+    groups = _group_matches_by_site([scoreless, scored])
+    assert [p["program_type"] for p in groups[0]["programs"]] == ["soccer", "art"]

--- a/tests/unit/test_email_grouping.py
+++ b/tests/unit/test_email_grouping.py
@@ -1,0 +1,62 @@
+"""Pure unit tests for the digest site->program grouping helper."""
+
+from __future__ import annotations
+
+from yas.email.builders import _group_matches_by_site, _program_label
+
+
+def _m(site_id, site_name, program_type, name, score):
+    return {
+        "offering_id": hash((site_id, name)) & 0xFFFF,
+        "offering_name": name,
+        "site_id": site_id,
+        "site_name": site_name,
+        "program_type": program_type,
+        "score": score,
+        "start_date": None,
+        "price_cents": None,
+        "registration_opens_at": None,
+        "registration_url": None,
+    }
+
+
+def test_program_label_titlecases_and_maps_unknown():
+    assert _program_label("soccer") == "Soccer"
+    assert _program_label("martial_arts") == "Martial Arts"
+    assert _program_label("unknown") == "Other"
+
+
+def test_groups_by_site_then_program():
+    # Flat list, already score-sorted desc (as gather_digest_payload produces).
+    matches = [
+        _m(1, "Park District", "soccer", "Soccer Camp", 0.91),
+        _m(1, "Park District", "swim", "Summer Swim", 0.80),
+        _m(1, "Park District", "soccer", "Lil Kickers", 0.74),
+        _m(2, "YMCA", "dance", "Ballet I", 0.66),
+    ]
+    groups = _group_matches_by_site(matches)
+
+    # Two sites, ordered by best score desc: Park District (0.91) then YMCA (0.66).
+    assert [g["site_name"] for g in groups] == ["Park District", "YMCA"]
+
+    park = groups[0]
+    # Programs ordered by their best offering's score: soccer (0.91) before swim (0.80).
+    assert [p["program_type"] for p in park["programs"]] == ["soccer", "swim"]
+    assert [p["program_label"] for p in park["programs"]] == ["Soccer", "Swim"]
+    # Offerings within soccer ordered by score desc.
+    soccer = park["programs"][0]
+    assert [o["offering_name"] for o in soccer["offerings"]] == ["Soccer Camp", "Lil Kickers"]
+
+    ymca = groups[1]
+    assert ymca["site_id"] == 2
+    assert [p["program_type"] for p in ymca["programs"]] == ["dance"]
+
+
+def test_empty_list_returns_empty():
+    assert _group_matches_by_site([]) == []
+
+
+def test_missing_site_name_groups_under_blank():
+    groups = _group_matches_by_site([_m(5, "", "art", "Painting", 0.5)])
+    assert groups[0]["site_id"] == 5
+    assert groups[0]["site_name"] == ""

--- a/tests/unit/test_email_render_pair.py
+++ b/tests/unit/test_email_render_pair.py
@@ -105,3 +105,13 @@ def test_offering_row_default_includes_site(variant: str) -> None:
     tpl = env.from_string(f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m) }}}}')
     out = tpl.render(m=_offering(site_name="Park District", score=0.9))
     assert "Park District" in out
+
+
+@pytest.mark.parametrize("variant", ["html", "text"])
+def test_offering_row_includes_registration_url(variant: str) -> None:
+    """Both row variants surface the registration link (text digests rely on this
+    after adopting offering_row_text in the grouped New Matches section)."""
+    macro = f"offering_row_{variant}"
+    tpl = env.from_string(f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m) }}}}')
+    out = tpl.render(m=_offering(registration_url="https://e.example.com/r/42"))
+    assert "https://e.example.com/r/42" in out

--- a/tests/unit/test_email_render_pair.py
+++ b/tests/unit/test_email_render_pair.py
@@ -87,3 +87,21 @@ def test_offering_row_macro_renders_score_when_present(variant: str) -> None:
     tpl = env.from_string(f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m) }}}}')
     out = tpl.render(m=_offering(score=0.91))
     assert "score 0.91" in out
+
+
+@pytest.mark.parametrize("variant", ["html", "text"])
+def test_offering_row_show_site_false_omits_site(variant: str) -> None:
+    macro = f"offering_row_{variant}"
+    tpl = env.from_string(
+        f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m, show_site=false) }}}}'
+    )
+    out = tpl.render(m=_offering(site_name="Park District", score=0.9))
+    assert "Park District" not in out
+
+
+@pytest.mark.parametrize("variant", ["html", "text"])
+def test_offering_row_default_includes_site(variant: str) -> None:
+    macro = f"offering_row_{variant}"
+    tpl = env.from_string(f'{{% from "macros.j2" import {macro} %}}{{{{ {macro}(m) }}}}')
+    out = tpl.render(m=_offering(site_name="Park District", score=0.9))
+    assert "Park District" in out


### PR DESCRIPTION
## Summary

The daily digest's **New Matches** section now groups activities by **site → program type → activity**, instead of a flat list. It also fixes a latent bug: `gather_digest_payload` never resolved site names (it passed `site_name=""`), so the digest showed activities with no source attribution at all.

Before:
```
New Matches (3)
• Soccer Camp · Jun 1 · $150 · score 0.91 · Register
• Summer Swim · Jun 15 · $140 · score 0.80 · Register
• Ballet I · Jun 3 · $120 · score 0.66 · Register
```

After:
```
New Matches (3)
Park District
  Soccer
    • Soccer Camp · Jun 1 · $150 · score 0.91 · Register
  Swim
    • Summer Swim · Jun 15 · $140 · score 0.80 · Register
YMCA
  Dance
    • Ballet I · Jun 3 · $120 · score 0.66 · Register
```

## What changed

- **`_group_matches_by_site` helper** (`yas.email.builders`): pure reorganization of the existing score-sorted match list into site → program → offerings. Sites ordered by their best match score; programs by best score within site; activities by score. No second query.
- **Site-name bug fix:** `gather_digest_payload` now batch-resolves `site_id → name` (one `select(Site)`) and populates `site_name` on each new-match dict. Adds `program_type` to the offering dict for the inner grouping key.
- **`new_match_groups`** derived field on `DigestPayload`, built at construction from the flat `new_matches` list (shared dict objects — one source of truth). The flat list is unchanged and still drives the header count, the empty-day skip, and the LLM top-line.
- **`show_site` flag** on `offering_row_html`/`offering_row_text` (default `true`, all existing callers unaffected). The grouped digest passes `show_site=false` so rows don't repeat the site that's already in the header.
- **Templates:** `digest.html.j2` / `digest.txt.j2` New Matches sections render the grouping. Other sections (Starting Soon, Registration Opens, Delivery Issues, empty/under-threshold) are untouched.

## Scope

Only the **New Matches** section is grouped. Starting Soon and Registration Opens stay flat — they're deliberately time-ordered, and grouping by site would fight that. The `empty` and `under_threshold` digest goldens are byte-identical.

## One behavior change beyond grouping

The digest **text** rows previously used a hand-rolled inline format that omitted the registration URL. Switching them to the shared `offering_row_text` macro (for DRYness and `show_site` support) means **text digests now include the per-row registration link** — a small intentional improvement. The `with_matches.txt` golden reflects this.

## Test Plan

- [x] `_group_matches_by_site` unit tests: ordering (site/program/activity), empty list, missing site name, label mapping (`unknown` → "Other")
- [x] Builder test: `site_name` populated (bug regression guard) + `new_match_groups` nesting, asserted on the real `gather_digest_payload` path
- [x] Macro test: `show_site=false` omits site, default includes it (both html + text)
- [x] Golden snapshots: re-baselined `with_matches`, new `multi_site` (2 sites × program types), both `.txt` and `.html`
- [x] Full suite 748 passed; ruff + `ruff format --check` + mypy clean

Spec: `docs/superpowers/specs/2026-05-20-digest-site-program-grouping-design.md`
Plan: `docs/superpowers/plans/2026-05-20-digest-site-program-grouping.md`

## Summary by Sourcery

Group the daily digest email’s New Matches section by site and program type while fixing missing site names and updating templates and tests accordingly.

New Features:
- Introduce a grouped digest structure that organizes new matches by site, then program type, then activity while preserving score-based ordering.
- Add a derived new_match_groups field to the digest payload for use by email templates without changing existing flat new_matches semantics.
- Add an optional show_site flag to email offering-row macros so rows can omit redundant site names in grouped contexts.

Bug Fixes:
- Resolve and populate site names for new-match offerings in the digest builder so activities are no longer rendered without source attribution.

Enhancements:
- Include program_type on offering dicts and derive human-friendly program labels for use in grouped digest views.
- Update HTML and text digest templates to render the new grouped New Matches layout and reuse shared row macros, improving consistency and adding registration links to text digests.
- Add a pure helper to group matches by site and program type, with comprehensive unit tests covering ordering and labeling.
- Extend digest builder tests to validate site-name resolution, grouping structure, and ordering across multiple sites and program types.
- Add tests for the new show_site macro behavior and re-baseline existing and new digest golden snapshots, including a multi-site scenario.

Documentation:
- Add design and implementation plan documents describing the digest site/program grouping behavior, architecture, and rollout steps.

Tests:
- Introduce new unit tests for match grouping, digest builder behavior, and template macros, plus new and updated golden email snapshots for single-site and multi-site digests.