### PR TITLE
ci: add ci-pass aggregator (fix BLOCKED docs-only PRs from matrix-axis required checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,3 +351,32 @@ jobs:
           IMAGE: ${{ steps.image.outputs.name }}
         run: |
           docker buildx imagetools inspect "${IMAGE}:latest"
+
+  # Stable-named aggregator so the branch ruleset can require a single
+  # `ci-pass` check regardless of the matrix dimensions (the per-axis
+  # `docker-build (linux/amd64, ubuntu-24.04, amd64)` names disappear
+  # whenever a runner image rotates, and a job-level `if:` on the matrix
+  # parent means the axis check names are never created at all — leaving
+  # docs-only PRs permanently BLOCKED with "expected check not reported").
+  # Treats SKIPPED as success: docs-only PRs skip docker-build via
+  # `changes`, and the aggregator must not block those merges.
+  # Pattern: owine/house-manager#191 (aggregator) + owine/trip-tracker
+  # ci.yml `docker-build` (skipped-as-success).
+  ci-pass:
+    needs: [changes, check, frontend-check, e2e, docker-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All required jobs passed or were appropriately skipped
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          # Log only the per-job `result` field, never the full `needs` blob.
+          # `outputs` declared by upstream jobs can carry sensitive values
+          # if anyone adds one in the future; restricting the dump to results
+          # keeps the diagnostic ("which job failed?") without the leak risk.
+          echo "$NEEDS_JSON" | jq 'map_values({result})'
+          if echo "$NEEDS_JSON" | jq -e 'any(.[].result; . == "failure" or . == "cancelled")' >/dev/null; then
+            echo "::error::One or more required jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- The ruleset requires `docker-build (linux/amd64, ubuntu-24.04, amd64)` and `docker-build (linux/arm64, ubuntu-24.04-arm, arm64)`, but `docker-build`'s job-level `if:` skips the parent on docs-only PRs (`changes.outputs.image == 'false'`). Matrix axes are never expanded, so those required contexts never report — PR is permanently `mergeStateStatus: BLOCKED`.
- Adds a stable-named `ci-pass` aggregator (`needs: [changes, check, frontend-check, e2e, docker-build]`, `if: always()`) that treats SKIPPED as success and logs only per-job `result` fields via `jq map_values` (never the raw `needs` blob, which can carry sensitive outputs).

Pattern mirrors owine/house-manager#191 (aggregator + log-dump tightening) and owine/trip-tracker's `ci.yml` `docker-build` aggregator.

## Follow-up

After this merges, swap the ruleset to drop the two `docker-build (axis)` contexts and require `ci-pass` instead. Keep `GitGuardian Security Checks`, `changes`, `check`, `frontend-check`, `e2e` (all are always-on lightweight gates). Then verify with a docs-only PR.

## Test plan

- [ ] Workflow PR itself: `changes.outputs.image == 'true'` (touches `.github/workflows/ci.yml`), full matrix runs.
- [ ] `ci-pass` reports success.
- [ ] After ruleset swap, a docs-only PR sees `docker-build` skipped and `ci-pass` green.

## Summary by Sourcery

CI:
- Introduce a ci-pass aggregator job that depends on core checks and docker-build, treats skipped jobs as success, and fails only when required jobs are failed or cancelled.