### PR TITLE
fix(email): thread reference date through renderer so rel_date is deterministic

### DIFF
--- a/src/yas/email/__init__.py
+++ b/src/yas/email/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, date
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,17 +34,20 @@ def _render_pair(
     txt_template: str,
     *,
     payload: Any,
+    today: date,
     **extras: Any,
 ) -> RenderedEmail:
     """Render one kind's two templates and pull the subject out of the .txt block.
 
-    The render context is always ``{"payload": payload, **extras}`` — callers
-    pass ``payload`` as a frozen dataclass and any additional well-known keys
-    (today only ``top_line`` for the digest) as keyword arguments. This keeps
-    the call sites in this module the single place that builds the context
-    dict, so future kinds can't drift by inventing ad-hoc keys.
+    The render context is always ``{"payload": payload, "today": today, **extras}`` —
+    callers pass ``payload`` as a frozen dataclass, ``today`` as the reference
+    date for relative date formatting (``rel_date`` filter), and any additional
+    well-known keys (e.g. ``top_line`` for the digest) as keyword arguments.
+    Threading ``today`` explicitly keeps rendered output deterministic: it
+    reflects what was true when the alert was scheduled or the digest assembled,
+    not whenever the template happens to render.
     """
-    ctx: dict[str, Any] = {"payload": payload, **extras}
+    ctx: dict[str, Any] = {"payload": payload, "today": today, **extras}
     txt_tpl = env.get_template(txt_template)
     html_tpl = env.get_template(html_template)
     # Subject lives in {% block subject %} in the .txt template.
@@ -74,7 +78,10 @@ async def render_email(
             alert_id=lead.id if lead else None,
         ) from exc
     payload = await renderer.build(session, lead, members)
-    return _render_pair(renderer.html_template, renderer.txt_template, payload=payload)
+    today = lead.scheduled_for.astimezone(UTC).date()
+    return _render_pair(
+        renderer.html_template, renderer.txt_template, payload=payload, today=today
+    )
 
 
 def render_digest_payload(payload: DigestPayload, top_line: str) -> RenderedEmail:
@@ -89,6 +96,7 @@ def render_digest_payload(payload: DigestPayload, top_line: str) -> RenderedEmai
         _DIGEST_HTML_TEMPLATE,
         _DIGEST_TXT_TEMPLATE,
         payload=payload,
+        today=payload.for_date,
         top_line=top_line,
     )
 

--- a/src/yas/email/__init__.py
+++ b/src/yas/email/__init__.py
@@ -79,9 +79,7 @@ async def render_email(
         ) from exc
     payload = await renderer.build(session, lead, members)
     today = lead.scheduled_for.astimezone(UTC).date()
-    return _render_pair(
-        renderer.html_template, renderer.txt_template, payload=payload, today=today
-    )
+    return _render_pair(renderer.html_template, renderer.txt_template, payload=payload, today=today)
 
 
 def render_digest_payload(payload: DigestPayload, top_line: str) -> RenderedEmail:

--- a/src/yas/email/templates/digest.html.j2
+++ b/src/yas/email/templates/digest.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html %}
+{% from "macros.j2" import offering_row_html with context %}
 {% block title %}Activity Digest — {{ payload.for_date }}{% endblock %}
 {% block heading %}Daily digest — {{ payload.kid_name }}{% endblock %}
 {% block body %}
@@ -29,7 +29,7 @@ We're still scanning sites and will be in touch as soon as we find something. Ba
 <h1 style="font-size: 1em; border-bottom: 1px solid #ccc;">Starting Soon</h1>
 <ul>
   {% for o in payload.starting_soon %}
-  <li><strong>{{ o.offering_name }}</strong> starts {{ o.start_date|rel_date }}</li>
+  <li><strong>{{ o.offering_name }}</strong> starts {{ o.start_date|rel_date(today=today) }}</li>
   {% endfor %}
 </ul>
 {% endif %}

--- a/src/yas/email/templates/digest.txt.j2
+++ b/src/yas/email/templates/digest.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 {% block subject %}{{ top_line }}{% endblock %}
 {% block body %}
 {% if payload.under_no_matches_threshold -%}
@@ -24,7 +24,7 @@ NEW MATCHES ({{ payload.new_matches|length }}):
 {% if payload.starting_soon -%}
 STARTING SOON:
 {% for o in payload.starting_soon -%}
-  - {{ o.offering_name }} starts {{ o.start_date|rel_date }}
+  - {{ o.offering_name }} starts {{ o.start_date|rel_date(today=today) }}
 {% endfor %}
 {%- endif %}
 {% if payload.registration_calendar -%}

--- a/src/yas/email/templates/macros.j2
+++ b/src/yas/email/templates/macros.j2
@@ -18,7 +18,7 @@
 <li>
   <strong>{{ m.offering_name }}</strong>
   {% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}
-  {% if m.start_date %}&middot; {{ m.start_date | rel_date }}{% endif %}
+  {% if m.start_date %}&middot; {{ m.start_date | rel_date(today=today|default(none)) }}{% endif %}
   {% if m.price_cents is not none %}&middot; {{ m.price_cents | price }}{% endif %}
   {% if m.score is defined and m.score is not none %}&middot; score {{ "%.2f" | format(m.score) }}{% endif %}
   {% if m.registration_url %}&middot; <a href="{{ m.registration_url }}">Register</a>{% endif %}
@@ -26,7 +26,7 @@
 {% endmacro %}
 
 {% macro offering_row_text(m, show_site=true) -%}
-  - {{ m.offering_name }}{% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}{% if m.start_date %} · {{ m.start_date | rel_date }}{% endif %}{% if m.price_cents is not none %} · {{ m.price_cents | price }}{% endif %}{% if m.score is defined and m.score is not none %} · score {{ "%.2f" | format(m.score) }}{% endif %}{% if m.registration_url %} · {{ m.registration_url }}{% endif %}
+  - {{ m.offering_name }}{% if show_site and m.site_name %} @ {{ m.site_name }}{% endif %}{% if m.start_date %} · {{ m.start_date | rel_date(today=today|default(none)) }}{% endif %}{% if m.price_cents is not none %} · {{ m.price_cents | price }}{% endif %}{% if m.score is defined and m.score is not none %} · score {{ "%.2f" | format(m.score) }}{% endif %}{% if m.registration_url %} · {{ m.registration_url }}{% endif %}
 {%- endmacro %}
 
 {% macro reg_countdown_html(opens_at, label) %}

--- a/src/yas/email/templates/new_match.html.j2
+++ b/src/yas/email/templates/new_match.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html %}
+{% from "macros.j2" import offering_row_html with context %}
 
 {% block title %}New match — {{ payload.kid_name }}{% endblock %}
 {% block heading %}New {% if payload.matches | length > 1 %}matches{% else %}match{% endif %} for {{ payload.kid_name }}{% endblock %}

--- a/src/yas/email/templates/new_match.txt.j2
+++ b/src/yas/email/templates/new_match.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 
 {% block subject %}{% if payload.matches | length > 1 %}{{ payload.matches | length }} new matches for {{ payload.kid_name }}{% else %}New match for {{ payload.kid_name }}: {{ payload.matches[0].offering_name }}{% endif %}{% endblock %}
 

--- a/src/yas/email/templates/reg_opens_1h.html.j2
+++ b/src/yas/email/templates/reg_opens_1h.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html, reg_countdown_html %}
+{% from "macros.j2" import offering_row_html, reg_countdown_html with context %}
 
 {% block title %}Registration opens in 1h: {{ payload.offering.offering_name }}{% endblock %}
 {% block heading %}Registration opens in ~1 hour: {{ payload.offering.offering_name }}{% endblock %}

--- a/src/yas/email/templates/reg_opens_1h.txt.j2
+++ b/src/yas/email/templates/reg_opens_1h.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 
 {% block subject %}Registration opens in 1h: {{ payload.offering.offering_name }}{% endblock %}
 

--- a/src/yas/email/templates/reg_opens_24h.html.j2
+++ b/src/yas/email/templates/reg_opens_24h.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html, reg_countdown_html %}
+{% from "macros.j2" import offering_row_html, reg_countdown_html with context %}
 
 {% block title %}Registration opens tomorrow: {{ payload.offering.offering_name }}{% endblock %}
 {% block heading %}Registration opens tomorrow: {{ payload.offering.offering_name }}{% endblock %}

--- a/src/yas/email/templates/reg_opens_24h.txt.j2
+++ b/src/yas/email/templates/reg_opens_24h.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 
 {% block subject %}Registration opens tomorrow: {{ payload.offering.offering_name }}{% endblock %}
 

--- a/src/yas/email/templates/reg_opens_now.html.j2
+++ b/src/yas/email/templates/reg_opens_now.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html, reg_countdown_html %}
+{% from "macros.j2" import offering_row_html, reg_countdown_html with context %}
 
 {% block title %}Register now: {{ payload.offering.offering_name }}{% endblock %}
 {% block heading %}Register now: {{ payload.offering.offering_name }}{% endblock %}

--- a/src/yas/email/templates/reg_opens_now.txt.j2
+++ b/src/yas/email/templates/reg_opens_now.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 
 {% block subject %}Register now: {{ payload.offering.offering_name }} for {{ payload.kid_name }}{% endblock %}
 

--- a/src/yas/email/templates/schedule_posted.html.j2
+++ b/src/yas/email/templates/schedule_posted.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html %}
+{% from "macros.j2" import offering_row_html with context %}
 
 {% block title %}New schedule posted: {{ payload.site_name }}{% endblock %}
 {% block heading %}New schedule posted: {{ payload.site_name }}{% endblock %}

--- a/src/yas/email/templates/schedule_posted.txt.j2
+++ b/src/yas/email/templates/schedule_posted.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 
 {% block subject %}New schedule posted: {{ payload.site_name }}{% endblock %}
 

--- a/src/yas/email/templates/watchlist_hit.html.j2
+++ b/src/yas/email/templates/watchlist_hit.html.j2
@@ -1,5 +1,5 @@
 {% extends "base.html.j2" %}
-{% from "macros.j2" import offering_row_html %}
+{% from "macros.j2" import offering_row_html with context %}
 
 {% block title %}Watchlist hit — {{ payload.kid_name }}{% endblock %}
 {% block heading %}Watchlist {% if payload.matches | length > 1 %}matches{% else %}hit{% endif %} for {{ payload.kid_name }}{% endblock %}

--- a/src/yas/email/templates/watchlist_hit.txt.j2
+++ b/src/yas/email/templates/watchlist_hit.txt.j2
@@ -1,5 +1,5 @@
 {% extends "base.txt.j2" %}
-{% from "macros.j2" import offering_row_text %}
+{% from "macros.j2" import offering_row_text with context %}
 
 {% block subject %}{% if payload.matches | length > 1 %}{{ payload.matches | length }} watchlist matches for {{ payload.kid_name }}{% else %}Watchlist hit for {{ payload.kid_name }}: {{ payload.matches[0].offering_name }}{% endif %}{% endblock %}
 

--- a/tests/unit/test_email_render_pair.py
+++ b/tests/unit/test_email_render_pair.py
@@ -28,7 +28,7 @@ def test_subject_with_embedded_newline_raises(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(env, "get_template", fake_get_template)
 
     with pytest.raises(EmailRenderError, match="embedded newline"):
-        _render_pair("x.html.j2", "x.txt.j2", payload=object())
+        _render_pair("x.html.j2", "x.txt.j2", payload=object(), today=date(2026, 5, 19))
 
 
 def test_render_pair_passes_extras_into_context(monkeypatch) -> None:
@@ -39,7 +39,9 @@ def test_render_pair_passes_extras_into_context(monkeypatch) -> None:
     html = env.from_string("{{ top_line }}")
     monkeypatch.setattr(env, "get_template", lambda name: txt if name.endswith(".txt.j2") else html)
 
-    rendered = _render_pair("x.html.j2", "x.txt.j2", payload=object(), top_line="Hello there")
+    rendered = _render_pair(
+        "x.html.j2", "x.txt.j2", payload=object(), today=date(2026, 5, 19), top_line="Hello there"
+    )
     assert rendered.subject == "Hello there"
     assert "Hello there" in rendered.body_html
 


### PR DESCRIPTION
## Summary
- `rel_date` defaulted to wall-clock `datetime.now(UTC).date()` when templates didn't pass `today=`, making golden snapshots time-dependent — main CI started failing on 2026-05-25 when `start_date=2026-06-01` crossed the 7-day threshold and the renderer flipped from `"Mon, Jun 1"` to `"in 6 days"`.
- Thread an explicit `today: date` through `_render_pair`; derive it from `Alert.scheduled_for` (per-alert emails) and `DigestPayload.for_date` (digest). Templates importing macros now use `{% from "macros.j2" import ... with context %}` so macros see `today`; macros use `today|default(none)` to keep standalone unit tests working.
- Side-benefit: an alert queued at 23:55 and flushed at 00:05 now renders the relative date that was true at scheduling time, not delivery time.

## Test plan
- [x] `uv run pytest` — 758 passed (previously 3 failing: `test_digest_golden[with_matches]`, `test_digest_golden[multi_site]`, `test_email_render_golden[new_match-seed_new_match]`)
- [x] `uv run ruff check` — clean
- [x] `uv run mypy src/yas/email/` — clean
- [ ] CI green on this branch