### PR TITLE
ci: address sourcery review on #134 (whitelist ci-pass acceptable results)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,9 @@ jobs:
           # if anyone adds one in the future; restricting the dump to results
           # keeps the diagnostic ("which job failed?") without the leak risk.
           echo "$NEEDS_JSON" | jq 'map_values({result})'
-          if echo "$NEEDS_JSON" | jq -e 'any(.[].result; . == "failure" or . == "cancelled")' >/dev/null; then
-            echo "::error::One or more required jobs failed or were cancelled."
+          # Whitelist acceptable results so future result types ('neutral',
+          # 'action_required', etc.) fail closed instead of silently passing.
+          if echo "$NEEDS_JSON" | jq -e 'any(.[].result; . != "success" and . != "skipped")' >/dev/null; then
+            echo "::error::One or more required jobs did not succeed or skip."
             exit 1
           fi


### PR DESCRIPTION
Addresses [sourcery-ai feedback on #134](https://github.com/owine/youth-activity-scheduler/pull/134#pullrequestreview).

## Summary

Switch `ci-pass` from blacklisting `failure|cancelled` to whitelisting `success|skipped`. Future result types (`neutral`, `action_required`, …) now fail closed instead of silently passing the aggregator.

## Test plan

- [ ] This PR runs the full matrix; `ci-pass` reports success.
- [ ] The follow-on ruleset swap (drop the two `docker-build (axis)` contexts, require `ci-pass`) will be done after this merges.

Not setting auto-merge — you wanted to work through review feedback first.

## Summary by Sourcery

CI:
- Adjust ci-pass workflow logic to whitelist success and skipped job results rather than blacklist failure and cancelled states.