### PR TITLE
test: fix freshness scoring time-bomb breaking all CI

### DIFF
--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -26,6 +26,9 @@ class _Offering:
 
 
 TODAY = date(2026, 4, 22)
+# Anchor "now" to TODAY so freshness tests stay deterministic regardless of the
+# wall clock; mixing datetime.now() with a frozen TODAY drifts as real time passes.
+NOW = datetime.combine(TODAY, time(12, 0), tzinfo=UTC)
 
 
 def test_score_breakdown_weighted_sum():
@@ -226,7 +229,7 @@ def test_registration_timing_unknown_defaults_half():
 
 def test_freshness_recent_full():
     kid = _Kid()
-    offering = _Offering(first_seen=datetime.now(UTC))
+    offering = _Offering(first_seen=NOW)
     _score, reasons = compute_score(
         kid,
         offering,
@@ -239,7 +242,7 @@ def test_freshness_recent_full():
 
 def test_freshness_old_zero():
     kid = _Kid()
-    offering = _Offering(first_seen=datetime.now(UTC) - timedelta(days=120))
+    offering = _Offering(first_seen=NOW - timedelta(days=120))
     _score, reasons = compute_score(
         kid,
         offering,
@@ -252,7 +255,7 @@ def test_freshness_old_zero():
 
 def test_score_is_weighted_combination():
     kid = _Kid(max_distance_mi=10.0)
-    offering = _Offering(first_seen=datetime.now(UTC))
+    offering = _Offering(first_seen=NOW)
     score, _reasons = compute_score(
         kid,
         offering,

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -25,6 +25,9 @@ class _Offering:
     first_seen: datetime | None = None
 
 
+# Arbitrary but fixed reference date. Several tests below hardcode dates relative
+# to it (e.g. the registration-timing tests use 2026-04-01 / 2026-04-15), so if you
+# change TODAY you must update those expectations too.
 TODAY = date(2026, 4, 22)
 # Anchor "now" to TODAY so freshness tests stay deterministic regardless of the
 # wall clock; mixing datetime.now() with a frozen TODAY drifts as real time passes.


### PR DESCRIPTION
## Problem

Every open Renovate PR was failing CI on the same single backend test — and so was \`main\` itself. The dependency bumps were innocent; \`ci-pass\` just aggregates the failing \`check\` job.

\`\`\`
FAILED tests/unit/test_scoring.py::test_freshness_old_zero
  Obtained: 0.01666666666666672   Expected: 0.0
\`\`\`

## Root cause

\`tests/unit/test_scoring.py\` froze \`TODAY = date(2026, 4, 22)\` but built \`first_seen\` from the live \`datetime.now()\`. With the freshness window at 60 days, a "120 days old" offering should score \`0.0\`. Once the real clock drifted ~2 months past the frozen \`TODAY\`, \`first_seen\` landed only 59 days before \`TODAY\`, giving \`1 − 59/60 = 1/60 = 0.01666…\`. A classic time bomb: it passed near the freeze date and rotted as time passed.

## Fix

- Add \`NOW = datetime.combine(TODAY, time(12, 0), tzinfo=UTC)\` anchored to \`TODAY\`.
- Use \`NOW\` for all three \`first_seen\` values instead of \`datetime.now(UTC)\`, making the freshness tests deterministic regardless of when CI runs.

\`tests/unit/test_scoring.py\` now passes 17/17 locally.

Merging this unblocks all open Renovate PRs (they just need a rebase afterward).

## Summary by Sourcery

Tests:
- Make freshness-related scoring tests deterministic by replacing datetime.now-based timestamps with a fixed NOW value derived from the frozen TODAY date.