### PR TITLE
ci(e2e): use `python -m yas migrate` instead of alembic CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,12 @@ jobs:
         run: pnpm run build
         working-directory: frontend
       - name: Apply migrations
+        # Runtime `python -m yas api` also migrates on startup, but the seed
+        # step below writes rows and needs the schema in place before the API
+        # boots. Use the `migrate` mode so this path stays canonical.
         run: |
           mkdir -p data
-          uv run alembic upgrade head
+          uv run python -m yas migrate
       - name: Seed e2e fixtures
         run: uv run python scripts/seed_e2e.py "$YAS_DATABASE_URL"
       - name: Install Playwright browsers


### PR DESCRIPTION
## Summary
- Replaces `uv run alembic upgrade head` at `.github/workflows/ci.yml:121` with `uv run python -m yas migrate`.
- Adds a comment explaining why the explicit migrate step has to stay: the seed step below it writes rows, so the schema needs to exist before the API process boots.

## Why
The runtime `python -m yas api` now migrates on startup (PR #116), so a casual reader might assume the explicit pre-seed migrate step is redundant and delete it — which would break seeding. The comment makes the intent explicit, and using the new `migrate` mode means the alembic CLI isn't documented in CI as the canonical schema-prep path anymore.

The `check` job's `Migrations apply cleanly` step (line 60) is intentionally untouched — that one is a deliberate validation that migration files apply against a fresh DB, distinct from the runtime auto-migration.

## Test plan
- [ ] CI passes (`check`, `frontend-check`, `e2e`, `docker-build` × 2)
- [ ] e2e job logs show `migrations.start` / `migrations.done` / `mode.migrate.done` lines from the structlog output