### PR TITLE
Eliminate yas-migrate container: apply migrations on startup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,5 @@ repos:
     rev: v1.50.4
     hooks:
       - id: ggshield
-        # Scans staged changes for secrets before commit. Free for individuals
-        # (1000 commits/month). Repo is public, so we also rely on GitHub
-        # native secret scanning + push protection for defence-in-depth.
         language_version: python3
         stages: [pre-commit]
-        # ggshield decides what to scan internally (staged ranges); don't
-        # let pre-commit pass file paths as CLI args.
-        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ uv sync
 cp .env.example .env
 echo "YAS_ANTHROPIC_API_KEY=sk-ant-…" >> .env
 mkdir -p data
-uv run alembic upgrade head
 uv run python -m yas all
 ```
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -34,8 +34,18 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-settings = get_settings()
-config.set_main_option("sqlalchemy.url", settings.database_url)
+# Prefer a URL explicitly injected by a programmatic caller (e.g.
+# yas.db.migrations) via config.attributes["sqlalchemy.url"]; fall back
+# to settings for `alembic …` CLI invocations.
+#
+# The propagation step (set_main_option) is required because Alembic's
+# runners read sqlalchemy.url from the INI section, not from attributes.
+# alembic.ini hardcodes a default URL, so we cannot gate on get_main_option.
+if "sqlalchemy.url" in config.attributes:
+    config.set_main_option("sqlalchemy.url", config.attributes["sqlalchemy.url"])
+else:
+    settings = get_settings()
+    config.set_main_option("sqlalchemy.url", settings.database_url)
 
 target_metadata = Base.metadata
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,8 +17,6 @@ x-build: &yas-build
   image: yas-local:dev   # local-only tag; not pushed
 
 services:
-  yas-migrate:
-    <<: *yas-build
   yas-worker:
     <<: *yas-build
   yas-api:

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -14,10 +14,6 @@
 #       exec yas-api sqlite3 /data/activities.db '.tables'
 
 services:
-  yas-migrate:
-    volumes:
-      - yas-data:/data
-
   yas-worker:
     volumes:
       - yas-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,33 +2,16 @@ x-image: &yas-image
   image: ghcr.io/owine/youth-activity-scheduler:latest
 
 services:
-  yas-migrate:
-    <<: *yas-image
-    command: ["uv", "run", "alembic", "upgrade", "head"]
-    env_file: .env
-    volumes:
-      - ./data:/data
-    restart: "no"
-    # The Dockerfile's baked HEALTHCHECK probes localhost:8080/healthz, which
-    # only makes sense for the API service. This container is a one-shot
-    # alembic runner — disable the inherited check so it doesn't report
-    # "unhealthy" before exiting.
-    healthcheck:
-      disable: true
-
   yas-worker:
     <<: *yas-image
     command: ["python", "-m", "yas", "worker"]
     env_file: .env
     volumes:
       - ./data:/data
-    depends_on:
-      yas-migrate:
-        condition: service_completed_successfully
     restart: unless-stopped
-    # Same reason as yas-migrate: the worker doesn't run an HTTP server, so
-    # the inherited Dockerfile HEALTHCHECK fails forever and breaks
-    # `depends_on: service_healthy` chains in deploy scripts.
+    # Disable the inherited Dockerfile HEALTHCHECK: this container doesn't
+    # run an HTTP server, so the curl probe would fail forever and break
+    # `depends_on: service_healthy` chains.
     healthcheck:
       disable: true
 
@@ -41,8 +24,6 @@ services:
     volumes:
       - ./data:/data
     depends_on:
-      yas-migrate:
-        condition: service_completed_successfully
       yas-worker:
         condition: service_started
     restart: unless-stopped

--- a/docs/superpowers/plans/2026-05-24-eliminate-migrate-container.md
+++ b/docs/superpowers/plans/2026-05-24-eliminate-migrate-container.md
@@ -1,0 +1,570 @@
+# Eliminate `yas-migrate` Container — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the `yas-migrate` one-shot service from compose by having every yas process apply Alembic migrations on startup.
+
+**Architecture:** A new `yas.db.migrations.upgrade_to_head(database_url)` helper invokes `alembic.command.upgrade` programmatically. It's called from `src/yas/__main__.py` after logging is configured and before the SQLAlchemy engine is created, for every CLI mode (`api`, `worker`, `all`, plus a new `migrate` mode). SQLite's OS-level file lock serializes the rare race between api and worker booting in parallel.
+
+**Tech Stack:** Python 3.14, Alembic, SQLAlchemy + aiosqlite, FastAPI, Docker Compose.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-eliminate-migrate-container-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/yas/db/migrations.py` — `upgrade_to_head(database_url)` helper
+- `tests/unit/test_db_migrations.py` — unit tests for the helper
+
+**Modified files:**
+- `alembic/env.py` — respect a pre-set `sqlalchemy.url` instead of always overwriting from settings (so the helper can pass a tmp URL during tests)
+- `src/yas/__main__.py` — add `"migrate"` mode, call `upgrade_to_head` at the top of `main()`
+- `docker-compose.yml` — delete `yas-migrate` service, drop `depends_on` edges
+- `docker-compose.dev.yml` — drop `yas-migrate` override block
+- `docker-compose.macos.yml` — drop `yas-migrate` volume override block
+- `scripts/smoke_phase2.sh` — replace `up -d yas-migrate` with comment+drop
+- `scripts/smoke_phase3.sh` — same
+- `scripts/smoke_phase3_5.sh` — same
+- `scripts/smoke_phase4.sh` — same
+- `scripts/e2e_phase5a.sh` — same, and drop from `build` line
+- `README.md` — remove `uv run alembic upgrade head` from Quickstart
+
+**Untouched:**
+- `Dockerfile` (alembic.ini and alembic/ already copied in)
+- `alembic.ini`, `alembic/versions/*` (no migration content changes)
+- `docker-compose.smoke.yml` (verified: no `yas-migrate` reference)
+
+---
+
+## Task 1: Add `alembic/env.py` URL-override gate
+
+This is a prerequisite. Today `env.py` unconditionally sets `sqlalchemy.url` from `get_settings()`, which would clobber any URL a programmatic caller (the new helper) tries to pass in. We make the assignment conditional: if the caller has already set a URL on the Config, use it; otherwise fall back to settings (preserves today's `alembic` CLI behavior).
+
+**Files:**
+- Modify: `alembic/env.py:34-37`
+
+- [ ] **Step 1: Read current `alembic/env.py`**
+
+Just read it. No edit yet.
+
+- [ ] **Step 2: Replace the settings-URL assignment with a conditional**
+
+Find:
+
+```python
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database_url)
+```
+
+Replace with:
+
+```python
+# Prefer a URL set by a programmatic caller (e.g. yas.db.migrations);
+# fall back to settings for `alembic …` CLI invocations.
+if not config.get_main_option("sqlalchemy.url"):
+    settings = get_settings()
+    config.set_main_option("sqlalchemy.url", settings.database_url)
+```
+
+- [ ] **Step 3: Verify the CLI path still works**
+
+Run from repo root with a throwaway DB:
+
+```bash
+YAS_DATABASE_URL=sqlite+aiosqlite:///$(mktemp -u --suffix=.db) uv run alembic upgrade head
+```
+
+Expected: alembic runs the migrations to head and exits 0. (You can ignore the "no such file" warning if the temp path is unwritable; just point at `data/test.db`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/env.py
+git commit -m "refactor(alembic): respect pre-set sqlalchemy.url in env.py
+
+Allows programmatic callers to pass a URL via Config.set_main_option
+without it being overwritten by settings."
+```
+
+---
+
+## Task 2: Add `upgrade_to_head` helper with tests
+
+**Files:**
+- Create: `src/yas/db/migrations.py`
+- Create: `tests/unit/test_db_migrations.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_db_migrations.py`:
+
+```python
+"""Tests for yas.db.migrations.upgrade_to_head."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from yas.db.migrations import upgrade_to_head
+
+
+def test_upgrade_to_head_creates_tables(tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+
+    upgrade_to_head(url)
+
+    # Sanity-check that at least one expected table exists. We don't enumerate
+    # all of them — that's coupling the test to the current schema. Pick a
+    # table that has existed since the very first migration.
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "select name from sqlite_master where type='table' and name='sites'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [("sites",)]
+
+
+def test_upgrade_to_head_is_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+
+    upgrade_to_head(url)
+    upgrade_to_head(url)  # second call should be a no-op, not raise
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_db_migrations.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'yas.db.migrations'`
+
+- [ ] **Step 3: Implement `upgrade_to_head`**
+
+Create `src/yas/db/migrations.py`:
+
+```python
+"""Programmatic Alembic runner used at process startup.
+
+Every yas process calls `upgrade_to_head` before opening the SQLAlchemy
+engine, replacing the dedicated `yas-migrate` compose service.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from yas.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def _find_alembic_ini() -> Path:
+    """Locate alembic.ini.
+
+    The package can be installed editable (file lives under src/yas/db/) or
+    non-editable into site-packages (file lives under .venv/.../yas/db/).
+    Repo-root layout and image layout both put alembic.ini next to a top-level
+    directory we can find by walking up from CWD. Prefer CWD because the image
+    sets WORKDIR /app and the repo's pytest runs from the repo root.
+    """
+    cwd_candidate = Path.cwd() / "alembic.ini"
+    if cwd_candidate.is_file():
+        return cwd_candidate
+    # Fallback: walk up from this file looking for alembic.ini. Handles the
+    # less common case where CWD doesn't contain it.
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "alembic.ini"
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError("alembic.ini not found from CWD or via parent walk")
+
+
+def upgrade_to_head(database_url: str) -> None:
+    """Apply pending Alembic migrations against `database_url`.
+
+    Idempotent: a no-op when the database is already at head.
+    """
+    cfg = Config(str(_find_alembic_ini()))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    log.info("migrations.start", url=database_url)
+    command.upgrade(cfg, "head")
+    log.info("migrations.done")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_db_migrations.py -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/yas/db/migrations.py tests/unit/test_db_migrations.py
+git commit -m "feat(db): add upgrade_to_head helper
+
+Programmatic Alembic runner that every yas process will call on
+startup, removing the need for a dedicated migrate container."
+```
+
+---
+
+## Task 3: Wire migrations into the CLI entrypoint
+
+Add `"migrate"` as a CLI mode and call `upgrade_to_head` at the top of `main()` so every mode applies migrations before doing real work.
+
+**Files:**
+- Modify: `src/yas/__main__.py`
+
+- [ ] **Step 1: Add `"migrate"` to the mode choices**
+
+In `build_parser()`, change the `choices` list from:
+
+```python
+choices=["api", "worker", "all"],
+```
+
+to:
+
+```python
+choices=["api", "worker", "all", "migrate"],
+```
+
+Update the `help` string to mention `migrate` (e.g. `"migrate (apply schema only and exit)"`).
+
+- [ ] **Step 2: Call `upgrade_to_head` in `main()`**
+
+In `main()`, **after** the `log = get_logger("yas.main")` line (so `log` is bound) and **before** the `engine = create_engine_for(...)` line, add:
+
+```python
+from yas.db.migrations import upgrade_to_head
+
+upgrade_to_head(settings.database_url)
+
+if args.mode == "migrate":
+    log.info("mode.migrate.done")
+    return 0
+```
+
+The early-return for `"migrate"` short-circuits before the engine is created or any mode branch runs.
+
+- [ ] **Step 3: Smoke-test the new mode locally**
+
+```bash
+rm -f /tmp/yas-test.db
+YAS_DATABASE_URL=sqlite+aiosqlite:////tmp/yas-test.db \
+  YAS_ANTHROPIC_API_KEY=sk-test \
+  uv run python -m yas migrate
+```
+
+Expected: process exits 0, logs show `migrations.start` then `migrations.done` then `mode.migrate.done`. The file `/tmp/yas-test.db` exists and contains the schema.
+
+Verify with:
+
+```bash
+sqlite3 /tmp/yas-test.db '.tables'
+```
+
+Expected: lists the schema tables (sites, offerings, kids, etc.).
+
+- [ ] **Step 4: Run the full test suite to catch regressions**
+
+```bash
+uv run pytest -x
+```
+
+Expected: all tests pass. (No existing tests exercise `__main__`'s mode branches; the new migration call is gated behind the CLI entry, so unit tests are unaffected.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/yas/__main__.py
+git commit -m "feat(cli): run migrations on every startup; add migrate mode
+
+Every yas process now applies pending Alembic migrations before
+opening the engine. The new 'migrate' mode applies and exits.
+This is the prerequisite for removing the yas-migrate compose
+service in the next commit."
+```
+
+---
+
+## Task 4: Remove `yas-migrate` from compose files
+
+**Files:**
+- Modify: `docker-compose.yml` — delete `yas-migrate` service block (lines ~4-15) and the two `yas-migrate: condition: service_completed_successfully` entries in `yas-worker` and `yas-api` `depends_on`.
+- Modify: `docker-compose.dev.yml` — delete the `yas-migrate: <<: *yas-build` line.
+- Modify: `docker-compose.macos.yml` — delete the `yas-migrate:` volume override block.
+
+- [ ] **Step 1: Edit `docker-compose.yml`**
+
+Delete the entire `yas-migrate:` service block (the first service under `services:`).
+
+In `yas-worker`, change:
+
+```yaml
+    depends_on:
+      yas-migrate:
+        condition: service_completed_successfully
+```
+
+to: delete those lines entirely. `yas-worker` should have no `depends_on:` key after this edit.
+
+In `yas-api`, change:
+
+```yaml
+    depends_on:
+      yas-migrate:
+        condition: service_completed_successfully
+      yas-worker:
+        condition: service_started
+```
+
+to:
+
+```yaml
+    depends_on:
+      yas-worker:
+        condition: service_started
+```
+
+(Keep the `yas-api → yas-worker` edge — the spec preserves it.)
+
+Also remove the stale comment in `yas-worker` that begins `# Same reason as yas-migrate:` and rewrite it to stand on its own (or delete it — the disabled healthcheck no longer needs justification by analogy).
+
+- [ ] **Step 2: Edit `docker-compose.dev.yml`**
+
+Delete the two lines:
+
+```yaml
+  yas-migrate:
+    <<: *yas-build
+```
+
+- [ ] **Step 3: Edit `docker-compose.macos.yml`**
+
+Delete the block:
+
+```yaml
+  yas-migrate:
+    volumes:
+      - yas-data:/data
+```
+
+- [ ] **Step 4: Validate compose syntax**
+
+```bash
+docker compose -f docker-compose.yml config > /dev/null
+docker compose -f docker-compose.yml -f docker-compose.dev.yml config > /dev/null
+docker compose -f docker-compose.yml -f docker-compose.macos.yml config > /dev/null
+```
+
+Expected: all three commands exit 0 with no output. (They print the resolved compose and discard it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml docker-compose.dev.yml docker-compose.macos.yml
+git commit -m "chore(compose): remove yas-migrate service
+
+API and worker now apply migrations on startup themselves. The
+dedicated migrate one-shot is no longer needed."
+```
+
+---
+
+## Task 5: Update shell scripts that referenced `yas-migrate`
+
+The smoke and e2e scripts bring `yas-migrate` up explicitly. Now that the service is gone, those lines must be removed; the api/worker services will migrate themselves on startup.
+
+**Files:**
+- Modify: `scripts/smoke_phase2.sh:17-18`
+- Modify: `scripts/smoke_phase3.sh:16`
+- Modify: `scripts/smoke_phase3_5.sh:16`
+- Modify: `scripts/smoke_phase4.sh:17`
+- Modify: `scripts/e2e_phase5a.sh:13-14`
+
+- [ ] **Step 1: Edit `scripts/smoke_phase2.sh`**
+
+Replace:
+
+```bash
+docker compose up -d yas-migrate
+docker compose logs yas-migrate | tail -5
+docker compose up -d yas-worker yas-api
+```
+
+with:
+
+```bash
+# yas-worker and yas-api apply migrations themselves on startup.
+docker compose up -d yas-worker yas-api
+```
+
+- [ ] **Step 2: Edit `scripts/smoke_phase3.sh`**
+
+Replace:
+
+```bash
+$COMPOSE up -d yas-migrate
+$COMPOSE up -d yas-worker yas-api
+```
+
+with:
+
+```bash
+$COMPOSE up -d yas-worker yas-api
+```
+
+- [ ] **Step 3: Edit `scripts/smoke_phase3_5.sh`**
+
+Same edit pattern as Step 2 — remove the `$COMPOSE up -d yas-migrate` line.
+
+- [ ] **Step 4: Edit `scripts/smoke_phase4.sh`**
+
+Same edit pattern as Step 2 — remove the `$COMPOSE up -d yas-migrate` line.
+
+- [ ] **Step 5: Edit `scripts/e2e_phase5a.sh`**
+
+Replace:
+
+```bash
+$COMPOSE build yas-api yas-worker yas-migrate
+$COMPOSE up -d yas-migrate
+```
+
+with:
+
+```bash
+$COMPOSE build yas-api yas-worker
+```
+
+- [ ] **Step 6: Quick sanity-check each script for stray references**
+
+```bash
+grep -n yas-migrate scripts/*.sh
+```
+
+Expected: no output (no remaining references in scripts).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/smoke_phase2.sh scripts/smoke_phase3.sh scripts/smoke_phase3_5.sh scripts/smoke_phase4.sh scripts/e2e_phase5a.sh
+git commit -m "chore(scripts): drop yas-migrate references from smoke/e2e
+
+Worker and api migrate themselves on startup now."
+```
+
+---
+
+## Task 6: Update README Quickstart
+
+The Quickstart says to run `uv run alembic upgrade head` before `python -m yas all`. That line is now redundant — `python -m yas all` will migrate.
+
+**Files:**
+- Modify: `README.md:66`
+
+- [ ] **Step 1: Delete the `uv run alembic upgrade head` line in Quickstart**
+
+Find the Quickstart block:
+
+```bash
+uv sync
+cp .env.example .env
+echo "YAS_ANTHROPIC_API_KEY=sk-ant-…" >> .env
+mkdir -p data
+uv run alembic upgrade head
+uv run python -m yas all
+```
+
+Delete the `uv run alembic upgrade head` line.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: drop manual alembic step from Quickstart
+
+python -m yas all now applies migrations itself on startup."
+```
+
+---
+
+## Task 7: End-to-end verification
+
+Confirm the assembled change actually boots and works.
+
+- [ ] **Step 1: Run the unit suite**
+
+```bash
+uv run pytest -x
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Boot the dev compose stack against a fresh DB**
+
+```bash
+rm -f data/activities.db data/activities.db-shm data/activities.db-wal
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+sleep 15
+docker compose ps
+```
+
+Expected: `yas-api` and `yas-worker` both `running` (healthy or starting); no `yas-migrate` service listed.
+
+- [ ] **Step 3: Confirm schema applied**
+
+```bash
+docker compose exec yas-api sqlite3 /data/activities.db '.tables'
+```
+
+Expected: lists all schema tables (sites, offerings, kids, alerts, etc.).
+
+- [ ] **Step 4: Confirm `/healthz` returns 200**
+
+```bash
+curl -fsS localhost:8080/healthz | jq .
+```
+
+Expected: 200 OK response.
+
+- [ ] **Step 5: Check the api logs for the migration banner**
+
+```bash
+docker compose logs yas-api | grep -E 'migrations\.(start|done)'
+```
+
+Expected: one `migrations.start` and one `migrations.done` line near the top of api startup.
+
+- [ ] **Step 6: Bring the stack down**
+
+```bash
+docker compose down
+```
+
+- [ ] **Step 7: (No commit — this task is verification only.)**
+
+If anything failed in steps 1-5, return to the relevant earlier task and fix before continuing.
+
+---
+
+## Out of Scope (do not do as part of this plan)
+
+- Migrating off SQLite.
+- Adding a `--skip-migrations` flag.
+- Updating historical references to `yas-migrate` inside `docs/superpowers/plans/2026-04-*.md` and `docs/superpowers/specs/2026-04-*.md` — those are historical artifacts of completed phases and should remain accurate to the topology of their time.
+- Migration rollback / `downgrade` tooling.

--- a/docs/superpowers/specs/2026-05-24-eliminate-migrate-container-design.md
+++ b/docs/superpowers/specs/2026-05-24-eliminate-migrate-container-design.md
@@ -1,0 +1,128 @@
+# Eliminate the `yas-migrate` Container
+
+**Date:** 2026-05-24
+**Status:** Approved (pending spec review)
+
+## Problem
+
+The `docker-compose.yml` topology currently includes three services:
+
+- `yas-migrate` — one-shot container that runs `alembic upgrade head` and exits
+- `yas-worker` — long-running crawl + alert worker, `depends_on: yas-migrate`
+- `yas-api` — FastAPI server, `depends_on: yas-migrate` and `yas-worker`
+
+`yas-migrate` exists only to apply schema changes before either long-running
+process opens the database. It adds a service to the topology and a dependency
+edge to two others, but has no runtime responsibility once it exits.
+
+The goal of this change is to **remove `yas-migrate`** and have every yas
+process apply pending migrations on its own startup.
+
+## Non-goals
+
+- Switching off SQLite.
+- Migration rollback / auto-downgrade tooling.
+- A `--skip-migrations` flag.
+- Changing the topology beyond removing one service and its `depends_on` edges.
+
+## Constraints
+
+- **Database:** SQLite at `/data/activities.db` on a shared bind mount. File-level
+  OS locking serializes concurrent writers.
+- **Topology:** api and worker run as separate containers on the same host,
+  sharing the SQLite volume.
+- **Image:** `alembic.ini` and the `alembic/` directory are already baked into
+  the image and used today by `yas-migrate`'s `uv run alembic upgrade head`
+  command.
+
+## Design
+
+### Architecture
+
+Every yas process — `api`, `worker`, `all`, and a new `migrate` mode — calls
+`alembic upgrade head` programmatically at the top of `main()`, after
+`configure_logging` and **before** the SQLAlchemy engine is created.
+
+Concurrency between processes is handled by SQLite's OS-level file lock:
+whichever process acquires the lock first applies the pending revisions; the
+loser sees no pending revisions and is a no-op.
+
+If migrations fail, the process exits non-zero before opening the engine or
+starting uvicorn. Same blast radius as a failed `yas-migrate` container today,
+just located in the api/worker process.
+
+### Components
+
+**New code**
+
+- `src/yas/db/migrations.py` — single function:
+
+  ```python
+  def upgrade_to_head(database_url: str) -> None:
+      """Apply pending Alembic migrations against `database_url`.
+
+      Idempotent — a no-op when the DB is already at head.
+      """
+  ```
+
+  Implementation: builds an `alembic.config.Config` pointing at the bundled
+  `alembic.ini`, overrides `sqlalchemy.url` via `cfg.set_main_option`, calls
+  `alembic.command.upgrade(cfg, "head")`. Logs the resolved revision before
+  and after so dev/prod logs are diagnosable.
+
+**Modified code**
+
+- `src/yas/__main__.py`:
+  - Add `"migrate"` to the `mode` `choices`.
+  - After `configure_logging(...)` and before `create_engine_for(...)`, call
+    `upgrade_to_head(settings.database_url)`.
+  - If `mode == "migrate"`, return 0 after migrations apply (no engine, no
+    uvicorn, no worker).
+
+**Removed / changed infra**
+
+- `docker-compose.yml` — delete the `yas-migrate` service. Remove the
+  `depends_on: yas-migrate` from `yas-worker` and `yas-api`. The
+  `yas-worker → yas-migrate` and `yas-api → yas-migrate` edges go away;
+  `yas-api → yas-worker` stays as-is (api still waits for worker to start).
+- `docker-compose.dev.yml`, `docker-compose.macos.yml`,
+  `docker-compose.smoke.yml` — audit and apply the same removal if they
+  reference `yas-migrate`.
+- `Dockerfile` — no change.
+
+### Why every mode, not just api?
+
+A "single designated owner" design (only `api` migrates; worker waits on
+`/healthz`) was considered and rejected:
+
+- Couples worker boot to api availability, which doesn't reflect the actual
+  data dependency (worker needs the schema, not the API process).
+- A developer running `python -m yas worker` directly during local
+  development would skip migrations.
+- The SQLite file lock already makes "everyone migrates" safe, so the extra
+  ordering constraint buys nothing.
+
+### Why programmatic Alembic, not a shell wrapper?
+
+A `entrypoint.sh` that runs `alembic upgrade head && exec python -m yas $mode`
+was considered. Rejected because it adds a shell layer and a second place
+where the migration step lives, without any benefit over calling Alembic from
+Python.
+
+## Testing
+
+- **Unit:** `upgrade_to_head` against a fresh tmp SQLite URL — assert tables
+  created. Call it again on the same URL — assert no-op (idempotency).
+- **Smoke:** existing `docker-compose.smoke.yml` boot flow should pass with
+  `yas-migrate` removed.
+- **Skipped:** no concurrent-upgrade test. SQLite lock behavior is a
+  library-level guarantee; testing it here would be theater.
+
+## Rollout
+
+Single PR. Backward compatible for any operator pulling the new image with
+their existing compose file — the old `yas-migrate` service still works
+(its command becomes redundant, not broken).
+
+Update `README.md` deployment section if it references `yas-migrate`
+(needs a grep to confirm).

--- a/scripts/e2e_phase5a.sh
+++ b/scripts/e2e_phase5a.sh
@@ -10,8 +10,7 @@ COMPOSE="docker compose -f docker-compose.yml"
 [ "$(uname)" = "Darwin" ] && COMPOSE="$COMPOSE -f docker-compose.macos.yml"
 
 $COMPOSE down -v 2>/dev/null || true
-$COMPOSE build yas-api yas-worker yas-migrate
-$COMPOSE up -d yas-migrate
+$COMPOSE build yas-api yas-worker
 $COMPOSE up -d yas-worker yas-api
 sleep 8
 

--- a/scripts/smoke_phase2.sh
+++ b/scripts/smoke_phase2.sh
@@ -14,8 +14,7 @@ if ! grep -q '^YAS_ANTHROPIC_API_KEY=sk-' .env 2>/dev/null || grep -q '^YAS_ANTH
 fi
 
 rm -f data/activities.db data/activities.db-shm data/activities.db-wal
-docker compose up -d yas-migrate
-docker compose logs yas-migrate | tail -5
+# yas-worker and yas-api apply migrations themselves on startup.
 docker compose up -d yas-worker yas-api
 sleep 10
 

--- a/scripts/smoke_phase3.sh
+++ b/scripts/smoke_phase3.sh
@@ -13,7 +13,6 @@ if [ "$(uname)" = "Darwin" ]; then
 fi
 
 $COMPOSE down 2>/dev/null || true
-$COMPOSE up -d yas-migrate
 $COMPOSE up -d yas-worker yas-api
 sleep 10
 

--- a/scripts/smoke_phase3_5.sh
+++ b/scripts/smoke_phase3_5.sh
@@ -13,7 +13,6 @@ if [ "$(uname)" = "Darwin" ]; then
 fi
 
 $COMPOSE down 2>/dev/null || true
-$COMPOSE up -d yas-migrate
 $COMPOSE up -d yas-worker yas-api
 sleep 10
 

--- a/scripts/smoke_phase4.sh
+++ b/scripts/smoke_phase4.sh
@@ -14,7 +14,6 @@ fi
 COMPOSE="$COMPOSE -f docker-compose.smoke.yml"
 
 $COMPOSE down 2>/dev/null || true
-$COMPOSE up -d yas-migrate
 $COMPOSE up -d yas-worker yas-api
 sleep 10
 

--- a/src/yas/__main__.py
+++ b/src/yas/__main__.py
@@ -20,8 +20,8 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="yas", description="Youth Activity Scheduler")
     p.add_argument(
         "mode",
-        choices=["api", "worker", "all"],
-        help="which process to run: api (FastAPI), worker (crawler+alerts), all (both)",
+        choices=["api", "worker", "all", "migrate"],
+        help="which process to run: api (FastAPI), worker (crawler+alerts), all (both), migrate (apply schema and exit)",
     )
     return p
 
@@ -70,6 +70,15 @@ def main(argv: list[str] | None = None) -> int:
     settings = get_settings()
     configure_logging(level=settings.log_level)
     log = get_logger("yas.main")
+
+    from yas.db.migrations import upgrade_to_head
+
+    upgrade_to_head(settings.database_url)
+
+    if args.mode == "migrate":
+        log.info("mode.migrate.done")
+        return 0
+
     engine = create_engine_for(settings.database_url)
 
     if args.mode == "api":

--- a/src/yas/db/migrations.py
+++ b/src/yas/db/migrations.py
@@ -1,0 +1,52 @@
+"""Programmatic Alembic runner used at process startup.
+
+Every yas process calls `upgrade_to_head` before opening the SQLAlchemy
+engine, replacing the dedicated `yas-migrate` compose service.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from yas.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def _find_alembic_ini() -> Path:
+    """Locate alembic.ini.
+
+    The package can be installed editable (file lives under src/yas/db/) or
+    non-editable into site-packages (file lives under .venv/.../yas/db/).
+    Repo-root layout and image layout both put alembic.ini next to a top-level
+    directory we can find by walking up from CWD. Prefer CWD because the image
+    sets WORKDIR /app and the repo's pytest runs from the repo root.
+    """
+    cwd_candidate = Path.cwd() / "alembic.ini"
+    if cwd_candidate.is_file():
+        return cwd_candidate
+    # Fallback: walk up from this file looking for alembic.ini. Handles the
+    # less common case where CWD doesn't contain it.
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "alembic.ini"
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError("alembic.ini not found from CWD or via parent walk")
+
+
+def upgrade_to_head(database_url: str) -> None:
+    """Apply pending Alembic migrations against `database_url`.
+
+    Idempotent: a no-op when the database is already at head.
+    """
+    cfg = Config(str(_find_alembic_ini()))
+    # Pass URL via attributes — env.py's gate reads it from there and
+    # propagates to set_main_option for both online and offline runners.
+    # See alembic/env.py for the contract.
+    cfg.attributes["sqlalchemy.url"] = database_url
+    log.info("migrations.start", url=database_url)
+    command.upgrade(cfg, "head")
+    log.info("migrations.done")

--- a/tests/unit/test_db_migrations.py
+++ b/tests/unit/test_db_migrations.py
@@ -1,0 +1,51 @@
+"""Tests for yas.db.migrations.upgrade_to_head."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from yas.db.migrations import upgrade_to_head
+
+
+def test_upgrade_to_head_creates_tables(tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+
+    upgrade_to_head(url)
+
+    # Sanity-check that at least one expected table exists. We don't enumerate
+    # all of them — that's coupling the test to the current schema. Pick a
+    # table that has existed since the very first migration.
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "select name from sqlite_master where type='table' and name='sites'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [("sites",)]
+
+
+def test_upgrade_to_head_is_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+
+    upgrade_to_head(url)
+    upgrade_to_head(url)  # second call should be a no-op, not raise
+
+
+def test_upgrade_to_head_uses_fallback_ini(tmp_path, monkeypatch) -> None:
+    # Exercise the parents-walk fallback in _find_alembic_ini. With CWD set
+    # to a directory that has no alembic.ini, the helper must still locate
+    # the repo's alembic.ini by walking up from its own __file__.
+    monkeypatch.chdir(tmp_path)
+    db_path = tmp_path / "test.db"
+    upgrade_to_head(f"sqlite+aiosqlite:///{db_path}")
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "select name from sqlite_master where type='table' and name='sites'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [("sites",)]


### PR DESCRIPTION
## Summary
- Adds `yas.db.migrations.upgrade_to_head(database_url)` and calls it unconditionally at the top of `main()` for every CLI mode (`api`, `worker`, `all`, and a new `migrate`).
- `alembic/env.py` now honors a URL injected by a programmatic caller via `cfg.attributes["sqlalchemy.url"]`, propagating it to `set_main_option` so both online and offline runners use the injected URL. CLI invocations still fall back to `get_settings()`.
- Deletes the `yas-migrate` one-shot service from all compose files and drops the corresponding `depends_on` edges; the `yas-api → yas-worker (service_started)` edge is preserved.
- Updates the manual smoke / e2e shell scripts and the README Quickstart to stop referencing the deleted service / step.

SQLite's file lock serializes the rare race when api and worker both boot in parallel and both try to migrate; the loser sees no pending revisions and is a no-op.

Spec: `docs/superpowers/specs/2026-05-24-eliminate-migrate-container-design.md`
Plan: `docs/superpowers/plans/2026-05-24-eliminate-migrate-container.md`

## Test plan
- [x] `uv run pytest -x` — 758 passed
- [x] All three `docker compose config` validations (`docker-compose.yml`, `+ dev`, `+ macos`) exit 0
- [x] `python -m yas migrate` against a tmp SQLite path applies all 17 schema tables and exits 0; logs show `migrations.start` / `migrations.done` / `mode.migrate.done`
- [x] New unit tests cover helper happy-path, idempotency, and the `_find_alembic_ini` parents-walk fallback
- [ ] Live Docker boot of the dev stack — deferred: blocked by a pre-existing `engines.node` (24.15.0) vs Dockerfile `FROM node:24.16.0-alpine` mismatch causing pnpm to want to recreate `node_modules` with no TTY. Unblocks once the pending `toolchain-versions` Renovate PR lands.

## Follow-ups (not in this PR)
- `.github/workflows/ci.yml` still runs an explicit `uv run alembic upgrade head` before `python -m yas api` in the e2e job. Now redundant (the helper is idempotent so it's harmless), but worth a cleanup pass.